### PR TITLE
fix: enable fallow test root discovery

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -16,10 +16,10 @@
   "rules": {
     "unused-files": "warn",
     "unused-exports": "warn",
-    "unused-deps": "warn",
-    "unlisted-deps": "error",
+    "unused-dependencies": "warn",
+    "unlisted-dependencies": "error",
     "unused-types": "off",
     "circular-dependencies": "warn",
-    "boundary-violations": "off"
+    "boundary-violation": "off"
   }
 }

--- a/fallow-plugin-lore-test-roots.json
+++ b/fallow-plugin-lore-test-roots.json
@@ -1,0 +1,11 @@
+{
+  "name": "lore-test-roots",
+  "detection": {
+    "type": "fileExists",
+    "pattern": "tests/**/*.test.mjs"
+  },
+  "entryPoints": [
+    "tests/**/*.test.mjs"
+  ],
+  "entryPointRole": "test"
+}


### PR DESCRIPTION
## Summary
- add a repo-local Fallow plugin that marks `tests/**/*.test.mjs` as test entry points
- let Fallow discover existing tests for coverage-gap and CRAP estimation
- reduce `fallow health` from 463 above threshold to 37 above threshold

## Verification
- `npx -y fallow health` → `37 above threshold`
