### PR TITLE
fix: return typed memory_search rows when lexical query misses

### DIFF
--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -3583,57 +3583,63 @@ export class LoreDb {
       normalize: normalizeFtsToken,
     });
     const repo = normalizeRepository(repository);
+    const runSearch = (ftsQuery) => {
+      const params = [];
+      let sql = `
+        SELECT
+          sm.id,
+          sm.type,
+          sm.content,
+          sm.scope,
+          sm.scope_source,
+          sm.confidence,
+          sm.repository,
+          sm.domain_key,
+          sm.updated_at,
+          sm.source_session_id,
+          sm.canonical_key,
+          sm.reinforcement_count,
+          sm.last_seen_at,
+          sm.metadata_json
+        FROM semantic_memory sm
+      `;
 
-    const params = [];
-    let sql = `
-      SELECT
-        sm.id,
-        sm.type,
-        sm.content,
-        sm.scope,
-        sm.scope_source,
-        sm.confidence,
-        sm.repository,
-        sm.domain_key,
-        sm.updated_at,
-        sm.source_session_id,
-        sm.canonical_key,
-        sm.reinforcement_count,
-        sm.last_seen_at,
-        sm.metadata_json
-      FROM semantic_memory sm
-    `;
+      if (ftsQuery) {
+        sql += ` JOIN semantic_fts ON semantic_fts.rowid = sm.rowid `;
+      }
 
-    if (sanitized) {
-      sql += ` JOIN semantic_fts ON semantic_fts.rowid = sm.rowid `;
-    }
+      sql += ` WHERE sm.superseded_by IS NULL `;
+      sql = applyScopeFilter(sql, params, repo, includeOtherRepositories, "sm");
 
-    sql += ` WHERE sm.superseded_by IS NULL `;
+      if (types.length > 0) {
+        sql += ` AND sm.type IN (${types.map(() => "?").join(", ")}) `;
+        params.push(...types);
+      }
 
-    sql = applyScopeFilter(sql, params, repo, includeOtherRepositories, "sm");
+      if (scopes.length > 0) {
+        sql += ` AND sm.scope IN (${scopes.map(() => "?").join(", ")}) `;
+        params.push(...scopes);
+      }
 
-    if (types.length > 0) {
-      sql += ` AND sm.type IN (${types.map(() => "?").join(", ")}) `;
-      params.push(...types);
-    }
+      if (ftsQuery) {
+        sql += ` AND semantic_fts MATCH ? `;
+        params.push(ftsQuery);
+        sql += ` ORDER BY bm25(semantic_fts), sm.confidence DESC, sm.updated_at DESC `;
+      } else {
+        sql += ` ORDER BY sm.confidence DESC, sm.updated_at DESC `;
+      }
 
-    if (scopes.length > 0) {
-      sql += ` AND sm.scope IN (${scopes.map(() => "?").join(", ")}) `;
-      params.push(...scopes);
-    }
+      sql += ` LIMIT ? `;
+      params.push(limit);
+      return this.db.prepare(sql).all(...params);
+    };
 
-    if (sanitized) {
-      sql += ` AND semantic_fts MATCH ? `;
-      params.push(sanitized);
-      sql += ` ORDER BY bm25(semantic_fts), sm.confidence DESC, sm.updated_at DESC `;
-    } else {
-      sql += ` ORDER BY sm.confidence DESC, sm.updated_at DESC `;
-    }
+    const lexicalRows = runSearch(sanitized);
+    const rows = types.length > 0 && sanitized
+      ? dedupeSemanticRows([...lexicalRows, ...runSearch("")])
+      : lexicalRows;
 
-    sql += ` LIMIT ? `;
-    params.push(limit);
-
-    return dedupeSemanticRows(this.db.prepare(sql).all(...params))
+    return dedupeSemanticRows(rows).slice(0, limit)
       .map((row) => ({
         ...row,
         domainKey: row.domain_key ?? null,

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -3583,7 +3583,7 @@ export class LoreDb {
       normalize: normalizeFtsToken,
     });
     const repo = normalizeRepository(repository);
-    const runSearch = (ftsQuery) => {
+    const runSearch = (ftsQuery, effectiveLimit = limit) => {
       const params = [];
       let sql = `
         SELECT
@@ -3630,13 +3630,19 @@ export class LoreDb {
       }
 
       sql += ` LIMIT ? `;
-      params.push(limit);
+      params.push(effectiveLimit);
       return this.db.prepare(sql).all(...params);
     };
 
     const lexicalRows = runSearch(sanitized);
-    const rows = types.length > 0 && sanitized
-      ? dedupeSemanticRows([...lexicalRows, ...runSearch("")])
+    const shouldRunTypedFallback = types.length > 0
+      && sanitized
+      && lexicalRows.length < limit;
+    const fallbackRows = shouldRunTypedFallback
+      ? runSearch("", Math.max(1, limit - lexicalRows.length))
+      : [];
+    const rows = fallbackRows.length > 0
+      ? dedupeSemanticRows([...lexicalRows, ...fallbackRows])
       : lexicalRows;
 
     return dedupeSemanticRows(rows).slice(0, limit)

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -3583,7 +3583,7 @@ export class LoreDb {
       normalize: normalizeFtsToken,
     });
     const repo = normalizeRepository(repository);
-    const runSearch = (ftsQuery, effectiveLimit = limit) => {
+    const runSearch = (ftsQuery, effectiveLimit = limit, excludedIds = []) => {
       const params = [];
       let sql = `
         SELECT
@@ -3621,6 +3621,11 @@ export class LoreDb {
         params.push(...scopes);
       }
 
+      if (excludedIds.length > 0) {
+        sql += ` AND sm.id NOT IN (${excludedIds.map(() => "?").join(", ")}) `;
+        params.push(...excludedIds);
+      }
+
       if (ftsQuery) {
         sql += ` AND semantic_fts MATCH ? `;
         params.push(ftsQuery);
@@ -3638,8 +3643,9 @@ export class LoreDb {
     const shouldRunTypedFallback = types.length > 0
       && sanitized
       && lexicalRows.length < limit;
+    const lexicalIds = lexicalRows.map((row) => row.id).filter(Boolean);
     const fallbackRows = shouldRunTypedFallback
-      ? runSearch("", Math.max(1, limit - lexicalRows.length))
+      ? runSearch("", Math.max(1, limit - lexicalRows.length), lexicalIds)
       : [];
     const rows = fallbackRows.length > 0
       ? dedupeSemanticRows([...lexicalRows, ...fallbackRows])

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -3576,7 +3576,15 @@ export class LoreDb {
     );
   }
 
-  searchSemantic({ query, repository, includeOtherRepositories = false, types = [], scopes = [], limit = 8 }) {
+  searchSemantic({
+    query,
+    repository,
+    includeOtherRepositories = false,
+    types = [],
+    scopes = [],
+    limit = 8,
+    includeTypedFallback = false,
+  }) {
     this.ensureOpen();
     const sanitized = sanitizeNormalizedFtsQuery(query, {
       aliases: QUERY_ALIASES,
@@ -3640,7 +3648,8 @@ export class LoreDb {
     };
 
     const lexicalRows = runSearch(sanitized);
-    const shouldRunTypedFallback = types.length > 0
+    const shouldRunTypedFallback = includeTypedFallback
+      && types.length > 0
       && sanitized
       && lexicalRows.length < limit;
     const lexicalIds = lexicalRows.map((row) => row.id).filter(Boolean);

--- a/lib/memory-tools-builders.mjs
+++ b/lib/memory-tools-builders.mjs
@@ -914,6 +914,7 @@ function buildMemorySearchTool(getRuntime) {
         includeOtherRepositories,
         types,
         limit,
+        includeTypedFallback: true,
       });
       const episodes = runtime.db.searchEpisodes({
         query,

--- a/tests/unit/memory-tools-hotspots.test.mjs
+++ b/tests/unit/memory-tools-hotspots.test.mjs
@@ -102,6 +102,53 @@ describe("memory-tools hotspot behavior", () => {
     }
   });
 
+  test("memory_search typed fallback fills remaining slots without duplicate overlap", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, tools, cleanup } = await setupFixtureTools({
+      enabled: true,
+    });
+
+    try {
+      db.insertSemanticMemory({
+        id: "open-loop-lexical-hit",
+        type: "open_loop",
+        content: "Address oauth timeout regression in memory search flow.",
+        scope: "repo",
+        repository: "fixture-repo",
+        confidence: 1.0,
+      });
+      db.insertSemanticMemory({
+        id: "open-loop-fallback-a",
+        type: "open_loop",
+        content: "Resolve dangling open loop triage after lexical fallback.",
+        scope: "repo",
+        repository: "fixture-repo",
+        confidence: 0.1,
+      });
+      db.insertSemanticMemory({
+        id: "open-loop-fallback-b",
+        type: "open_loop",
+        content: "Close assistant goal follow-ups discovered in maintenance.",
+        scope: "repo",
+        repository: "fixture-repo",
+        confidence: 0.1,
+      });
+
+      const memorySearch = findTool(tools, "memory_search");
+      const output = await memorySearch.handler({
+        query: "oauth timeout regression",
+        type: "open_loop",
+        limit: 2,
+      }, {
+        sessionId: "memory-search-overlap-fallback",
+      });
+
+      assert.match(output, /Address oauth timeout regression in memory search flow\./);
+      assert.equal((output.match(/\[open-loop-/g) || []).length, 2);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("memory_intent_journal records and lists entries with repository defaults", { skip: SKIP_NO_FTS5 }, async () => {
     const { db, config, cleanup } = await withFixtureDb({
       configOverrides: {

--- a/tests/unit/memory-tools-hotspots.test.mjs
+++ b/tests/unit/memory-tools-hotspots.test.mjs
@@ -67,6 +67,41 @@ describe("memory-tools module split", () => {
 });
 
 describe("memory-tools hotspot behavior", () => {
+  test("memory_search with a type filter falls back to typed rows when lexical query misses", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, tools, cleanup } = await setupFixtureTools({
+      enabled: true,
+    });
+
+    try {
+      db.insertSemanticMemory({
+        type: "open_loop",
+        content: "Resolve the lingering README conflict before final review.",
+        scope: "repo",
+        repository: "fixture-repo",
+      });
+      db.insertSemanticMemory({
+        type: "open_loop",
+        content: "Triage pending follow-up actions for memory search parity.",
+        scope: "repo",
+        repository: "fixture-repo",
+      });
+
+      const memorySearch = findTool(tools, "memory_search");
+      const output = await memorySearch.handler({
+        query: "network timeout oauth retries",
+        type: "open_loop",
+        limit: 10,
+      }, {
+        sessionId: "memory-search-open-loop",
+      });
+
+      assert.match(output, /Resolve the lingering README conflict before final review\./);
+      assert.match(output, /Triage pending follow-up actions for memory search parity\./);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("memory_intent_journal records and lists entries with repository defaults", { skip: SKIP_NO_FTS5 }, async () => {
     const { db, config, cleanup } = await withFixtureDb({
       configOverrides: {

--- a/tests/unit/memory-tools-hotspots.test.mjs
+++ b/tests/unit/memory-tools-hotspots.test.mjs
@@ -67,6 +67,36 @@ describe("memory-tools module split", () => {
 });
 
 describe("memory-tools hotspot behavior", () => {
+  test("searchSemantic keeps typed fallback opt-in for shared relevance searches", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+      },
+    });
+
+    try {
+      db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Prefer narrow code review fixes with targeted validation.",
+        scope: "transferable",
+        repository: "other-repo",
+      });
+
+      const rows = db.searchSemantic({
+        query: "network timeout oauth retries",
+        repository: "fixture-repo",
+        includeOtherRepositories: true,
+        types: ["user_preference"],
+        scopes: ["transferable"],
+        limit: 5,
+      });
+
+      assert.deepEqual(rows, []);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("memory_search with a type filter falls back to typed rows when lexical query misses", { skip: SKIP_NO_FTS5 }, async () => {
     const { db, tools, cleanup } = await setupFixtureTools({
       enabled: true,


### PR DESCRIPTION
## Summary
- Reproduced issue #20 where memory_search with a type filter returned no rows when lexical terms missed.
- Updated searchSemantic to keep lexical matches first, then fall back to typed rows when a type filter is provided.
- Added a regression test for the type-filter fallback behavior.

## Notes
- This preserves lexical ranking while ensuring type-filtered recall remains complete for open_loop and assistant_goal rows.

Closes #20