### PR TITLE
fix: stop session-start backfill snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ Lore can optionally do a full archive import on session start with progress upda
 - Use `maintenanceScheduler.sessionStartBackfill.maxCandidates` to bound how many session candidates Lore plans per startup sweep.
 - Use `maintenanceScheduler.sessionStartBackfill.maxInspected` to cap how many raw session-store rows Lore inspects before deferring the rest to later startup sweeps.
 - Lore announces when the import starts, reports incremental progress, and logs completion or failure.
-- The import reuses the existing controlled backfill state, so `memory_backfill` and `memory_status` still reflect the live run.
+- The import reuses the existing controlled backfill engine, but it does **not** create restore snapshots.
+- Manual controlled `memory_backfill` runs still create snapshots that can be restored by run ID.
 - The default is conservative: disabled in code defaults, enabled in the all-features-on example config.
 
 ---

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -163,6 +163,8 @@ This is the highest-risk scenario. The DB is at `~/.copilot/lore.db`.
 
 3. **Re-derive from session-store** — if the DB is corrupted and there is no backup, the memory store can be partially rebuilt by re-running backfill tools against the raw `session-store.db` (which Lore never writes to). The rebuilt store will be missing any memories that were saved explicitly but not derivable from raw sessions.
 
+   Lore may create snapshots for schema migration safety and manual controlled backfill runs. Automatic session-start archive import does not create restore snapshots, so there is nothing to restore for those runs by ID.
+
 4. **Fresh start** — delete `lore.db` and restart the Copilot CLI. Lore will create a clean DB and run all migrations from scratch. You lose all memories.
 
 > **Migration safety rule**: all schema migrations in Lore are additive (add columns, add tables, add indexes). Destructive migrations are never applied silently. If a future release needs a breaking migration, it will be called out in the CHANGELOG as **BREAKING** and the pre-release checklist will include a migration test against a fixture DB.

--- a/docs/superpowers/specs/2026-04-12-session-start-backfill-snapshot-policy-design.md
+++ b/docs/superpowers/specs/2026-04-12-session-start-backfill-snapshot-policy-design.md
@@ -1,0 +1,111 @@
+# Session-start backfill snapshot policy design
+
+## Problem
+
+Lore currently snapshots `lore.db` for every new controlled backfill run, including the automatic session-start archive import path. In practice that produces a full database copy on many session starts even when the run only creates derived records for a small number of newly discovered sessions. Those snapshots accumulate in `~/.copilot/backups/lore` and consume disk without adding much recovery value for the automatic startup flow.
+
+## Goal
+
+Stop automatic session-start backfill from creating snapshots while preserving the existing restoreable snapshot behavior for manual controlled backfill starts and schema-migration safety backups.
+
+## Non-goals
+
+- Changing schema-migration backup behavior in `LoreDb.initialize()`
+- Redesigning manual controlled backfill restore semantics
+- Adding backup retention or pruning in this change
+
+## Chosen approach
+
+Introduce an explicit snapshot-policy input for controlled backfill starts.
+
+- `startControlledBackfillRun(...)` accepts a snapshot-policy option.
+- Automatic session-start backfill passes `never`.
+- Manual controlled backfill starts keep the current default behavior, which continues creating a snapshot when the run has candidates.
+
+This makes the behavioral split explicit at the call site instead of inferring it from `refreshExisting`, candidate actions, or config state.
+
+## Alternatives considered
+
+### 1. Infer snapshot behavior from `refreshExisting`
+
+Only snapshot when `refreshExisting === true`.
+
+Rejected because it makes restoreability depend on an indirect flag rather than the actual product intent. It would also be easy to break later if new backfill modes are added that are destructive without using `refreshExisting`.
+
+### 2. Add a config flag for automatic session-start snapshots
+
+Expose a setting to keep or disable automatic startup snapshots.
+
+Rejected because the product decision is already clear: startup runs should not snapshot. Adding config would preserve the bad default, widen the surface area, and leave the codepath more complex than necessary.
+
+## Design details
+
+### API shape
+
+Add a narrow snapshot policy to controlled backfill starts, for example:
+
+- `auto` — current behavior; snapshot when the run has candidates
+- `never` — never create a snapshot for the run
+
+The initial implementation only needs the modes required by current callers.
+
+### Callers
+
+#### Automatic session-start backfill
+
+`maybeRunSessionStartBackfill(...)` passes `never` when it calls `startControlledBackfillRun(...)`.
+
+Result:
+
+- startup runs still create `backfill_run` rows
+- startup runs still process candidates
+- startup runs store `snapshot_path = null`
+- existing progress/status formatting continues to work and will render `snapshot: none`
+
+#### Manual controlled backfill
+
+The `memory_backfill` tool continues calling `startControlledBackfillRun(...)` without overriding the default snapshot behavior.
+
+Result:
+
+- manual starts still create snapshots
+- restore-by-run remains available for those manual runs
+
+### Restore behavior
+
+No restore behavior changes are required in this change.
+
+Runs created with `snapshot_path = null` already fail clearly in `restoreControlledBackfillRun(...)` with `backfill run <id> does not have a snapshot path`, which is acceptable for the new startup-run behavior.
+
+## Data flow
+
+1. Session starts.
+2. Lore runtime initializes normally.
+3. If session-start archive import is enabled and candidates exist, Lore starts a controlled backfill run with snapshot policy `never`.
+4. Lore creates the `backfill_run` row with `snapshot_path = null`.
+5. Lore processes backfill items and updates run progress as it does today.
+6. Manual controlled backfill continues to use the default snapshot behavior and stores a `snapshot_path`.
+
+## Affected files
+
+- `lib/backfill.mjs` — add snapshot-policy handling inside `startControlledBackfillRun(...)`
+- `extension.mjs` — pass the no-snapshot policy from the automatic session-start path
+- `tests/unit/...` — add regression coverage for startup vs manual behavior
+
+## Error handling
+
+- Starting automatic session-start backfill should continue succeeding without a snapshot.
+- Manual restore of a run without a snapshot should continue failing with the existing explicit error.
+- No silent fallback to snapshot creation should occur in the startup path.
+
+## Testing
+
+Add focused tests for:
+
+1. automatic session-start backfill starts a run with `snapshot_path = null`
+2. manual controlled backfill start still produces a snapshot path
+3. restore still fails clearly for runs that do not have a snapshot
+
+## Rollout notes
+
+This is a behavior change only for the automatic session-start archive import path. Manual controlled backfill and migration safety backups remain unchanged, so the rollout risk is low and localized.

--- a/docs/superpowers/specs/2026-04-12-session-start-backfill-snapshot-policy-design.md
+++ b/docs/superpowers/specs/2026-04-12-session-start-backfill-snapshot-policy-design.md
@@ -6,7 +6,7 @@ Lore currently snapshots `lore.db` for every new controlled backfill run, includ
 
 ## Goal
 
-Stop automatic session-start backfill from creating snapshots while preserving the existing restoreable snapshot behavior for manual controlled backfill starts and schema-migration safety backups.
+Stop automatic session-start backfill from creating snapshots while preserving the existing restorable snapshot behavior for manual controlled backfill starts and schema-migration safety backups.
 
 ## Non-goals
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -68,7 +68,7 @@ This document defines which surfaces are **supported**, **experimental**, or **u
 
 | Tool | Status | Notes |
 |---|---|---|
-| `memory_backfill` | 🟡 Experimental | Backfills memories from the raw session store. The public tool is bounded to 20 items per run; manual controlled runs still create restoreable snapshots, while session-start archive import uses the same engine without creating snapshots. |
+| `memory_backfill` | 🟡 Experimental | Backfills memories from the raw session store. The public tool is bounded to 20 items per run; manual controlled runs still create restorable snapshots, while session-start archive import uses the same engine without creating snapshots. |
 | `memory_deferred_process` | 🟡 Experimental | Triggers processing of extractions deferred during session-start. |
 
 ### Replay and portability

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -68,7 +68,7 @@ This document defines which surfaces are **supported**, **experimental**, or **u
 
 | Tool | Status | Notes |
 |---|---|---|
-| `memory_backfill` | 🟡 Experimental | Backfills memories from the raw session store. The public tool is bounded to 20 items per run; larger volumes use the same controlled backfill engine through direct module access or session-start archive import. |
+| `memory_backfill` | 🟡 Experimental | Backfills memories from the raw session store. The public tool is bounded to 20 items per run; manual controlled runs still create restoreable snapshots, while session-start archive import uses the same engine without creating snapshots. |
 | `memory_deferred_process` | 🟡 Experimental | Triggers processing of extractions deferred during session-start. |
 
 ### Replay and portability
@@ -186,7 +186,7 @@ It auto-runs on session start only when all of these are true:
 Additional task gates:
 
 - On session start, Lore only auto-selects the `deferredExtraction` maintenance task; the broader maintenance set is for manual or scripted sweeps.
-- Optional archive import is separate from the maintenance task list and is configured under `maintenanceScheduler.sessionStartBackfill.*`. When enabled, Lore announces start/progress/completion in the CLI while reusing the existing controlled backfill run state, `maxCandidates` bounds how many pending sessions it queues per startup sweep, and `maxInspected` bounds how much raw history it scans before deferring the rest to later starts.
+- Optional archive import is separate from the maintenance task list and is configured under `maintenanceScheduler.sessionStartBackfill.*`. When enabled, Lore announces start/progress/completion in the CLI while reusing the existing controlled backfill run state, `maxCandidates` bounds how many pending sessions it queues per startup sweep, `maxInspected` bounds how much raw history it scans before deferring the rest to later starts, and startup runs do not create restore snapshots.
 - `deferredExtraction` also requires `deferredExtraction.enabled: true`, and on session start it additionally requires `deferredExtraction.autoProcessOnSessionStart: true`.
 - `doctorSnapshot` requires `rollout.loreDoctor: true`.
 - Proposal/integrity/review surfaces stay bounded by the `evolutionLedger`, `proposalGeneration`, `generatedArtifactIntegrity`, and `reviewGate` rollout flags.

--- a/extension.mjs
+++ b/extension.mjs
@@ -686,6 +686,7 @@ async function maybeRunSessionStartBackfill(session, activeRuntime, repository) 
           refreshExisting: options.refreshExisting,
           batchSize: options.batchSize,
           plan: preview,
+          snapshotPolicy: "never",
         });
         run = started.run;
       }

--- a/lib/backfill.mjs
+++ b/lib/backfill.mjs
@@ -280,6 +280,19 @@ function normalizeBackfillRepository({ repository, includeOtherRepositories }) {
   return includeOtherRepositories ? null : repository;
 }
 
+function resolveControlledBackfillSnapshotPolicy(value) {
+  return value === "never" ? "never" : "auto";
+}
+
+function maybeCreateControlledBackfillSnapshot({ db, candidateCount, snapshotPolicy }) {
+  if (candidateCount <= 0) {
+    return null;
+  }
+  return resolveControlledBackfillSnapshotPolicy(snapshotPolicy) === "never"
+    ? null
+    : db.backupDatabase();
+}
+
 function buildPlanEntries({
   db,
   candidates,
@@ -527,6 +540,7 @@ export function startControlledBackfillRun({
   refreshExisting = true,
   batchSize = 5,
   plan = null,
+  snapshotPolicy = "auto",
 }) {
   const effectivePlan = plan && Array.isArray(plan.candidates)
     ? plan
@@ -538,7 +552,11 @@ export function startControlledBackfillRun({
       limit,
       refreshExisting,
     });
-  const snapshotPath = effectivePlan.candidates.length > 0 ? db.backupDatabase() : null;
+  const snapshotPath = maybeCreateControlledBackfillSnapshot({
+    db,
+    candidateCount: effectivePlan.candidates.length,
+    snapshotPolicy,
+  });
   const runId = db.createBackfillRun({
     strategy: "session_refresh",
     dryRun: false,

--- a/lib/backfill.mjs
+++ b/lib/backfill.mjs
@@ -281,14 +281,23 @@ function normalizeBackfillRepository({ repository, includeOtherRepositories }) {
 }
 
 function resolveControlledBackfillSnapshotPolicy(value) {
-  return value === "never" ? "never" : "auto";
+  if (value === undefined) {
+    return "auto";
+  }
+  if (value === "auto" || value === "never") {
+    return value;
+  }
+  throw new Error(
+    `invalid controlled backfill snapshot policy: ${String(value)}; expected "auto" or "never"`,
+  );
 }
 
 function maybeCreateControlledBackfillSnapshot({ db, candidateCount, snapshotPolicy }) {
+  const resolvedSnapshotPolicy = resolveControlledBackfillSnapshotPolicy(snapshotPolicy);
   if (candidateCount <= 0) {
     return null;
   }
-  return resolveControlledBackfillSnapshotPolicy(snapshotPolicy) === "never"
+  return resolvedSnapshotPolicy === "never"
     ? null
     : db.backupDatabase();
 }

--- a/lib/capability-manifest.mjs
+++ b/lib/capability-manifest.mjs
@@ -242,7 +242,7 @@ const CAPABILITY_SPECS = [
     support: {
       status: "experimental",
       category: "Backfill and deferred processing",
-      notes: "Backfills memories from the raw session store. The public tool is bounded to 20 items per run; manual controlled runs still create restoreable snapshots, while session-start archive import uses the same engine without creating snapshots.",
+      notes: "Backfills memories from the raw session store. The public tool is bounded to 20 items per run; manual controlled runs still create restorable snapshots, while session-start archive import uses the same engine without creating snapshots.",
       rolloutFlags: [],
     },
   },

--- a/lib/capability-manifest.mjs
+++ b/lib/capability-manifest.mjs
@@ -242,7 +242,7 @@ const CAPABILITY_SPECS = [
     support: {
       status: "experimental",
       category: "Backfill and deferred processing",
-      notes: "Backfills memories from the raw session store. The public tool is bounded to 20 items per run; larger volumes use the same controlled backfill engine through direct module access or session-start archive import.",
+      notes: "Backfills memories from the raw session store. The public tool is bounded to 20 items per run; manual controlled runs still create restoreable snapshots, while session-start archive import uses the same engine without creating snapshots.",
       rolloutFlags: [],
     },
   },

--- a/lib/memory-tools.mjs
+++ b/lib/memory-tools.mjs
@@ -2559,7 +2559,7 @@ export function createMemoryTools({ getRuntime }) {
         }
 
         const mode = args.mode === "controlled" ? "controlled" : "legacy";
-        const limit = ensureLimit(args.limit, mode === "controlled" ? 25 : runtime.config.limits.recentSessionsFallbackLimit);
+        const limit = ensureLimit(args.limit, mode === "controlled" ? 20 : runtime.config.limits.recentSessionsFallbackLimit);
         const includeOtherRepositories = args.includeOtherRepositories === true;
         const refreshExisting = mode === "controlled"
           ? args.refreshExisting !== false

--- a/lib/memory-tools.mjs
+++ b/lib/memory-tools.mjs
@@ -2587,6 +2587,7 @@ export function createMemoryTools({ getRuntime }) {
               limit,
               refreshExisting,
               batchSize,
+              snapshotPolicy: "auto",
             });
             return [
               `Started controlled backfill run ${result.runId}.`,

--- a/tests/unit/progress-reporting.test.mjs
+++ b/tests/unit/progress-reporting.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { describe, test } from "node:test";
 
 import {
@@ -42,6 +43,24 @@ function buildRuntime(db, config, { sessionStore } = {}) {
 }
 
 describe("phase-3 progress reporting surfaces", () => {
+  test("session-start caller disables restore snapshots explicitly", () => {
+    const extensionSource = readFileSync(
+      new URL("../../extension.mjs", import.meta.url),
+      "utf8",
+    );
+
+    assert.match(extensionSource, /snapshotPolicy: "never"/);
+  });
+
+  test("manual memory_backfill start keeps automatic snapshot policy explicit", () => {
+    const memoryToolsSource = readFileSync(
+      new URL("../../lib/memory-tools.mjs", import.meta.url),
+      "utf8",
+    );
+
+    assert.match(memoryToolsSource, /snapshotPolicy: "auto"/);
+  });
+
   test("session-start backfill decision prefers resuming an existing running run", () => {
     const decision = buildSessionStartBackfillDecision({
       preview: { candidates: [{ sessionId: "session-a" }] },
@@ -285,7 +304,7 @@ describe("phase-3 progress reporting surfaces", () => {
       },
     });
     try {
-      db.createBackfillRun({
+      const runId = db.createBackfillRun({
         strategy: "session_refresh",
         dryRun: false,
         repository: "fixture-repo",
@@ -304,6 +323,7 @@ describe("phase-3 progress reporting surfaces", () => {
       const output = await findTool(tools, "memory_backfill").handler({
         mode: "controlled",
         action: "status",
+        runId,
       }, {
         sessionId: "session-progress-status",
       });
@@ -312,6 +332,7 @@ describe("phase-3 progress reporting surfaces", () => {
       assert.match(output, /progressCompletedCount: 0/);
       assert.match(output, /progressRunningCount: 2/);
       assert.match(output, /currentPhase: processing/);
+      assert.match(output, /snapshotPath: none/);
     } finally {
       cleanup();
     }

--- a/tests/unit/progress-reporting.test.mjs
+++ b/tests/unit/progress-reporting.test.mjs
@@ -350,6 +350,37 @@ describe("phase-3 progress reporting surfaces", () => {
     }
   });
 
+  test("controlled backfill rejects invalid snapshot policies", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+      },
+    });
+    try {
+      assert.throws(
+        () => startControlledBackfillRun({
+          db,
+          sessionStore: {
+            getRecentSessions: () => [
+              { id: "session-a", repository: "fixture-repo", updated_at: null, summary: "alpha" },
+            ],
+            getSessionArtifacts: () => ({ turns: [], workspace: null }),
+            getWorkspaceMetadata: () => null,
+          },
+          repository: "fixture-repo",
+          includeOtherRepositories: false,
+          limit: 5,
+          refreshExisting: false,
+          batchSize: 5,
+          snapshotPolicy: "typo",
+        }),
+        /invalid controlled backfill snapshot policy/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
   test("manual controlled memory_backfill start still creates a snapshot path", { skip: SKIP_NO_FTS5 }, async () => {
     const { db, config, cleanup } = await withFixtureDb({
       configOverrides: {

--- a/tests/unit/progress-reporting.test.mjs
+++ b/tests/unit/progress-reporting.test.mjs
@@ -278,6 +278,43 @@ describe("phase-3 progress reporting surfaces", () => {
     }
   });
 
+  test("memory_backfill controlled preview defaults to the public 20-session cap", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+      },
+    });
+    try {
+      const runtime = buildRuntime(db, config, {
+        sessionStore: {
+          getRecentSessions: ({ limit }) => Array.from({ length: 25 }, (_, index) => ({
+            id: `session-${index + 1}`,
+            repository: "fixture-repo",
+            updated_at: null,
+            summary: `summary-${index + 1}`,
+          })).slice(0, limit),
+          getSessionArtifacts: () => null,
+          getWorkspaceMetadata: () => null,
+        },
+      });
+      const tools = createMemoryTools({
+        getRuntime: async () => runtime,
+      });
+      const output = await findTool(tools, "memory_backfill").handler({
+        mode: "controlled",
+        action: "preview",
+      }, {
+        sessionId: "session-progress-preview-default-cap",
+      });
+
+      assert.match(output, /inspected: 20/);
+      assert.match(output, /candidateCount: 20/);
+      assert.match(output, /progressTotalCount: 20/);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("memory_backfill controlled status reports running counts and current phase", { skip: SKIP_NO_FTS5 }, async () => {
     const { db, config, cleanup } = await withFixtureDb({
       configOverrides: {

--- a/tests/unit/progress-reporting.test.mjs
+++ b/tests/unit/progress-reporting.test.mjs
@@ -1,5 +1,4 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { describe, test } from "node:test";
 
 import {
@@ -43,24 +42,6 @@ function buildRuntime(db, config, { sessionStore } = {}) {
 }
 
 describe("phase-3 progress reporting surfaces", () => {
-  test("session-start caller disables restore snapshots explicitly", () => {
-    const extensionSource = readFileSync(
-      new URL("../../extension.mjs", import.meta.url),
-      "utf8",
-    );
-
-    assert.match(extensionSource, /snapshotPolicy: "never"/);
-  });
-
-  test("manual memory_backfill start keeps automatic snapshot policy explicit", () => {
-    const memoryToolsSource = readFileSync(
-      new URL("../../lib/memory-tools.mjs", import.meta.url),
-      "utf8",
-    );
-
-    assert.match(memoryToolsSource, /snapshotPolicy: "auto"/);
-  });
-
   test("session-start backfill decision prefers resuming an existing running run", () => {
     const decision = buildSessionStartBackfillDecision({
       preview: { candidates: [{ sessionId: "session-a" }] },

--- a/tests/unit/progress-reporting.test.mjs
+++ b/tests/unit/progress-reporting.test.mjs
@@ -4,6 +4,8 @@ import { describe, test } from "node:test";
 import {
   buildSessionStartBackfillPreview,
   buildSessionStartBackfillDecision,
+  restoreControlledBackfillRun,
+  startControlledBackfillRun,
   summarizeBackfillRunProgress,
 } from "../../lib/backfill.mjs";
 import { createMemoryTools } from "../../lib/memory-tools.mjs";
@@ -310,6 +312,100 @@ describe("phase-3 progress reporting surfaces", () => {
       assert.match(output, /progressCompletedCount: 0/);
       assert.match(output, /progressRunningCount: 2/);
       assert.match(output, /currentPhase: processing/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("controlled backfill can skip snapshot creation when snapshot policy is never", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+      },
+    });
+    try {
+      const result = startControlledBackfillRun({
+        db,
+        sessionStore: {
+          getRecentSessions: () => [
+            { id: "session-a", repository: "fixture-repo", updated_at: null, summary: "alpha" },
+          ],
+          getSessionArtifacts: () => ({ turns: [], workspace: null }),
+          getWorkspaceMetadata: () => null,
+        },
+        repository: "fixture-repo",
+        includeOtherRepositories: false,
+        limit: 5,
+        refreshExisting: false,
+        batchSize: 5,
+        snapshotPolicy: "never",
+      });
+
+      assert.strictEqual(result.snapshotPath, null);
+      assert.strictEqual(result.run.snapshot_path, null);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("manual controlled memory_backfill start still creates a snapshot path", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+      },
+    });
+    try {
+      const runtime = buildRuntime(db, config, {
+        sessionStore: {
+          getRecentSessions: () => [
+            { id: "session-a", repository: "fixture-repo", updated_at: null, summary: "alpha" },
+          ],
+          getSessionArtifacts: () => ({ turns: [], workspace: null }),
+          getWorkspaceMetadata: () => null,
+        },
+      });
+      const tools = createMemoryTools({
+        getRuntime: async () => runtime,
+      });
+      const output = await findTool(tools, "memory_backfill").handler({
+        mode: "controlled",
+        action: "start",
+        limit: 5,
+        batchSize: 5,
+        refreshExisting: false,
+      }, {
+        sessionId: "session-controlled-start",
+      });
+
+      assert.match(output, /snapshotPath: .*lore-.*\.db/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("restoreControlledBackfillRun still fails clearly for runs without snapshots", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+      },
+    });
+    try {
+      const runId = db.createBackfillRun({
+        strategy: "session_refresh",
+        dryRun: false,
+        repository: "fixture-repo",
+        includeOtherRepositories: false,
+        refreshExisting: false,
+        batchSize: 5,
+        totalCandidates: 1,
+        snapshotPath: null,
+        metadata: {},
+      });
+
+      assert.throws(
+        () => restoreControlledBackfillRun({ db, runId }),
+        /does not have a snapshot path/,
+      );
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary
- add controlled backfill snapshot policy support plus regression coverage for no-snapshot startup runs and snapshot-preserving manual runs
- wire session-start backfill to use `snapshotPolicy: "never"` while keeping manual `memory_backfill` on `"auto"`
- update docs and capability-manifest support notes to match the new startup/manual snapshot behavior

## Test Plan
- [x] node --test tests/unit/progress-reporting.test.mjs
- [x] node --test tests/unit/capability-manifest.test.mjs
- [x] npm test