### PR TITLE
refactor: eliminate fallow threshold findings

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -16,10 +16,10 @@
   "rules": {
     "unused-files": "warn",
     "unused-exports": "warn",
-    "unused-deps": "warn",
-    "unlisted-deps": "error",
+    "unused-dependencies": "warn",
+    "unlisted-dependencies": "error",
     "unused-types": "off",
     "circular-dependencies": "warn",
-    "boundary-violations": "off"
+    "boundary-violation": "off"
   }
 }

--- a/browser/app.js
+++ b/browser/app.js
@@ -183,6 +183,7 @@ function renderWorkstreamsList(workstreams) {
   `
 }
 
+// fallow-ignore-next-line complexity
 function renderOverview(data) {
   const stats = data?.stats ?? {}
   const trend = data?.latencyTrend ?? {}
@@ -246,6 +247,7 @@ function renderMemoriesFilters(filterData) {
   `
 }
 
+// fallow-ignore-next-line complexity
 function renderMemoriesTable(data) {
   const rows = data?.rows ?? []
   return `
@@ -301,6 +303,7 @@ function applyMemoriesFilterControls() {
 
   const button = document.getElementById("mem-apply")
   if (button) {
+// fallow-ignore-next-line complexity
     button.onclick = async () => {
       state.memoriesFilters.type = document.getElementById("mem-filter-type")?.value || ""
       state.memoriesFilters.scope = document.getElementById("mem-filter-scope")?.value || ""
@@ -381,6 +384,7 @@ function renderDoctorReports(doctorReports) {
   `).join("") || renderEmptyBlock("No doctor reports found.")
 }
 
+// fallow-ignore-next-line complexity
 function renderMaintenance(data) {
   const runs = data?.runs ?? []
   const taskStates = data?.taskStates ?? []
@@ -597,6 +601,7 @@ function renderGraph(graph) {
     nodesByColumn[column].push(node)
   }
 
+// fallow-ignore-next-line complexity
   const renderNode = (node) => {
     const classes = ["graph-node", `node-${escapeHtml(node.kind || "memory")}`]
     const commonAttrs = `class="${classes.join(" ")}" data-node-id="${escapeHtml(node.id)}"`

--- a/browser/app.js
+++ b/browser/app.js
@@ -183,13 +183,28 @@ function renderWorkstreamsList(workstreams) {
   `
 }
 
-// fallow-ignore-next-line complexity
+function asArray(value) {
+  return Array.isArray(value) ? value : []
+}
+
+function normalizeOverviewData(data) {
+  return {
+    stats: data?.stats ?? {},
+    trend: data?.latencyTrend ?? {},
+    activityRows: asArray(data?.activity),
+    workstreams: asArray(data?.activeWorkstreams),
+    dueTasks: data?.maintenance?.dueTasks ?? [],
+  }
+}
+
 function renderOverview(data) {
-  const stats = data?.stats ?? {}
-  const trend = data?.latencyTrend ?? {}
-  const activityRows = Array.isArray(data?.activity) ? data.activity : []
-  const workstreams = Array.isArray(data?.activeWorkstreams) ? data.activeWorkstreams : []
-  const dueTasks = data?.maintenance?.dueTasks ?? []
+  const {
+    stats,
+    trend,
+    activityRows,
+    workstreams,
+    dueTasks,
+  } = normalizeOverviewData(data)
 
   views.overview.innerHTML = `
     ${renderMetricGrid([
@@ -247,7 +262,6 @@ function renderMemoriesFilters(filterData) {
   `
 }
 
-// fallow-ignore-next-line complexity
 function renderMemoriesTable(data) {
   const rows = data?.rows ?? []
   return `
@@ -267,22 +281,53 @@ function renderMemoriesTable(data) {
           </tr>
         </thead>
         <tbody>
-          ${rows.map((row) => `
-            <tr>
-              <td>${escapeHtml(formatTime(row.updatedAt))}</td>
-              <td>${escapeHtml(row.type)}</td>
-              <td>${escapeHtml(row.scope)}</td>
-              <td>${escapeHtml(row.repository ?? "")}</td>
-              <td>${escapeHtml(row.canonicalKey ?? "")}</td>
-              <td>${row.supersededBy ? '<span class="tag warn">superseded</span>' : '<span class="tag ok">active</span>'}</td>
-              <td>${escapeHtml(row.content)}</td>
-              <td>${renderDrilldownAction(row.type === "workstream_overlay" ? "workstream" : "memory", row.id, "Open")}</td>
-            </tr>
-          `).join("") || '<tr><td colspan="8" class="row-muted">No memories match filters.</td></tr>'}
+          ${renderMemoryTableRows(rows)}
         </tbody>
       </table>
     </div>
   `
+}
+
+function renderMemoryStateTag(row) {
+  return row.supersededBy
+    ? '<span class="tag warn">superseded</span>'
+    : '<span class="tag ok">active</span>'
+}
+
+function resolveMemoryDrilldownEntity(row) {
+  return row.type === "workstream_overlay" ? "workstream" : "memory"
+}
+
+function renderMemoryTableRows(rows) {
+  if (rows.length === 0) {
+    return '<tr><td colspan="8" class="row-muted">No memories match filters.</td></tr>'
+  }
+  return rows.map((row) => `
+    <tr>
+      <td>${escapeHtml(formatTime(row.updatedAt))}</td>
+      <td>${escapeHtml(row.type)}</td>
+      <td>${escapeHtml(row.scope)}</td>
+      <td>${escapeHtml(row.repository ?? "")}</td>
+      <td>${escapeHtml(row.canonicalKey ?? "")}</td>
+      <td>${renderMemoryStateTag(row)}</td>
+      <td>${escapeHtml(row.content)}</td>
+      <td>${renderDrilldownAction(resolveMemoryDrilldownEntity(row), row.id, "Open")}</td>
+    </tr>
+  `).join("")
+}
+
+function readMemoriesFilterValue(id, fallback = "") {
+  return document.getElementById(id)?.value || fallback
+}
+
+async function applyMemoriesFiltersFromDom() {
+  state.memoriesFilters.type = readMemoriesFilterValue("mem-filter-type")
+  state.memoriesFilters.scope = readMemoriesFilterValue("mem-filter-scope")
+  state.memoriesFilters.repository = readMemoriesFilterValue("mem-filter-repo")
+  state.memoriesFilters.canonicalKey = readMemoriesFilterValue("mem-filter-canonical")
+  state.memoriesFilters.state = readMemoriesFilterValue("mem-filter-state", "active")
+  state.memoriesFilters.page = 1
+  await loadMemories()
 }
 
 function applyMemoriesFilterControls() {
@@ -303,16 +348,7 @@ function applyMemoriesFilterControls() {
 
   const button = document.getElementById("mem-apply")
   if (button) {
-// fallow-ignore-next-line complexity
-    button.onclick = async () => {
-      state.memoriesFilters.type = document.getElementById("mem-filter-type")?.value || ""
-      state.memoriesFilters.scope = document.getElementById("mem-filter-scope")?.value || ""
-      state.memoriesFilters.repository = document.getElementById("mem-filter-repo")?.value || ""
-      state.memoriesFilters.canonicalKey = document.getElementById("mem-filter-canonical")?.value || ""
-      state.memoriesFilters.state = document.getElementById("mem-filter-state")?.value || "active"
-      state.memoriesFilters.page = 1
-      await loadMemories()
-    }
+    button.onclick = async () => applyMemoriesFiltersFromDom()
   }
 }
 
@@ -384,13 +420,25 @@ function renderDoctorReports(doctorReports) {
   `).join("") || renderEmptyBlock("No doctor reports found.")
 }
 
-// fallow-ignore-next-line complexity
+function normalizeMaintenanceData(data) {
+  const maintenancePlan = data?.maintenancePlan ?? {}
+  return {
+    runs: asArray(data?.runs),
+    taskStates: asArray(data?.taskStates),
+    deferred: asArray(data?.deferred),
+    doctorReports: asArray(data?.doctorReports),
+    dueTasks: asArray(maintenancePlan.dueTasks),
+  }
+}
+
 function renderMaintenance(data) {
-  const runs = data?.runs ?? []
-  const taskStates = data?.taskStates ?? []
-  const deferred = data?.deferred ?? []
-  const doctorReports = data?.doctorReports ?? []
-  const dueTasks = data?.maintenancePlan?.dueTasks ?? []
+  const {
+    runs,
+    taskStates,
+    deferred,
+    doctorReports,
+    dueTasks,
+  } = normalizeMaintenanceData(data)
 
   views.maintenance.innerHTML = `
     <h2>Due maintenance tasks</h2>
@@ -601,10 +649,17 @@ function renderGraph(graph) {
     nodesByColumn[column].push(node)
   }
 
-// fallow-ignore-next-line complexity
+  const renderNodeDetails = (node) => [
+    `<span class="graph-node-title">${escapeHtml(node.title)}</span>`,
+    node.subtitle ? `<span class="graph-node-subtitle">${escapeHtml(node.subtitle)}</span>` : "",
+    node.meta ? `<span class="graph-node-meta">${escapeHtml(node.meta)}</span>` : "",
+    node.badge ? `<span class="tag node-badge">${escapeHtml(node.badge)}</span>` : "",
+  ].filter(Boolean).join("")
+
   const renderNode = (node) => {
     const classes = ["graph-node", `node-${escapeHtml(node.kind || "memory")}`]
     const commonAttrs = `class="${classes.join(" ")}" data-node-id="${escapeHtml(node.id)}"`
+    const nodeDetails = renderNodeDetails(node)
 
     if (node.navigable && node.entityType && node.entityId) {
       return `
@@ -614,20 +669,14 @@ function renderGraph(graph) {
           data-drilldown-entity="${escapeHtml(node.entityType)}"
           data-drilldown-id="${escapeHtml(node.entityId)}"
         >
-          <span class="graph-node-title">${escapeHtml(node.title)}</span>
-          ${node.subtitle ? `<span class="graph-node-subtitle">${escapeHtml(node.subtitle)}</span>` : ""}
-          ${node.meta ? `<span class="graph-node-meta">${escapeHtml(node.meta)}</span>` : ""}
-          ${node.badge ? `<span class="tag node-badge">${escapeHtml(node.badge)}</span>` : ""}
+          ${nodeDetails}
         </button>
       `
     }
 
     return `
       <div ${commonAttrs}>
-        <span class="graph-node-title">${escapeHtml(node.title)}</span>
-        ${node.subtitle ? `<span class="graph-node-subtitle">${escapeHtml(node.subtitle)}</span>` : ""}
-        ${node.meta ? `<span class="graph-node-meta">${escapeHtml(node.meta)}</span>` : ""}
-        ${node.badge ? `<span class="tag node-badge">${escapeHtml(node.badge)}</span>` : ""}
+        ${nodeDetails}
       </div>
     `
   }

--- a/browser/server.mjs
+++ b/browser/server.mjs
@@ -1117,6 +1117,7 @@ function queryDrilldown({ db, url }) {
   throw new HttpError(400, "unsupported_drilldown_entity", `Unsupported drilldown entity: ${entityType}`)
 }
 
+// fallow-ignore-next-line complexity
 function buildBrowserApiResponse({ db, url, host, normalizedRepository }) {
   if (url.pathname === "/api/health") {
     return {

--- a/browser/server.mjs
+++ b/browser/server.mjs
@@ -1117,81 +1117,39 @@ function queryDrilldown({ db, url }) {
   throw new HttpError(400, "unsupported_drilldown_entity", `Unsupported drilldown entity: ${entityType}`)
 }
 
-// fallow-ignore-next-line complexity
+function buildBrowserApiSuccessPayload(data, host, normalizedRepository, dbPath) {
+  return buildReadOnlyPayload({
+    ok: true,
+    host,
+    repository: normalizedRepository,
+    dbPath,
+    ...data,
+  })
+}
+
 function buildBrowserApiResponse({ db, url, host, normalizedRepository }) {
+  const dbPath = db.config?.paths?.derivedStorePath ?? null
+  const dataFactories = {
+    "/api/overview": () => ({ data: queryOverview({ db, repository: normalizedRepository }) }),
+    "/api/memories": () => ({ data: queryMemories({ db, url }) }),
+    "/api/memories/filters": () => ({ data: queryMemoryFilters({ db }) }),
+    "/api/maintenance": () => ({ data: queryMaintenance({ db, repository: normalizedRepository }) }),
+    "/api/episodes": () => ({ data: queryEpisodes({ db, repository: normalizedRepository }) }),
+    "/api/drilldown": () => ({ data: queryDrilldown({ db, url }) }),
+  }
   if (url.pathname === "/api/health") {
     return {
       statusCode: 200,
-      payload: buildReadOnlyPayload({
-        ok: true,
-        host,
-        repository: normalizedRepository,
-        dbPath: db.config?.paths?.derivedStorePath ?? null,
-      }),
+      payload: buildBrowserApiSuccessPayload({}, host, normalizedRepository, dbPath),
     }
   }
-
-  if (url.pathname === "/api/overview") {
-    return {
+  const factory = dataFactories[url.pathname]
+  return factory
+    ? {
       statusCode: 200,
-      payload: buildReadOnlyPayload({
-        ok: true,
-        data: queryOverview({ db, repository: normalizedRepository }),
-      }),
+      payload: buildBrowserApiSuccessPayload(factory(), host, normalizedRepository, dbPath),
     }
-  }
-
-  if (url.pathname === "/api/memories") {
-    return {
-      statusCode: 200,
-      payload: buildReadOnlyPayload({
-        ok: true,
-        data: queryMemories({ db, url }),
-      }),
-    }
-  }
-
-  if (url.pathname === "/api/memories/filters") {
-    return {
-      statusCode: 200,
-      payload: buildReadOnlyPayload({
-        ok: true,
-        data: queryMemoryFilters({ db }),
-      }),
-    }
-  }
-
-  if (url.pathname === "/api/maintenance") {
-    return {
-      statusCode: 200,
-      payload: buildReadOnlyPayload({
-        ok: true,
-        data: queryMaintenance({ db, repository: normalizedRepository }),
-      }),
-    }
-  }
-
-  if (url.pathname === "/api/episodes") {
-    return {
-      statusCode: 200,
-      payload: buildReadOnlyPayload({
-        ok: true,
-        data: queryEpisodes({ db, repository: normalizedRepository }),
-      }),
-    }
-  }
-
-  if (url.pathname === "/api/drilldown") {
-    return {
-      statusCode: 200,
-      payload: buildReadOnlyPayload({
-        ok: true,
-        data: queryDrilldown({ db, url }),
-      }),
-    }
-  }
-
-  return null
+    : null
 }
 
 function handleBrowserRequestError(res, error) {

--- a/extension.mjs
+++ b/extension.mjs
@@ -743,13 +743,30 @@ function maybePruneDurableTraceSamples({ activeRuntime, repository }) {
   });
 }
 
-// fallow-ignore-next-line complexity
+function persistTraceContextInjectionUpdates(activeRuntime, repository, contextInjectionUpdates) {
+  if (!contextInjectionUpdates) {
+    return;
+  }
+  writeActivitySuccessUpdates({
+    db: activeRuntime.db,
+    repository,
+    updates: contextInjectionUpdates,
+  });
+}
+
+function resolveTraceSuccessRecord(traceResult) {
+  const traceRecord = traceResult.record ?? null;
+  return {
+    traceRecord,
+    traceId: traceResult.id ?? traceRecord?.id ?? null,
+  };
+}
+
 function persistTraceSuccess({ activeRuntime, repository, traceResult, durationMs, hook }) {
   if (!activeRuntime?.db || !traceResult || typeof traceResult !== "object") {
     return;
   }
-  const traceRecord = traceResult.record ?? null;
-  const traceId = traceResult.id ?? traceRecord?.id ?? null;
+  const { traceRecord, traceId } = resolveTraceSuccessRecord(traceResult);
   if (!traceRecord) {
     return;
   }
@@ -767,13 +784,7 @@ function persistTraceSuccess({ activeRuntime, repository, traceResult, durationM
         repository,
         updates: traceUpdates,
       });
-      if (contextInjectionUpdates) {
-        writeActivitySuccessUpdates({
-          db: activeRuntime.db,
-          repository,
-          updates: contextInjectionUpdates,
-        });
-      }
+      persistTraceContextInjectionUpdates(activeRuntime, repository, contextInjectionUpdates);
 
       if (traceResult.durableSelected !== true) {
         return;
@@ -791,6 +802,127 @@ function persistTraceSuccess({ activeRuntime, repository, traceResult, durationM
       // best-effort visibility persistence; never block hook path
     }
   });
+}
+
+async function handleSessionStartHook({
+  session,
+  invocation,
+  input,
+  metrics,
+}) {
+  const startedAt = Date.now();
+  const context = await getContext(session, invocation.sessionId, input.cwd);
+  const { runtime: activeRuntime, repository, workspacePath } = context;
+
+  if (isHookRuntimeUnavailable(activeRuntime)) {
+    return;
+  }
+
+  if (!hooksEnabled(activeRuntime.config)) {
+    await logOnce(
+      session,
+      "lore-disabled",
+      `lore hooks are disabled by default; create ${activeRuntime.config.configPath} with { "enabled": true }, or set LORE_ENABLED=1 to enable`,
+      "info",
+    );
+    return;
+  }
+
+  await maybeSeedSessionStartOnboarding(session, activeRuntime, invocation.sessionId);
+  await maybeRunMaintenanceScheduler(session, activeRuntime, repository);
+  await maybeRunSessionStartBackfill(session, activeRuntime, repository);
+  maybeHydrateOverlay(session, activeRuntime, workspacePath, repository, invocation.sessionId);
+
+  const prompt = input.initialPrompt ?? "";
+  const { assembled } = await assembleSessionStartCapsule({
+    prompt,
+    repository,
+    activeRuntime,
+  });
+
+  await finalizeHookObservation({
+    session,
+    activeRuntime,
+    repository,
+    hook: "onSessionStart",
+    prompt,
+    promptNeed: assembled.trace?.promptNeed ?? detectPromptContextNeed(prompt),
+    trace: assembled.trace,
+    contextText: assembled.text,
+    durationMs: Date.now() - startedAt,
+    metricWindow: metrics.sessionStartMs,
+    latencyMetric: "sessionStart",
+    hookLabel: "lore onSessionStart",
+    targetMs: activeRuntime.config.latencyTargetsMs.sessionStartP95,
+  });
+
+  return assembled.text
+    ? { additionalContext: assembled.text }
+    : undefined;
+}
+
+function readSessionEndExtraction(activeRuntime, sessionId) {
+  return activeRuntime.sessionStore
+    ? activeRuntime.sessionStore.getSessionArtifacts(sessionId)
+    : null;
+}
+
+function maybeEnqueueDeferredSessionExtraction(activeRuntime, sessionId, repository) {
+  if (!activeRuntime.config?.deferredExtraction?.enabled
+    || !activeRuntime.config.deferredExtraction.autoEnqueueOnSessionEnd) {
+    return;
+  }
+  activeRuntime.db.enqueueDeferredExtraction({
+    sessionId,
+    repository,
+    reason: "session_end",
+    priority: 10,
+    metadata: {
+      mode: "deferred",
+    },
+  });
+}
+
+async function handleSessionEndHook({
+  session,
+  invocation,
+  input,
+}) {
+  const context = await getContext(session, invocation.sessionId, input.cwd);
+  const { runtime: activeRuntime, workspace, repository } = context;
+
+  if (!activeRuntime.initialized || activeRuntime.lastError || !hooksEnabled(activeRuntime.config)) {
+    return;
+  }
+
+  try {
+    const extraction = readSessionEndExtraction(activeRuntime, invocation.sessionId);
+    if (!extraction) {
+      return;
+    }
+
+    applySessionExtraction({
+      db: activeRuntime.db,
+      sessionId: invocation.sessionId,
+      repository,
+      sessionArtifacts: extraction,
+      workspace,
+    });
+    maybeEnqueueDeferredSessionExtraction(activeRuntime, invocation.sessionId, repository);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    await session.log(`lore session-end extraction skipped: ${message}`, {
+      ephemeral: true,
+      level: "warning",
+    });
+  }
+
+  if (input.reason === "error") {
+    await session.log("lore observed session end with error", {
+      ephemeral: true,
+      level: "warning",
+    });
+  }
 }
 
 async function maybeProcessDeferredExtractions(session, activeRuntime, repository) {
@@ -1160,64 +1292,9 @@ async function recordUserPromptBypassObservation({
 const session = await joinSession({
   onPermissionRequest: approveAll,
   hooks: {
-// fallow-ignore-next-line complexity
     onSessionStart: async (input, invocation) => {
-      const startedAt = Date.now();
       lastKnownCwd = input.cwd || lastKnownCwd;
-
-      const context = await getContext(session, invocation.sessionId, input.cwd);
-      const { runtime: activeRuntime, repository, workspacePath } = context;
-
-      if (isHookRuntimeUnavailable(activeRuntime)) {
-        return;
-      }
-
-      if (!hooksEnabled(activeRuntime.config)) {
-        await logOnce(
-          session,
-          "lore-disabled",
-          `lore hooks are disabled by default; create ${activeRuntime.config.configPath} with { "enabled": true }, or set LORE_ENABLED=1 to enable`,
-          "info",
-        );
-        return;
-      }
-
-      await maybeSeedSessionStartOnboarding(session, activeRuntime, invocation.sessionId);
-
-      await maybeRunMaintenanceScheduler(session, activeRuntime, repository);
-      await maybeRunSessionStartBackfill(session, activeRuntime, repository);
-      maybeHydrateOverlay(session, activeRuntime, workspacePath, repository, invocation.sessionId);
-
-      const { assembled } = await assembleSessionStartCapsule({
-        prompt: input.initialPrompt ?? "",
-        repository,
-        activeRuntime,
-      });
-
-      const durationMs = Date.now() - startedAt;
-      await finalizeHookObservation({
-        session,
-        activeRuntime,
-        repository,
-        hook: "onSessionStart",
-        prompt: input.initialPrompt ?? "",
-        promptNeed: assembled.trace?.promptNeed ?? detectPromptContextNeed(input.initialPrompt ?? ""),
-        trace: assembled.trace,
-        contextText: assembled.text,
-        durationMs,
-        metricWindow: metrics.sessionStartMs,
-        latencyMetric: "sessionStart",
-        hookLabel: "lore onSessionStart",
-        targetMs: activeRuntime.config.latencyTargetsMs.sessionStartP95,
-      });
-
-      if (!assembled.text) {
-        return;
-      }
-
-      return {
-        additionalContext: assembled.text,
-      };
+      return handleSessionStartHook({ session, invocation, input, metrics });
     },
 
     onUserPromptSubmitted: async (input, invocation) => {
@@ -1281,58 +1358,9 @@ const session = await joinSession({
       };
     },
 
-// fallow-ignore-next-line complexity
     onSessionEnd: async (input, invocation) => {
       lastKnownCwd = input.cwd || lastKnownCwd;
-      const context = await getContext(session, invocation.sessionId, input.cwd);
-      const { runtime: activeRuntime, workspace, repository } = context;
-
-      if (!activeRuntime.initialized || activeRuntime.lastError || !hooksEnabled(activeRuntime.config)) {
-        return;
-      }
-
-      try {
-        const extraction = activeRuntime.sessionStore
-          ? activeRuntime.sessionStore.getSessionArtifacts(invocation.sessionId)
-          : null;
-        if (!extraction) {
-          return;
-        }
-
-        applySessionExtraction({
-          db: activeRuntime.db,
-          sessionId: invocation.sessionId,
-          repository,
-          sessionArtifacts: extraction,
-          workspace,
-        });
-
-        if (activeRuntime.config?.deferredExtraction?.enabled
-          && activeRuntime.config.deferredExtraction.autoEnqueueOnSessionEnd) {
-          activeRuntime.db.enqueueDeferredExtraction({
-            sessionId: invocation.sessionId,
-            repository,
-            reason: "session_end",
-            priority: 10,
-            metadata: {
-              mode: "deferred",
-            },
-          });
-        }
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        await session.log(`lore session-end extraction skipped: ${message}`, {
-          ephemeral: true,
-          level: "warning",
-        });
-      }
-
-      if (input.reason === "error") {
-        await session.log("lore observed session end with error", {
-          ephemeral: true,
-          level: "warning",
-        });
-      }
+      return handleSessionEndHook({ session, invocation, input });
     },
   },
   tools: createMemoryTools({

--- a/extension.mjs
+++ b/extension.mjs
@@ -743,6 +743,7 @@ function maybePruneDurableTraceSamples({ activeRuntime, repository }) {
   });
 }
 
+// fallow-ignore-next-line complexity
 function persistTraceSuccess({ activeRuntime, repository, traceResult, durationMs, hook }) {
   if (!activeRuntime?.db || !traceResult || typeof traceResult !== "object") {
     return;
@@ -1159,6 +1160,7 @@ async function recordUserPromptBypassObservation({
 const session = await joinSession({
   onPermissionRequest: approveAll,
   hooks: {
+// fallow-ignore-next-line complexity
     onSessionStart: async (input, invocation) => {
       const startedAt = Date.now();
       lastKnownCwd = input.cwd || lastKnownCwd;
@@ -1279,6 +1281,7 @@ const session = await joinSession({
       };
     },
 
+// fallow-ignore-next-line complexity
     onSessionEnd: async (input, invocation) => {
       lastKnownCwd = input.cwd || lastKnownCwd;
       const context = await getContext(session, invocation.sessionId, input.cwd);

--- a/fallow-plugin-lore-test-roots.json
+++ b/fallow-plugin-lore-test-roots.json
@@ -1,0 +1,11 @@
+{
+  "name": "lore-test-roots",
+  "detection": {
+    "type": "fileExists",
+    "pattern": "tests/**/*.test.mjs"
+  },
+  "entryPoints": [
+    "tests/**/*.test.mjs"
+  ],
+  "entryPointRole": "test"
+}

--- a/lib/backfill.mjs
+++ b/lib/backfill.mjs
@@ -36,6 +36,7 @@ function buildSessionImprovementTrace(episodeDigest) {
   };
 }
 
+// fallow-ignore-next-line complexity
 function buildSessionImprovementArtifact({ sessionId, memory, episodeDigest, linkedMemoryId }) {
   const descriptor = buildSessionImprovementDescriptor(memory);
   const canonicalKey = buildSemanticCanonicalKey(memory);

--- a/lib/backfill.mjs
+++ b/lib/backfill.mjs
@@ -36,7 +36,41 @@ function buildSessionImprovementTrace(episodeDigest) {
   };
 }
 
-// fallow-ignore-next-line complexity
+function buildSessionImprovementSourceCaseId({
+  memory,
+  scope,
+  repository,
+  canonicalKey,
+}) {
+  return [
+    "session",
+    memory.type,
+    scope,
+    repository,
+    canonicalKey ?? String(memory.sourceTurnIndex ?? "na"),
+  ].join(":");
+}
+
+function buildSessionImprovementEvidence({
+  sessionId,
+  repository,
+  memory,
+  descriptor,
+  signalType,
+}) {
+  return {
+    sessionId,
+    repository,
+    memoryType: memory.type,
+    signalType,
+    sourceTurnIndex: memory.sourceTurnIndex ?? null,
+    content: memory.content,
+    [descriptor.detailKey]: descriptor.detailValue,
+    examples: memory.metadata?.examples ?? [],
+    tags: memory.tags ?? [],
+  };
+}
+
 function buildSessionImprovementArtifact({ sessionId, memory, episodeDigest, linkedMemoryId }) {
   const descriptor = buildSessionImprovementDescriptor(memory);
   const canonicalKey = buildSemanticCanonicalKey(memory);
@@ -44,30 +78,25 @@ function buildSessionImprovementArtifact({ sessionId, memory, episodeDigest, lin
   const scope = memory.scope ?? "repo";
   const signalType = memory.metadata?.signalType ?? null;
   const sourceLabel = signalType?.startsWith("repeated_") ? "Session-inferred" : "Session-derived";
-  const sourceCaseId = [
-    "session",
-    memory.type,
+  const sourceCaseId = buildSessionImprovementSourceCaseId({
+    memory,
     scope,
     repository,
-    canonicalKey ?? String(memory.sourceTurnIndex ?? "na"),
-  ].join(":");
+    canonicalKey,
+  });
   return {
     sourceCaseId,
     sourceKind: "session",
     title: `${sourceLabel} ${descriptor.title}`,
     summary: `${descriptor.summaryLabel}: ${descriptor.detailValue}`,
     linkedMemoryId,
-    evidence: {
+    evidence: buildSessionImprovementEvidence({
       sessionId,
       repository,
-      memoryType: memory.type,
+      memory,
+      descriptor,
       signalType,
-      sourceTurnIndex: memory.sourceTurnIndex ?? null,
-      content: memory.content,
-      [descriptor.detailKey]: descriptor.detailValue,
-      examples: memory.metadata?.examples ?? [],
-      tags: memory.tags ?? [],
-    },
+    }),
     trace: buildSessionImprovementTrace(episodeDigest),
   };
 }

--- a/lib/capability-renderer.mjs
+++ b/lib/capability-renderer.mjs
@@ -94,6 +94,7 @@ function buildCapabilityRecommendationReasonLines(primaryRoute) {
     : ["- No explicit rationale recorded."];
 }
 
+// fallow-ignore-next-line complexity
 function buildRouteCandidateLines(candidate) {
   const lines = [
     `- ${candidate.route} score=${candidate.score} base=${candidate.baseScore ?? candidate.score} heuristic=${candidate.heuristicScore ?? 0} support=${candidate.supportLevel} available=${candidate.available}`,
@@ -123,6 +124,7 @@ function buildCapabilityMatchLines(match) {
   ];
 }
 
+// fallow-ignore-next-line complexity
 function buildCapabilityRecommendationReportHeaderLines(recommendation) {
   return [
     "## Capability Routing Recommendation",

--- a/lib/capability-renderer.mjs
+++ b/lib/capability-renderer.mjs
@@ -94,7 +94,13 @@ function buildCapabilityRecommendationReasonLines(primaryRoute) {
     : ["- No explicit rationale recorded."];
 }
 
-// fallow-ignore-next-line complexity
+function appendDelimitedValuesLine(lines, label, values) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return;
+  }
+  lines.push(`  ${label}: ${values.join(" | ")}`);
+}
+
 function buildRouteCandidateLines(candidate) {
   const lines = [
     `- ${candidate.route} score=${candidate.score} base=${candidate.baseScore ?? candidate.score} heuristic=${candidate.heuristicScore ?? 0} support=${candidate.supportLevel} available=${candidate.available}`,
@@ -102,12 +108,8 @@ function buildRouteCandidateLines(candidate) {
     `  matchedTokens: ${candidate.matchedTokens.join(", ") || "none"}`,
     `  supportingMatches: ${candidate.supportingMatches.map((match) => match.name).join(", ") || "none"}`,
   ];
-  if (candidate.reasons?.length > 0) {
-    lines.push(`  reasons: ${candidate.reasons.join(" | ")}`);
-  }
-  if (candidate.gaps.length > 0) {
-    lines.push(`  gaps: ${candidate.gaps.join(" | ")}`);
-  }
+  appendDelimitedValuesLine(lines, "reasons", candidate.reasons);
+  appendDelimitedValuesLine(lines, "gaps", candidate.gaps);
   return lines;
 }
 
@@ -124,7 +126,24 @@ function buildCapabilityMatchLines(match) {
   ];
 }
 
-// fallow-ignore-next-line complexity
+function formatCapabilityConfidenceLine(confidence) {
+  if (!confidence || typeof confidence !== "object") {
+    return "confidence: unknown";
+  }
+  return confidence.value != null
+    ? `confidence: ${confidence.label ?? "unknown"} (${confidence.value})`
+    : `confidence: ${confidence.label ?? "unknown"}`;
+}
+
+function buildPromptNeedHeaderLines(promptNeed = {}, promptProfile = {}) {
+  return [
+    `requiresLookup: ${promptNeed.requiresLookup === true}`,
+    `hasTemporalSignal: ${promptNeed.hasTemporalSignal === true}`,
+    `wantsContinuity: ${promptNeed.wantsContinuity === true}`,
+    `greeting: ${promptProfile.greeting === true}`,
+  ];
+}
+
 function buildCapabilityRecommendationReportHeaderLines(recommendation) {
   return [
     "## Capability Routing Recommendation",
@@ -137,13 +156,10 @@ function buildCapabilityRecommendationReportHeaderLines(recommendation) {
     `primaryTargetType: ${recommendation.primaryRoute.targetType ?? "none"}`,
     `primaryExecutionMode: ${recommendation.primaryRoute.executionMode ?? "none"}`,
     `primaryScore: ${recommendation.primaryRoute.score}`,
-    `confidence: ${recommendation.confidence?.label ?? "unknown"}${recommendation.confidence?.value != null ? ` (${recommendation.confidence.value})` : ""}`,
+    formatCapabilityConfidenceLine(recommendation.confidence),
     `supportLevel: ${recommendation.primaryRoute.supportLevel}`,
     `matchedPromptTokens: ${recommendation.promptTokens.join(", ") || "none"}`,
-    `requiresLookup: ${recommendation.promptNeed?.requiresLookup === true}`,
-    `hasTemporalSignal: ${recommendation.promptNeed?.hasTemporalSignal === true}`,
-    `wantsContinuity: ${recommendation.promptNeed?.wantsContinuity === true}`,
-    `greeting: ${recommendation.promptProfile?.greeting === true}`,
+    ...buildPromptNeedHeaderLines(recommendation.promptNeed, recommendation.promptProfile),
     "",
     "## Why This Route",
     "",

--- a/lib/capability-router.mjs
+++ b/lib/capability-router.mjs
@@ -812,6 +812,7 @@ function buildRouterAssertion(label, passed, details) {
   return { label, passed, details };
 }
 
+// fallow-ignore-next-line complexity
 function buildBaseRouterAssertions({
   definition,
   primaryRoute,

--- a/lib/capability-router.mjs
+++ b/lib/capability-router.mjs
@@ -812,7 +812,23 @@ function buildRouterAssertion(label, passed, details) {
   return { label, passed, details };
 }
 
-// fallow-ignore-next-line complexity
+function buildExpectedValueAssertion(label, expected, actual) {
+  return buildRouterAssertion(
+    `${label} === ${expected}`,
+    actual === expected,
+    `actual=${actual ?? "unknown"}`,
+  );
+}
+
+function buildCountAssertion(label, items) {
+  const count = Array.isArray(items) ? items.length : 0;
+  return buildRouterAssertion(
+    `${label} are present`,
+    count > 0,
+    `actual=${count}`,
+  );
+}
+
 function buildBaseRouterAssertions({
   definition,
   primaryRoute,
@@ -821,36 +837,16 @@ function buildBaseRouterAssertions({
   confidenceValue,
 }) {
   return [
-    buildRouterAssertion(
-      `route === ${definition.expectedRouteKind}`,
-      primaryRoute.route === definition.expectedRouteKind,
-      `actual=${primaryRoute.route ?? "unknown"}`,
-    ),
-    buildRouterAssertion(
-      `target === ${definition.expectedTargetName}`,
-      primaryRoute.targetName === definition.expectedTargetName,
-      `actual=${primaryRoute.targetName ?? "unknown"}`,
-    ),
-    buildRouterAssertion(
-      `executionMode === ${definition.expectedExecutionMode}`,
-      primaryRoute.executionMode === definition.expectedExecutionMode,
-      `actual=${primaryRoute.executionMode ?? "unknown"}`,
-    ),
+    buildExpectedValueAssertion("route", definition.expectedRouteKind, primaryRoute.route),
+    buildExpectedValueAssertion("target", definition.expectedTargetName, primaryRoute.targetName),
+    buildExpectedValueAssertion("executionMode", definition.expectedExecutionMode, primaryRoute.executionMode),
     buildRouterAssertion(
       `confidence >= ${minConfidence}`,
       confidenceValue >= minConfidence,
       `actual=${confidenceValue}`,
     ),
-    buildRouterAssertion(
-      "primary route has reasons",
-      Array.isArray(primaryRoute.reasons) && primaryRoute.reasons.length > 0,
-      `actual=${primaryRoute.reasons?.length ?? 0}`,
-    ),
-    buildRouterAssertion(
-      "route candidates are present",
-      Array.isArray(recommendation.routeCandidates) && recommendation.routeCandidates.length > 0,
-      `actual=${recommendation.routeCandidates?.length ?? 0}`,
-    ),
+    buildCountAssertion("primary route reasons", primaryRoute.reasons),
+    buildCountAssertion("route candidates", recommendation.routeCandidates),
   ];
 }
 

--- a/lib/capability-scanner.mjs
+++ b/lib/capability-scanner.mjs
@@ -320,7 +320,6 @@ async function scanSkills(rootPath) {
   };
 }
 
-// fallow-ignore-next-line complexity
 async function scanAgents(rootPath) {
   const agentsDir = path.join(rootPath, "agents");
   const entries = await safeReadDir(agentsDir);
@@ -337,9 +336,7 @@ async function scanAgents(rootPath) {
     }
 
     const { attributes, body } = parseFrontmatter(content);
-    const name = typeof attributes.name === "string" && attributes.name
-      ? attributes.name
-      : entry.name.replace(/\.agent\.md$/, "");
+    const name = resolveAgentName(attributes, entry.name);
     const description = typeof attributes.description === "string" ? attributes.description : "";
     const summary = extractLeadParagraph(body);
     const sourcePath = relativePath(rootPath, agentFile);
@@ -360,10 +357,7 @@ async function scanAgents(rootPath) {
         { text: summary, weight: 2 },
         { text: body, weight: 1 },
       ],
-      triggerCapabilities: [
-        summary,
-        manualOnly ? "manual-only" : "delegated",
-      ],
+      triggerCapabilities: buildAgentTriggerCapabilities(summary, manualOnly),
       metadata: {
         sourceKind: "agent",
         frontmatter: attributes,
@@ -383,7 +377,41 @@ function extensionSummary(rootPath, extensionName, extensionFile, sourceText, to
   };
 }
 
-// fallow-ignore-next-line complexity
+function resolveAgentName(attributes, entryName) {
+  return typeof attributes.name === "string" && attributes.name
+    ? attributes.name
+    : entryName.replace(/\.agent\.md$/, "");
+}
+
+function buildAgentTriggerCapabilities(summary, manualOnly) {
+  return [summary, manualOnly ? "manual-only" : "delegated"];
+}
+
+function buildExtensionToolCapability(tool, extensionName, sourcePath) {
+  return buildCapabilityBase({
+    id: `tool:${tool.name}`,
+    name: tool.name,
+    description: tool.description || `${extensionName} tool`,
+    sourcePath,
+    capabilityType: "tool",
+    routeKindHints: buildToolRouteHints(tool.name, extensionName),
+    summary: `${extensionName} extension tool`,
+    keywordParts: [
+      { text: tool.name, weight: 4 },
+      { text: tool.description, weight: 3 },
+      { text: extensionName, weight: 1 },
+    ],
+    triggerCapabilities: [
+      extensionName,
+      ...buildToolRouteHints(tool.name, extensionName),
+    ],
+    metadata: {
+      sourceKind: "extension_tool",
+      extensionName,
+    },
+  });
+}
+
 async function scanExtensionSurfaces(rootPath) {
   const extensionsDir = path.join(rootPath, "extensions");
   const entries = await safeReadDir(extensionsDir);
@@ -403,28 +431,7 @@ async function scanExtensionSurfaces(rootPath) {
     const toolSpecs = entry.name === "lore" ? [] : extractToolSpecs(sourceText);
     const sourcePath = relativePath(rootPath, extensionFile);
     for (const tool of toolSpecs) {
-      tools.push(buildCapabilityBase({
-        id: `tool:${tool.name}`,
-        name: tool.name,
-        description: tool.description || `${entry.name} tool`,
-        sourcePath,
-        capabilityType: "tool",
-        routeKindHints: buildToolRouteHints(tool.name, entry.name),
-        summary: `${entry.name} extension tool`,
-        keywordParts: [
-          { text: tool.name, weight: 4 },
-          { text: tool.description, weight: 3 },
-          { text: entry.name, weight: 1 },
-        ],
-        triggerCapabilities: [
-          entry.name,
-          ...buildToolRouteHints(tool.name, entry.name),
-        ],
-        metadata: {
-          sourceKind: "extension_tool",
-          extensionName: entry.name,
-        },
-      }));
+      tools.push(buildExtensionToolCapability(tool, entry.name, sourcePath));
     }
 
     extensions.push(extensionSummary(

--- a/lib/capability-scanner.mjs
+++ b/lib/capability-scanner.mjs
@@ -320,6 +320,7 @@ async function scanSkills(rootPath) {
   };
 }
 
+// fallow-ignore-next-line complexity
 async function scanAgents(rootPath) {
   const agentsDir = path.join(rootPath, "agents");
   const entries = await safeReadDir(agentsDir);
@@ -382,6 +383,7 @@ function extensionSummary(rootPath, extensionName, extensionFile, sourceText, to
   };
 }
 
+// fallow-ignore-next-line complexity
 async function scanExtensionSurfaces(rootPath) {
   const extensionsDir = path.join(rootPath, "extensions");
   const entries = await safeReadDir(extensionsDir);

--- a/lib/capsule-assembler.mjs
+++ b/lib/capsule-assembler.mjs
@@ -270,7 +270,6 @@ function collectPromptNeedSignals(prompt) {
   };
 }
 
-// fallow-ignore-next-line complexity
 function derivePromptNeedTemporalFlags({
   rawTemporalSignal,
   directAddressed,
@@ -279,19 +278,9 @@ function derivePromptNeedTemporalFlags({
   contextualTaskTerms,
   wantsStyleContext,
 }) {
-  const hasTemporalSignal = rawTemporalSignal
-    && (
-      !directAddressed
-      || hasConsistencySignal
-      || hasTransferSignal
-      || contextualTaskTerms.length > 0
-    );
-  const identityOnly = directAddressed
-    && !hasTemporalSignal
-    && !hasConsistencySignal
-    && !hasTransferSignal
-    && !wantsStyleContext
-    && contextualTaskTerms.length === 0;
+  const hasTaskSignals = hasConsistencySignal || hasTransferSignal || contextualTaskTerms.length > 0;
+  const hasTemporalSignal = rawTemporalSignal && (!directAddressed || hasTaskSignals);
+  const identityOnly = directAddressed && !hasTemporalSignal && !hasTaskSignals && !wantsStyleContext;
   return {
     hasTemporalSignal,
     identityOnly,
@@ -536,7 +525,14 @@ function describeSemanticRow(memory, currentRepository = null) {
   };
 }
 
-// fallow-ignore-next-line complexity
+function isCrossRepoDescription(value, currentRepository) {
+  return !!(
+    currentRepository
+    && value?.repository
+    && value.repository !== currentRepository
+  );
+}
+
 function describeEpisodeRow(episode, currentRepository = null) {
   return {
     id: episode.id ?? null,
@@ -546,11 +542,7 @@ function describeEpisodeRow(episode, currentRepository = null) {
     updatedAt: episode.updated_at ?? null,
     dateKey: episode.date_key ?? null,
     significance: episode.significance ?? 0,
-    crossRepo: !!(
-      currentRepository
-      && episode.repository
-      && episode.repository !== currentRepository
-    ),
+    crossRepo: isCrossRepoDescription(episode, currentRepository),
     summary: normalizeText(episode.summary),
   };
 }
@@ -1144,7 +1136,6 @@ function resolveLocalEpisodeLines({
   };
 }
 
-// fallow-ignore-next-line complexity
 function resolveHistoryHintLines({
   allowRepoLocalTaskContext,
   sessionStore,
@@ -1155,13 +1146,14 @@ function resolveHistoryHintLines({
   episodeLines,
   relatedTitle,
 }) {
-  if (!allowRepoLocalTaskContext || !sessionStore || !query || episodeLines.length > 0) {
+  const historyLookupEnabled = !!(sessionStore && query);
+  if (!allowRepoLocalTaskContext || !historyLookupEnabled || episodeLines.length > 0) {
     recordCapsuleLookup(
       state,
       "historyHints",
       buildEmptyCapsuleLookup(
-        !!(sessionStore && query),
-        sessionStore && query ? "local_episode_results_present" : "history_lookup_disabled",
+        historyLookupEnabled,
+        historyLookupEnabled ? "local_episode_results_present" : "history_lookup_disabled",
       ),
     );
     return { episodeLines, relatedTitle };

--- a/lib/capsule-assembler.mjs
+++ b/lib/capsule-assembler.mjs
@@ -270,6 +270,7 @@ function collectPromptNeedSignals(prompt) {
   };
 }
 
+// fallow-ignore-next-line complexity
 function derivePromptNeedTemporalFlags({
   rawTemporalSignal,
   directAddressed,
@@ -535,6 +536,7 @@ function describeSemanticRow(memory, currentRepository = null) {
   };
 }
 
+// fallow-ignore-next-line complexity
 function describeEpisodeRow(episode, currentRepository = null) {
   return {
     id: episode.id ?? null,
@@ -1142,6 +1144,7 @@ function resolveLocalEpisodeLines({
   };
 }
 
+// fallow-ignore-next-line complexity
 function resolveHistoryHintLines({
   allowRepoLocalTaskContext,
   sessionStore,

--- a/lib/db-episode-scoring.mjs
+++ b/lib/db-episode-scoring.mjs
@@ -68,7 +68,6 @@ function buildTermWeights(episodes, terms) {
   return weights;
 }
 
-// fallow-ignore-next-line complexity
 function scoreEpisodeAgainstWeightedTerms(episode, terms, primaryTerms, termWeights, exactMatchIds) {
   if (terms.length === 0) {
     return 0;
@@ -96,11 +95,24 @@ function scoreEpisodeAgainstWeightedTerms(episode, terms, primaryTerms, termWeig
     }
   }
 
-  if (matchedTerms === 0 || (matchedPrimaryTerms === 0 && matchedTerms < 2)) {
+  if (!hasEnoughMatchedTerms(matchedTerms, matchedPrimaryTerms)) {
     return 0;
   }
 
-  score += matchedTerms * 0.35;
+  return score + scoreEpisodeBonuses({
+    episode,
+    exactMatchIds,
+    matchedTerms,
+    matchedPrimaryTerms,
+  });
+}
+
+function hasEnoughMatchedTerms(matchedTerms, matchedPrimaryTerms) {
+  return matchedTerms > 0 && (matchedPrimaryTerms > 0 || matchedTerms >= 2);
+}
+
+function scoreEpisodeBonuses({ episode, exactMatchIds, matchedTerms, matchedPrimaryTerms }) {
+  let score = matchedTerms * 0.35;
   score += matchedPrimaryTerms * 1.25;
   if (exactMatchIds.has(episode.session_id)) {
     score += 2;

--- a/lib/db-episode-scoring.mjs
+++ b/lib/db-episode-scoring.mjs
@@ -68,6 +68,7 @@ function buildTermWeights(episodes, terms) {
   return weights;
 }
 
+// fallow-ignore-next-line complexity
 function scoreEpisodeAgainstWeightedTerms(episode, terms, primaryTerms, termWeights, exactMatchIds) {
   if (terms.length === 0) {
     return 0;

--- a/lib/db-temporal-sections.mjs
+++ b/lib/db-temporal-sections.mjs
@@ -19,6 +19,7 @@ function formatSessionHintLine(session) {
   return `- ${prefix}${sourceLabel}${excerpt}${repositoryLabel}`;
 }
 
+// fallow-ignore-next-line complexity
 function formatTemporalVerifierSessionLine(session) {
   const summary = normalizeText(session.workspaceSummary || session.summary);
   if (!summary) {

--- a/lib/db-temporal-sections.mjs
+++ b/lib/db-temporal-sections.mjs
@@ -19,23 +19,36 @@ function formatSessionHintLine(session) {
   return `- ${prefix}${sourceLabel}${excerpt}${repositoryLabel}`;
 }
 
-// fallow-ignore-next-line complexity
+function buildCrossRepoRepositoryLabel(session) {
+  return session.currentRepository
+    && session.repository
+    && session.repository !== session.currentRepository
+    ? ` [example from ${session.repository}]`
+    : "";
+}
+
+function resolveSessionTimestamp(session, fieldNames) {
+  for (const fieldName of fieldNames) {
+    if (session[fieldName]) {
+      return session[fieldName];
+    }
+  }
+  return "";
+}
+
 function formatTemporalVerifierSessionLine(session) {
   const summary = normalizeText(session.workspaceSummary || session.summary);
   if (!summary) {
     return "";
   }
-  const timestamp = session.sessionStoreUpdatedAt
-    ?? session.sessionStoreCreatedAt
-    ?? session.updated_at
-    ?? session.created_at
-    ?? "";
+  const timestamp = resolveSessionTimestamp(session, [
+    "sessionStoreUpdatedAt",
+    "sessionStoreCreatedAt",
+    "updated_at",
+    "created_at",
+  ]);
   const prefix = timestamp ? `${String(timestamp).slice(0, 10)}: ` : "";
-  const repositoryLabel = session.currentRepository
-    && session.repository
-    && session.repository !== session.currentRepository
-    ? ` [example from ${session.repository}]`
-    : "";
+  const repositoryLabel = buildCrossRepoRepositoryLabel(session);
   return `- ${prefix}${summary}${repositoryLabel}`;
 }
 

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -393,6 +393,7 @@ function formatSemanticContextLine(memory) {
 
 
 
+// fallow-ignore-next-line complexity
 function serializeSemanticTraceRow(memory, currentRepository = null) {
   return {
     id: memory.id ?? null,
@@ -595,6 +596,7 @@ function buildLoreStatsPayload({
   };
 }
 
+// fallow-ignore-next-line complexity
 function createPromptContextTrace({
   prompt,
   repository,
@@ -1403,6 +1405,7 @@ export class LoreDb {
     });
   }
 
+// fallow-ignore-next-line complexity
   insertIntentJournalEntry({
     repository = null,
     sessionId = null,
@@ -1482,6 +1485,7 @@ export class LoreDb {
     }));
   }
 
+// fallow-ignore-next-line complexity
   insertTrajectoryArtifact({
     kind,
     repository = null,
@@ -4172,6 +4176,7 @@ export class LoreDb {
     };
   }
 
+// fallow-ignore-next-line complexity
   buildPromptCrossRepoContext({
     lexicalPrompt,
     repository,

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -391,22 +391,118 @@ function formatSemanticContextLine(memory) {
   return `- [${memory.type}${scopeLabel}${repositoryLabel}] ${memory.content}`;
 }
 
+function normalizeTraceMemoryRow(memory) {
+  return memory && typeof memory === "object" ? memory : {};
+}
 
-
-// fallow-ignore-next-line complexity
-function serializeSemanticTraceRow(memory, currentRepository = null) {
+function buildSemanticTraceIdentity(memory) {
   return {
     id: memory.id ?? null,
     type: memory.type ?? null,
     scope: memory.scope ?? null,
     scopeSource: memory.scope_source ?? null,
     repository: memory.repository ?? null,
+  };
+}
+
+function buildSemanticTraceMetadata(memory) {
+  return {
     updatedAt: memory.updated_at ?? null,
     canonicalKey: memory.canonical_key ?? null,
     reinforcementCount: memory.reinforcement_count ?? 1,
     lastSeenAt: memory.last_seen_at ?? null,
-    crossRepo: isCrossRepoRow(memory, currentRepository),
-    content: normalizeText(memory.content),
+  };
+}
+
+function serializeSemanticRows(rows, repository) {
+  return rows.map((memory) => serializeSemanticTraceRow(memory, repository));
+}
+
+function serializeEpisodeRows(rows, repository) {
+  return rows.map((episode) => serializeEpisodeTraceRow(episode, repository));
+}
+
+function serializeSessionRows(rows, repository) {
+  return rows.map((session) => serializeSessionTraceRow(session, repository));
+}
+
+
+
+function serializeSemanticTraceRow(memory, currentRepository = null) {
+  const normalizedMemory = normalizeTraceMemoryRow(memory);
+  return {
+    ...buildSemanticTraceIdentity(normalizedMemory),
+    ...buildSemanticTraceMetadata(normalizedMemory),
+    crossRepo: isCrossRepoRow(normalizedMemory, currentRepository),
+    content: normalizeText(normalizedMemory.content),
+  };
+}
+
+function buildStyleAddressingTraceLookup({
+  effectiveStyleSection,
+  assistantPersonaRows,
+  relationshipPreferenceRows,
+  repository,
+}) {
+  const styleRows = [
+    ...serializeSemanticRows(assistantPersonaRows, repository),
+    ...serializeSemanticRows(relationshipPreferenceRows, repository),
+  ];
+  return {
+    enabled: effectiveStyleSection.trace.enabled,
+    ambientEnabled: effectiveStyleSection.trace.ambientEnabled,
+    includeAmbient: effectiveStyleSection.trace.includeAmbient,
+    promptLocal: effectiveStyleSection.trace.promptLocal,
+    rows: styleRows,
+    includedRows: effectiveStyleSection.trace.includeAmbient ? styleRows : [],
+    reason: effectiveStyleSection.trace.reason,
+  };
+}
+
+function buildCrossRepoPreferencesTraceLookup({
+  allowGenericCrossRepoFallback,
+  crossRepoPreferenceRows,
+  crossRepoPreferences,
+  repository,
+}) {
+  return {
+    enabled: allowGenericCrossRepoFallback,
+    scopes: [MEMORY_SCOPE.TRANSFERABLE],
+    rows: serializeSemanticRows(crossRepoPreferenceRows, repository),
+    includedRows: serializeSemanticRows(crossRepoPreferences, repository),
+    filtered: crossRepoPreferenceRows
+      .filter((memory) => !isCrossRepoRow(memory, repository))
+      .map((memory) => ({
+        stage: "cross_repo_filter",
+        reason: "same_repository",
+        row: serializeSemanticTraceRow(memory, repository),
+      })),
+    reason: null,
+  };
+}
+
+function buildCrossRepoEpisodesTraceLookup({
+  allowGenericCrossRepoFallback,
+  crossRepoEpisodeDetails,
+  crossRepoEpisodes,
+  repository,
+}) {
+  return {
+    enabled: allowGenericCrossRepoFallback,
+    scopes: [MEMORY_SCOPE.TRANSFERABLE],
+    rankedRows: crossRepoEpisodeDetails?.trace?.rankedRows ?? [],
+    includedRows: serializeEpisodeRows(crossRepoEpisodes, repository),
+    filtered: [
+      ...(crossRepoEpisodeDetails?.trace?.filtered ?? []),
+      ...((crossRepoEpisodeDetails?.episodes ?? [])
+        .filter((episode) => !isCrossRepoRow(episode, repository))
+        .map((episode) => ({
+          stage: "cross_repo_filter",
+          reason: "same_repository",
+          row: serializeEpisodeTraceRow(episode, repository),
+        }))),
+    ],
+    reason: null,
   };
 }
 
@@ -596,7 +692,6 @@ function buildLoreStatsPayload({
   };
 }
 
-// fallow-ignore-next-line complexity
 function createPromptContextTrace({
   prompt,
   repository,
@@ -638,32 +733,21 @@ function createPromptContextTrace({
       localMemories: {
         query: prompt,
         types: ["commitment", "open_loop", "rejected_approach", "blocker", "user_preference", "assistant_identity", "user_identity", "assistant_goal", "recurring_mistake"],
-        rows: memories.map((memory) => serializeSemanticTraceRow(memory, repository)),
-        includedRows: localMemories.map((memory) => serializeSemanticTraceRow(memory, repository)),
+        rows: serializeSemanticRows(memories, repository),
+        includedRows: serializeSemanticRows(localMemories, repository),
       },
       identityMemories: {
         query: identityName ?? "",
         scopes: [MEMORY_SCOPE.GLOBAL],
-        rows: identityMemories.map((memory) => serializeSemanticTraceRow(memory, repository)),
-        includedRows: identityMemories.map((memory) => serializeSemanticTraceRow(memory, repository)),
+        rows: serializeSemanticRows(identityMemories, repository),
+        includedRows: serializeSemanticRows(identityMemories, repository),
       },
-      styleAddressing: {
-        enabled: effectiveStyleSection.trace.enabled,
-        ambientEnabled: effectiveStyleSection.trace.ambientEnabled,
-        includeAmbient: effectiveStyleSection.trace.includeAmbient,
-        promptLocal: effectiveStyleSection.trace.promptLocal,
-        rows: [
-          ...assistantPersonaRows.map((memory) => serializeSemanticTraceRow(memory, repository)),
-          ...relationshipPreferenceRows.map((memory) => serializeSemanticTraceRow(memory, repository)),
-        ],
-        includedRows: effectiveStyleSection.trace.includeAmbient
-          ? [
-              ...assistantPersonaRows.map((memory) => serializeSemanticTraceRow(memory, repository)),
-              ...relationshipPreferenceRows.map((memory) => serializeSemanticTraceRow(memory, repository)),
-            ]
-          : [],
-        reason: effectiveStyleSection.trace.reason,
-      },
+      styleAddressing: buildStyleAddressingTraceLookup({
+        effectiveStyleSection,
+        assistantPersonaRows,
+        relationshipPreferenceRows,
+        repository,
+      }),
       daySummary: {
         date: temporalDate,
         rows: daySummaryRows.map((summary) => serializeDaySummaryTraceRow(summary, repository)),
@@ -672,40 +756,21 @@ function createPromptContextTrace({
         reason: null,
       },
       localEpisodes: episodeDetails.trace,
-      crossRepoPreferences: {
-        enabled: allowGenericCrossRepoFallback,
-        scopes: [MEMORY_SCOPE.TRANSFERABLE],
-        rows: crossRepoPreferenceRows.map((memory) => serializeSemanticTraceRow(memory, repository)),
-        includedRows: crossRepoPreferences.map((memory) => serializeSemanticTraceRow(memory, repository)),
-        filtered: crossRepoPreferenceRows
-          .filter((memory) => !isCrossRepoRow(memory, repository))
-          .map((memory) => ({
-            stage: "cross_repo_filter",
-            reason: "same_repository",
-            row: serializeSemanticTraceRow(memory, repository),
-          })),
-        reason: null,
-      },
-      crossRepoEpisodes: {
-        enabled: allowGenericCrossRepoFallback,
-        scopes: [MEMORY_SCOPE.TRANSFERABLE],
-        rankedRows: crossRepoEpisodeDetails?.trace?.rankedRows ?? [],
-        includedRows: crossRepoEpisodes.map((episode) => serializeEpisodeTraceRow(episode, repository)),
-        filtered: [
-          ...(crossRepoEpisodeDetails?.trace?.filtered ?? []),
-          ...((crossRepoEpisodeDetails?.episodes ?? [])
-            .filter((episode) => !isCrossRepoRow(episode, repository))
-            .map((episode) => ({
-              stage: "cross_repo_filter",
-              reason: "same_repository",
-              row: serializeEpisodeTraceRow(episode, repository),
-            }))),
-        ],
-        reason: null,
-      },
+      crossRepoPreferences: buildCrossRepoPreferencesTraceLookup({
+        allowGenericCrossRepoFallback,
+        crossRepoPreferenceRows,
+        crossRepoPreferences,
+        repository,
+      }),
+      crossRepoEpisodes: buildCrossRepoEpisodesTraceLookup({
+        allowGenericCrossRepoFallback,
+        crossRepoEpisodeDetails,
+        crossRepoEpisodes,
+        repository,
+      }),
       crossRepoHints: {
         enabled: allowGenericCrossRepoFallback && !!sessionStore,
-        rows: crossRepoHints.map((session) => serializeSessionTraceRow(session, repository)),
+        rows: serializeSessionRows(crossRepoHints, repository),
         includedRows: [],
         reason: null,
       },
@@ -1405,7 +1470,6 @@ export class LoreDb {
     });
   }
 
-// fallow-ignore-next-line complexity
   insertIntentJournalEntry({
     repository = null,
     sessionId = null,
@@ -1420,9 +1484,14 @@ export class LoreDb {
     if (!normalizedSummary) {
       throw new Error("summary is required");
     }
-    const normalizedIntentKind = String(intentKind || "").trim().toLowerCase() || "journal";
-    const allowedKinds = new Set(["journal", "routing", "rollout", "reviewer", "fallback", "serendipity"]);
-    const safeIntentKind = allowedKinds.has(normalizedIntentKind) ? normalizedIntentKind : "journal";
+    const normalizeIntentKind = (value) => {
+      const normalized = String(value || "").trim().toLowerCase() || "journal";
+      const allowedKinds = new Set(["journal", "routing", "rollout", "reviewer", "fallback", "serendipity"]);
+      return allowedKinds.has(normalized) ? normalized : "journal";
+    };
+    const normalizeOptionalString = (value) => (
+      typeof value === "string" && value.trim().length > 0 ? value.trim() : null
+    );
     const id = crypto.randomUUID();
     this.db.prepare(`
       INSERT INTO intent_journal (
@@ -1439,11 +1508,11 @@ export class LoreDb {
     `).run(
       id,
       normalizeRepository(repository),
-      typeof sessionId === "string" && sessionId.trim().length > 0 ? sessionId.trim() : null,
-      typeof turnHint === "string" && turnHint.trim().length > 0 ? turnHint.trim() : null,
-      safeIntentKind,
+      normalizeOptionalString(sessionId),
+      normalizeOptionalString(turnHint),
+      normalizeIntentKind(intentKind),
       normalizedSummary,
-      typeof rationale === "string" && rationale.trim().length > 0 ? rationale.trim() : null,
+      normalizeOptionalString(rationale),
       JSON.stringify(context ?? {}),
       nowIso(),
     );
@@ -1485,7 +1554,6 @@ export class LoreDb {
     }));
   }
 
-// fallow-ignore-next-line complexity
   insertTrajectoryArtifact({
     kind,
     repository = null,
@@ -1504,6 +1572,8 @@ export class LoreDb {
     this.ensureOpen();
     const normalizedKind = validateRequiredStringField(kind, "kind");
     const normalizedSummary = validateRequiredStringField(summary, "summary");
+    const normalizeOptionalValue = (value) => (value ? String(value) : null);
+    const roundIfFinite = (value) => (Number.isFinite(value) ? Math.round(value) : null);
     const id = crypto.randomUUID();
     this.db.prepare(`
       INSERT INTO trajectory_artifact (
@@ -1527,15 +1597,15 @@ export class LoreDb {
       id,
       normalizedKind,
       normalizeRepository(repository),
-      sourceCaseId ? String(sourceCaseId) : null,
-      sourceKind ? String(sourceKind) : null,
-      improvementArtifactId ? String(improvementArtifactId) : null,
-      eventKey ? String(eventKey) : null,
+      normalizeOptionalValue(sourceCaseId),
+      normalizeOptionalValue(sourceKind),
+      normalizeOptionalValue(improvementArtifactId),
+      normalizeOptionalValue(eventKey),
       normalizedSummary,
       String(severity || "info"),
       String(outcome || "captured"),
-      Number.isFinite(latencyMs) ? Math.round(latencyMs) : null,
-      Number.isFinite(targetMs) ? Math.round(targetMs) : null,
+      roundIfFinite(latencyMs),
+      roundIfFinite(targetMs),
       JSON.stringify(context ?? {}),
       JSON.stringify(trace ?? {}),
       nowIso(),
@@ -4176,7 +4246,6 @@ export class LoreDb {
     };
   }
 
-// fallow-ignore-next-line complexity
   buildPromptCrossRepoContext({
     lexicalPrompt,
     repository,
@@ -4187,6 +4256,12 @@ export class LoreDb {
   }) {
     const allowGenericCrossRepoFallback = allowCrossRepoFallback && !pureTemporalRecall;
     const crossRepoPreferenceLimit = Math.max(1, Math.min(2, Math.floor(limit / 2) || 1));
+    const selectCrossRepoRows = (rows) => withCurrentRepository(
+      rows
+        .filter((row) => isCrossRepoRow(row, repository))
+        .slice(0, crossRepoPreferenceLimit),
+      repository,
+    );
     const crossRepoPreferenceRows = allowGenericCrossRepoFallback
       ? this.searchSemantic({
           query: lexicalPrompt,
@@ -4198,12 +4273,7 @@ export class LoreDb {
         })
       : [];
     const crossRepoPreferences = allowGenericCrossRepoFallback
-      ? withCurrentRepository(
-          crossRepoPreferenceRows
-            .filter((memory) => isCrossRepoRow(memory, repository))
-            .slice(0, crossRepoPreferenceLimit),
-          repository,
-        )
+      ? selectCrossRepoRows(crossRepoPreferenceRows)
       : [];
     const crossRepoEpisodeDetails = allowGenericCrossRepoFallback
       ? this.findRelevantEpisodesDetailed({
@@ -4215,12 +4285,7 @@ export class LoreDb {
         })
       : null;
     const crossRepoEpisodes = allowGenericCrossRepoFallback
-      ? withCurrentRepository(
-          crossRepoEpisodeDetails.episodes
-            .filter((episode) => isCrossRepoRow(episode, repository))
-            .slice(0, Math.max(1, Math.min(2, Math.floor(limit / 2) || 1))),
-          repository,
-        )
+      ? selectCrossRepoRows(crossRepoEpisodeDetails.episodes)
       : [];
     const crossRepoHints = allowGenericCrossRepoFallback && sessionStore
       ? withCurrentRepository(
@@ -4229,7 +4294,7 @@ export class LoreDb {
             repository: null,
             limit: Math.max(limit * 4, 8),
           }).filter((session) => isCrossRepoRow(session, repository))
-            .slice(0, Math.max(1, Math.min(2, Math.floor(limit / 2) || 1))),
+            .slice(0, crossRepoPreferenceLimit),
           repository,
         )
       : [];

--- a/lib/diagnostics.mjs
+++ b/lib/diagnostics.mjs
@@ -391,23 +391,31 @@ function matchesEvidenceItem(traceRow, definition) {
   return textMatches && typeMatches;
 }
 
-// fallow-ignore-next-line complexity
+function bestMatchPosition(matches) {
+  return matches.length > 0
+    ? Math.min(...matches.map((match) => match.position))
+    : null;
+}
+
+function buildEvidenceLabel(item) {
+  return item.label ?? item.includesAny?.[0] ?? item.types?.[0] ?? "expected-evidence";
+}
+
+function buildEvidenceOutcome(bestIncludedPosition, bestRankedPosition) {
+  if (bestIncludedPosition != null) {
+    return "included";
+  }
+  return bestRankedPosition != null ? "ranked_only" : "missing";
+}
+
 function evaluateEvidenceItem(traceRows, item) {
   const rankedMatches = traceRows.ranked.filter((traceRow) => matchesEvidenceItem(traceRow, item));
   const includedMatches = traceRows.included.filter((traceRow) => matchesEvidenceItem(traceRow, item));
-  const bestRankedPosition = rankedMatches.length > 0
-    ? Math.min(...rankedMatches.map((match) => match.position))
-    : null;
-  const bestIncludedPosition = includedMatches.length > 0
-    ? Math.min(...includedMatches.map((match) => match.position))
-    : null;
-  const outcome = bestIncludedPosition != null
-    ? "included"
-    : bestRankedPosition != null
-      ? "ranked_only"
-      : "missing";
+  const bestRankedPosition = bestMatchPosition(rankedMatches);
+  const bestIncludedPosition = bestMatchPosition(includedMatches);
+  const outcome = buildEvidenceOutcome(bestIncludedPosition, bestRankedPosition);
   return {
-    label: item.label ?? item.includesAny?.[0] ?? item.types?.[0] ?? "expected-evidence",
+    label: buildEvidenceLabel(item),
     includesAny: ensureArray(item.includesAny),
     types: ensureArray(item.types),
     outcome,
@@ -792,7 +800,6 @@ function buildReplayFailureEvidence({
   };
 }
 
-// fallow-ignore-next-line complexity
 function buildReplayFailureContext({
   definition,
   explanation,
@@ -801,6 +808,7 @@ function buildReplayFailureContext({
   missCategory,
   failedAssertions,
 }) {
+  const normalizedEvidence = evidence || {};
   return {
     title: definition.title,
     caseType: definition.caseType ?? "must_pass",
@@ -808,9 +816,9 @@ function buildReplayFailureContext({
     rankingOutcome: rankingOutcome ?? null,
     missCategory: missCategory ?? null,
     failedAssertionCount: failedAssertions.length,
-    expectedEvidenceCount: evidence?.expectedCount ?? 0,
-    includedEvidenceCount: evidence?.includedCount ?? 0,
-    rankedOnlyEvidenceCount: evidence?.rankedOnlyCount ?? 0,
+    expectedEvidenceCount: normalizedEvidence.expectedCount ?? 0,
+    includedEvidenceCount: normalizedEvidence.includedCount ?? 0,
+    rankedOnlyEvidenceCount: normalizedEvidence.rankedOnlyCount ?? 0,
     estimatedTokens: explanation.estimatedTokens ?? 0,
   };
 }
@@ -1276,19 +1284,19 @@ export async function explainMemoryRetrieval({
   };
 }
 
-// fallow-ignore-next-line complexity
 function buildExplanationOverviewLines(explanation, sectionTitles) {
+  const promptNeed = explanation.promptNeed ?? {};
   return [
     `mode: ${explanation.mode}`,
     `repository: ${explanation.repository ?? "global-only"}`,
     `prompt: ${explanation.prompt}`,
-    `requiresLookup: ${explanation.promptNeed?.requiresLookup === true}`,
-    `wantsContinuity: ${explanation.promptNeed?.wantsContinuity === true}`,
-    `wantsStyleContext: ${explanation.promptNeed?.wantsStyleContext === true}`,
-    `wantsCrossRepoExamples: ${explanation.promptNeed?.wantsCrossRepoExamples === true}`,
-    `wantsRepoLocalTaskContext: ${explanation.promptNeed?.wantsRepoLocalTaskContext === true}`,
-    `identityOnly: ${explanation.promptNeed?.identityOnly === true}`,
-    `directAddressed: ${explanation.promptNeed?.directAddressed === true}`,
+    `requiresLookup: ${promptNeed.requiresLookup === true}`,
+    `wantsContinuity: ${promptNeed.wantsContinuity === true}`,
+    `wantsStyleContext: ${promptNeed.wantsStyleContext === true}`,
+    `wantsCrossRepoExamples: ${promptNeed.wantsCrossRepoExamples === true}`,
+    `wantsRepoLocalTaskContext: ${promptNeed.wantsRepoLocalTaskContext === true}`,
+    `identityOnly: ${promptNeed.identityOnly === true}`,
+    `directAddressed: ${promptNeed.directAddressed === true}`,
     `estimatedTokens: ${explanation.estimatedTokens ?? 0}`,
     "",
     "## Output Sections",

--- a/lib/diagnostics.mjs
+++ b/lib/diagnostics.mjs
@@ -391,6 +391,7 @@ function matchesEvidenceItem(traceRow, definition) {
   return textMatches && typeMatches;
 }
 
+// fallow-ignore-next-line complexity
 function evaluateEvidenceItem(traceRows, item) {
   const rankedMatches = traceRows.ranked.filter((traceRow) => matchesEvidenceItem(traceRow, item));
   const includedMatches = traceRows.included.filter((traceRow) => matchesEvidenceItem(traceRow, item));
@@ -791,6 +792,7 @@ function buildReplayFailureEvidence({
   };
 }
 
+// fallow-ignore-next-line complexity
 function buildReplayFailureContext({
   definition,
   explanation,
@@ -1274,6 +1276,7 @@ export async function explainMemoryRetrieval({
   };
 }
 
+// fallow-ignore-next-line complexity
 function buildExplanationOverviewLines(explanation, sectionTitles) {
   return [
     `mode: ${explanation.mode}`,

--- a/lib/lore-doctor.mjs
+++ b/lib/lore-doctor.mjs
@@ -287,7 +287,28 @@ function buildMaintenanceAttentionIncident(state) {
   };
 }
 
-// fallow-ignore-next-line complexity
+function hasReplayAttentionCounts(replayAttention) {
+  return replayAttention.mustPassFailed > 0
+    || replayAttention.rankingTargetPartial > 0
+    || replayAttention.rankingTargetMissing > 0;
+}
+
+function buildTaskSpecificAttentionIncident(state) {
+  if (state.taskName === "replayCorpus") {
+    const replayAttention = readReplayAttentionCounts(state);
+    return hasReplayAttentionCounts(replayAttention)
+      ? buildReplayCorpusAttentionIncident(state, replayAttention)
+      : null;
+  }
+  if (state.taskName === "validationCorpus") {
+    const validationFailed = state.lastSummary?.failed ?? 0;
+    return validationFailed > 0
+      ? buildValidationCorpusAttentionIncident(state, validationFailed)
+      : null;
+  }
+  return null;
+}
+
 function classifyMaintenanceTask(state) {
   if (state.lastStatus === "failed") {
     return buildMaintenanceFailureIncident(state);
@@ -295,21 +316,7 @@ function classifyMaintenanceTask(state) {
   if (state.lastStatus !== "needs_attention") {
     return null;
   }
-
-  const replayAttention = readReplayAttentionCounts(state);
-  const hasReplayAttention = replayAttention.mustPassFailed > 0
-    || replayAttention.rankingTargetPartial > 0
-    || replayAttention.rankingTargetMissing > 0;
-  if (state.taskName === "replayCorpus" && hasReplayAttention) {
-    return buildReplayCorpusAttentionIncident(state, replayAttention);
-  }
-
-  const validationFailed = state.lastSummary?.failed ?? 0;
-  if (state.taskName === "validationCorpus" && validationFailed > 0) {
-    return buildValidationCorpusAttentionIncident(state, validationFailed);
-  }
-
-  return buildMaintenanceAttentionIncident(state);
+  return buildTaskSpecificAttentionIncident(state) ?? buildMaintenanceAttentionIncident(state);
 }
 
 function classifyMaintenanceTasks(taskStates) {

--- a/lib/lore-doctor.mjs
+++ b/lib/lore-doctor.mjs
@@ -287,6 +287,7 @@ function buildMaintenanceAttentionIncident(state) {
   };
 }
 
+// fallow-ignore-next-line complexity
 function classifyMaintenanceTask(state) {
   if (state.lastStatus === "failed") {
     return buildMaintenanceFailureIncident(state);

--- a/lib/maintenance-scheduler.mjs
+++ b/lib/maintenance-scheduler.mjs
@@ -147,6 +147,7 @@ function isTaskEnabled({ taskName, options, runtime, trigger }) {
   return taskCheck ? taskCheck({ runtime, trigger }) : true;
 }
 
+// fallow-ignore-next-line complexity
 function buildDueEvaluation({ taskName, state, options, force = false }) {
   const cadenceMinutes = options.taskCadenceMinutes[taskName] ?? 0;
   const referenceAt = state?.last_completed_at ?? state?.last_started_at ?? null;
@@ -202,6 +203,7 @@ function buildTaskPreview({ taskName, state, options }) {
   return null;
 }
 
+// fallow-ignore-next-line complexity
 function buildTaskEntry({
   taskName,
   state,

--- a/lib/maintenance-scheduler.mjs
+++ b/lib/maintenance-scheduler.mjs
@@ -147,50 +147,72 @@ function isTaskEnabled({ taskName, options, runtime, trigger }) {
   return taskCheck ? taskCheck({ runtime, trigger }) : true;
 }
 
-// fallow-ignore-next-line complexity
-function buildDueEvaluation({ taskName, state, options, force = false }) {
-  const cadenceMinutes = options.taskCadenceMinutes[taskName] ?? 0;
-  const referenceAt = state?.last_completed_at ?? state?.last_started_at ?? null;
-  if (force) {
-    return {
-      due: true,
-      reason: "forced",
-      cadenceMinutes,
-      lastRunMinutesAgo: elapsedMinutesSince(referenceAt),
-    };
-  }
-  if (!referenceAt) {
-    return {
-      due: true,
-      reason: "never_run",
-      cadenceMinutes,
-      lastRunMinutesAgo: null,
-    };
-  }
-  const ageMinutes = elapsedMinutesSince(referenceAt);
+function buildDueResult({
+  due,
+  reason,
+  cadenceMinutes,
+  lastRunMinutesAgo,
+  nextRunMinutes = null,
+}) {
+  return {
+    due,
+    reason,
+    cadenceMinutes,
+    lastRunMinutesAgo,
+    nextRunMinutes,
+  };
+}
+
+function readTaskReferenceAt(state) {
+  return state?.last_completed_at ?? state?.last_started_at ?? null;
+}
+
+function buildAgeBasedDueEvaluation(cadenceMinutes, ageMinutes) {
   if (cadenceMinutes === 0) {
-    return {
+    return buildDueResult({
       due: true,
       reason: "always_due",
       cadenceMinutes,
       lastRunMinutesAgo: ageMinutes,
-    };
+    });
   }
   if (ageMinutes == null || ageMinutes >= cadenceMinutes) {
-    return {
+    return buildDueResult({
       due: true,
       reason: ageMinutes == null ? "due_unknown_age" : "cadence_elapsed",
       cadenceMinutes,
       lastRunMinutesAgo: ageMinutes,
-    };
+    });
   }
-  return {
+  return buildDueResult({
     due: false,
     reason: "within_cadence",
     cadenceMinutes,
     lastRunMinutesAgo: ageMinutes,
     nextRunMinutes: cadenceMinutes - ageMinutes,
-  };
+  });
+}
+
+function buildDueEvaluation({ taskName, state, options, force = false }) {
+  const cadenceMinutes = options.taskCadenceMinutes[taskName] ?? 0;
+  const referenceAt = readTaskReferenceAt(state);
+  if (force) {
+    return buildDueResult({
+      due: true,
+      reason: "forced",
+      cadenceMinutes,
+      lastRunMinutesAgo: elapsedMinutesSince(referenceAt),
+    });
+  }
+  if (!referenceAt) {
+    return buildDueResult({
+      due: true,
+      reason: "never_run",
+      cadenceMinutes,
+      lastRunMinutesAgo: null,
+    });
+  }
+  return buildAgeBasedDueEvaluation(cadenceMinutes, elapsedMinutesSince(referenceAt));
 }
 
 function buildTaskPreview({ taskName, state, options }) {
@@ -203,7 +225,6 @@ function buildTaskPreview({ taskName, state, options }) {
   return null;
 }
 
-// fallow-ignore-next-line complexity
 function buildTaskEntry({
   taskName,
   state,
@@ -214,14 +235,15 @@ function buildTaskEntry({
   force,
 }) {
   const enabled = isTaskEnabled({ taskName, options, runtime, trigger });
+  const cadenceMinutes = options.taskCadenceMinutes[taskName] ?? 0;
   const due = enabled
     ? buildDueEvaluation({ taskName, state, options, force })
-    : {
+    : buildDueResult({
       due: false,
       reason: "disabled",
-      cadenceMinutes: options.taskCadenceMinutes[taskName] ?? 0,
-      lastRunMinutesAgo: elapsedMinutesSince(state?.last_completed_at ?? state?.last_started_at ?? null),
-    };
+      cadenceMinutes,
+      lastRunMinutesAgo: elapsedMinutesSince(readTaskReferenceAt(state)),
+    });
   const preview = buildTaskPreview({ taskName, state, options });
   return {
     taskName,

--- a/lib/memory-operations.mjs
+++ b/lib/memory-operations.mjs
@@ -280,14 +280,14 @@ function buildLookupEnvelope(name, lookup) {
   };
 }
 
-// fallow-ignore-next-line complexity
 function buildSourceAccountingEntry(detail) {
+  const normalizedDetail = detail && typeof detail === "object" ? detail : {};
   return {
-    title: detail?.title ?? "section",
-    source: detail?.source ?? null,
-    budget: detail?.budget ?? null,
-    usedTokens: detail?.usedTokens ?? 0,
-    entryCount: detail?.entryCount ?? 0,
+    title: normalizedDetail.title ?? "section",
+    source: normalizedDetail.source ?? null,
+    budget: normalizedDetail.budget ?? null,
+    usedTokens: normalizedDetail.usedTokens ?? 0,
+    entryCount: normalizedDetail.entryCount ?? 0,
   };
 }
 
@@ -311,27 +311,42 @@ function buildLookupEnvelopeFromEntry([name, lookup]) {
   return buildLookupEnvelope(name, lookup);
 }
 
-// fallow-ignore-next-line complexity
+function asObjectRecord(value) {
+  return value && typeof value === "object" ? value : {};
+}
+
+function normalizeTraceOutput(result) {
+  const normalizedResult = asObjectRecord(result);
+  const trace = asObjectRecord(normalizedResult.trace);
+  const output = asObjectRecord(trace.output);
+  return {
+    lookups: asObjectRecord(trace.lookups),
+    output,
+    estimatedTokens: normalizedResult.estimatedTokens ?? 0,
+    overlays: Array.isArray(normalizedResult.overlays) ? normalizedResult.overlays : [],
+  };
+}
+
 function buildEvidenceEnvelope(result) {
-  const lookups = Object.entries(result?.trace?.lookups ?? {})
-    .map(buildLookupEnvelopeFromEntry);
+  const normalized = normalizeTraceOutput(result);
+  const lookups = Object.entries(normalized.lookups).map(buildLookupEnvelopeFromEntry);
 
   const supportingFacts = dedupeStrings(
     lookups.flatMap((lookup) => lookup.includedEntries.map((entry) => entry.text)),
     8,
   );
-  const sourceAccounting = buildSourceAccounting(result?.trace?.output?.sectionDetails);
+  const sourceAccounting = buildSourceAccounting(normalized.output.sectionDetails);
   const evidenceEntries = dedupeEvidenceEntries(
     lookups.flatMap((lookup) => selectLookupEvidenceEntries(lookup)),
     12,
   );
 
   return {
-    sections: result?.trace?.output?.sectionTitles ?? [],
-    estimatedTokens: result?.estimatedTokens ?? 0,
+    sections: normalized.output.sectionTitles ?? [],
+    estimatedTokens: normalized.estimatedTokens,
     supportingFacts,
     sourceAccounting,
-    workstreamOverlays: Array.isArray(result?.overlays) ? result.overlays : [],
+    workstreamOverlays: normalized.overlays,
     evidenceEntries,
     lookups,
   };

--- a/lib/memory-operations.mjs
+++ b/lib/memory-operations.mjs
@@ -311,6 +311,7 @@ function buildLookupEnvelopeFromEntry([name, lookup]) {
   return buildLookupEnvelope(name, lookup);
 }
 
+// fallow-ignore-next-line complexity
 function buildEvidenceEnvelope(result) {
   const lookups = Object.entries(result?.trace?.lookups ?? {})
     .map(buildLookupEnvelopeFromEntry);

--- a/lib/overlay-hydrator.mjs
+++ b/lib/overlay-hydrator.mjs
@@ -131,6 +131,7 @@ function hasLocalWorkstreamArtifacts({ plan, todos }) {
   return plan != null || todos.inProgress.length > 0 || todos.blocked.length > 0;
 }
 
+// fallow-ignore-next-line complexity
 function buildHydratedOverlay({
   repository,
   sessionId,

--- a/lib/overlay-hydrator.mjs
+++ b/lib/overlay-hydrator.mjs
@@ -131,7 +131,24 @@ function hasLocalWorkstreamArtifacts({ plan, todos }) {
   return plan != null || todos.inProgress.length > 0 || todos.blocked.length > 0;
 }
 
-// fallow-ignore-next-line complexity
+function buildOverlayTitle(taskId) {
+  return taskId
+    ? taskId.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
+    : "Current Workstream";
+}
+
+function buildOverlayMetadata(plan, todos, maintenanceBlockers) {
+  return {
+    source: "overlay_hydrator",
+    hydratedAt: new Date().toISOString(),
+    hasPlan: plan != null,
+    todoInProgressCount: todos.inProgress.length,
+    todoBlockedCount: todos.blocked.length,
+    todoPendingCount: todos.pending.length,
+    maintenanceBlockerCount: maintenanceBlockers.length,
+  };
+}
+
 function buildHydratedOverlay({
   repository,
   sessionId,
@@ -140,9 +157,7 @@ function buildHydratedOverlay({
   maintenanceBlockers,
 }) {
   const overlayId = sanitizeRetainedText(plan?.taskId || "current-workstream");
-  const title = plan?.taskId
-    ? plan.taskId.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
-    : "Current Workstream";
+  const title = buildOverlayTitle(plan?.taskId);
   const blockers = sanitizeRetainedList([
     ...todos.blocked,
     ...maintenanceBlockers,
@@ -171,15 +186,7 @@ function buildHydratedOverlay({
       nextActions,
       status,
       sourceSessionId: sessionId,
-      metadata: {
-        source: "overlay_hydrator",
-        hydratedAt: new Date().toISOString(),
-        hasPlan: plan != null,
-        todoInProgressCount: todos.inProgress.length,
-        todoBlockedCount: todos.blocked.length,
-        todoPendingCount: todos.pending.length,
-        maintenanceBlockerCount: maintenanceBlockers.length,
-      },
+      metadata: buildOverlayMetadata(plan, todos, maintenanceBlockers),
     }),
   };
 }

--- a/lib/query-normalizer.mjs
+++ b/lib/query-normalizer.mjs
@@ -177,7 +177,21 @@ function buildDate(year, monthIndex, day) {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
-// fallow-ignore-next-line complexity
+function includesWeekdayQualifier(text, qualifier, weekday) {
+  return new RegExp(`\\b${qualifier}\\s+${weekday}\\b`).test(text);
+}
+
+function resolveWeekdayDifference({ currentIndex, targetIndex, hasLastQualifier, hasThisQualifier }) {
+  const initialDiff = (currentIndex - targetIndex + 7) % 7;
+  if (hasThisQualifier) {
+    return initialDiff === 0 ? 0 : initialDiff;
+  }
+  if (hasLastQualifier || initialDiff === 0) {
+    return initialDiff === 0 ? 7 : initialDiff;
+  }
+  return initialDiff;
+}
+
 function resolveWeekdayDate(text, now) {
   const matchedWeekday = WEEKDAYS.find((weekday) => text.includes(weekday));
   if (!matchedWeekday) {
@@ -186,19 +200,14 @@ function resolveWeekdayDate(text, now) {
 
   const targetIndex = WEEKDAYS.indexOf(matchedWeekday);
   const currentIndex = now.getUTCDay();
-  const hasLastQualifier = new RegExp(`\\blast\\s+${matchedWeekday}\\b`).test(text);
-  const hasThisQualifier = new RegExp(`\\bthis\\s+${matchedWeekday}\\b`).test(text);
-
-  let diff = (currentIndex - targetIndex + 7) % 7;
-  if (hasLastQualifier || (!hasThisQualifier && diff === 0)) {
-    diff = diff === 0 ? 7 : diff;
-  }
-  if (hasThisQualifier && diff === 0) {
-    diff = 0;
-  }
-  if (hasThisQualifier && diff < 0) {
-    return null;
-  }
+  const hasLastQualifier = includesWeekdayQualifier(text, "last", matchedWeekday);
+  const hasThisQualifier = includesWeekdayQualifier(text, "this", matchedWeekday);
+  const diff = resolveWeekdayDifference({
+    currentIndex,
+    targetIndex,
+    hasLastQualifier,
+    hasThisQualifier,
+  });
 
   const value = startOfDay(now);
   value.setUTCDate(value.getUTCDate() - diff);

--- a/lib/query-normalizer.mjs
+++ b/lib/query-normalizer.mjs
@@ -177,6 +177,7 @@ function buildDate(year, monthIndex, day) {
   return Number.isNaN(date.getTime()) ? null : date;
 }
 
+// fallow-ignore-next-line complexity
 function resolveWeekdayDate(text, now) {
   const matchedWeekday = WEEKDAYS.find((weekday) => text.includes(weekday));
   if (!matchedWeekday) {

--- a/lib/rule-extractor.mjs
+++ b/lib/rule-extractor.mjs
@@ -159,6 +159,7 @@ function buildEpisodeSummaryFallback(repository, session, sessionId, details) {
   return `Worked in ${location}${branch || ""} (${sessionId})`;
 }
 
+// fallow-ignore-next-line complexity
 function buildEpisodeSummary({
   sessionId,
   repository,

--- a/lib/rule-extractor.mjs
+++ b/lib/rule-extractor.mjs
@@ -159,7 +159,38 @@ function buildEpisodeSummaryFallback(repository, session, sessionId, details) {
   return `Worked in ${location}${branch || ""} (${sessionId})`;
 }
 
-// fallow-ignore-next-line complexity
+function buildEpisodeSummarySeed({
+  latestCheckpoint,
+  session,
+  turns,
+  config,
+}) {
+  const candidates = [
+    meaningfulSummary(latestCheckpoint?.title),
+    meaningfulSummary(session.summary),
+    meaningfulSummary(normalizeTurnText(turns[0]?.user_message, config)),
+    meaningfulSummary(latestCheckpoint?.overview),
+    meaningfulSummary(latestCheckpoint?.work_done),
+    meaningfulSummary(normalizeTurnText(turns.at(-1)?.assistant_response, config)),
+  ];
+  return candidates.find(Boolean);
+}
+
+function buildEpisodeSummaryDetails({ decisions, actions, openItems, files, refs }) {
+  const highlights = uniqueStrings([
+    ...decisions.slice(0, 2),
+    ...actions.slice(0, 2),
+    ...openItems.slice(0, 1),
+  ], 2);
+  const summarizedPaths = summarizePaths(files);
+  const summarizedRefs = summarizeRefs(refs);
+  return [
+    ...highlights,
+    summarizedPaths.length > 0 ? `files: ${summarizedPaths.join(", ")}` : "",
+    summarizedRefs.length > 0 ? `refs: ${summarizedRefs.join(", ")}` : "",
+  ].filter(Boolean);
+}
+
 function buildEpisodeSummary({
   sessionId,
   repository,
@@ -173,25 +204,8 @@ function buildEpisodeSummary({
   openItems,
   config = null,
 }) {
-  const seed = [
-    meaningfulSummary(latestCheckpoint?.title),
-    meaningfulSummary(session.summary),
-    meaningfulSummary(normalizeTurnText(turns[0]?.user_message, config)),
-    meaningfulSummary(latestCheckpoint?.overview),
-    meaningfulSummary(latestCheckpoint?.work_done),
-    meaningfulSummary(normalizeTurnText(turns.at(-1)?.assistant_response, config)),
-  ].find(Boolean);
-
-  const highlights = uniqueStrings([
-    ...decisions.slice(0, 2),
-    ...actions.slice(0, 2),
-    ...openItems.slice(0, 1),
-  ], 2);
-  const details = [
-    ...highlights,
-    summarizePaths(files).length > 0 ? `files: ${summarizePaths(files).join(", ")}` : "",
-    summarizeRefs(refs).length > 0 ? `refs: ${summarizeRefs(refs).join(", ")}` : "",
-  ].filter(Boolean);
+  const seed = buildEpisodeSummarySeed({ latestCheckpoint, session, turns, config });
+  const details = buildEpisodeSummaryDetails({ decisions, actions, openItems, files, refs });
 
   if (seed) {
     return truncateText(

--- a/scripts/dev-install.mjs
+++ b/scripts/dev-install.mjs
@@ -85,7 +85,40 @@ function isSameInstall(sourcePath, targetPath) {
   return realpathSync(sourcePath) === realpathSync(targetPath);
 }
 
-// fallow-ignore-next-line complexity
+function logInstallSummary(label, installTarget) {
+  console.log(`${label}Lore dev-install`);
+  console.log(`  repo root   : ${REPO_ROOT}`);
+  console.log(`  install dir : ${installTarget}`);
+  console.log(`  mode        : directory-copy`);
+}
+
+function logDryRunNoChanges() {
+  console.log("[dry-run] Copilot CLI discovery is more reliable with a real directory install than a symlink.");
+  console.log("[dry-run] No changes made.");
+}
+
+function describeTargetAction(targetType, label) {
+  if (targetType === "symlink") {
+    console.log(`${label}Replacing existing symlink with a real directory install.`);
+    return;
+  }
+  if (targetType === "directory") {
+    console.log(`${label}Refreshing existing Lore install directory.`);
+    return;
+  }
+  console.log(`${label}Installing Lore into Copilot extensions.`);
+}
+
+function ensureExtensionsDir(extensionsDir, dryRun, label) {
+  if (existsSync(extensionsDir)) {
+    return;
+  }
+  console.log(`${label}Creating extensions dir: ${extensionsDir}`);
+  if (!dryRun) {
+    mkdirSync(extensionsDir, { recursive: true });
+  }
+}
+
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const copilotHome = args.copilotHome ?? path.join(os.homedir(), ".copilot");
@@ -94,26 +127,18 @@ function main() {
   const label = args.dryRun ? "[dry-run] " : "";
   const targetState = describeTarget(installTarget);
 
-  console.log(`${label}Lore dev-install`);
-  console.log(`  repo root   : ${REPO_ROOT}`);
-  console.log(`  install dir : ${installTarget}`);
-  console.log(`  mode        : directory-copy`);
+  logInstallSummary(label, installTarget);
 
   if (isSameInstall(REPO_ROOT, installTarget)) {
     console.log(`${label}Lore is already running from the install directory.`);
     console.log(`${label}Use 'git pull' in ${installTarget} to update this checkout.`);
     if (args.dryRun) {
-      console.log("[dry-run] No changes made.");
+      logDryRunNoChanges();
     }
     return;
   }
 
-  if (!existsSync(extensionsDir)) {
-    console.log(`${label}Creating extensions dir: ${extensionsDir}`);
-    if (!args.dryRun) {
-      mkdirSync(extensionsDir, { recursive: true });
-    }
-  }
+  ensureExtensionsDir(extensionsDir, args.dryRun, label);
 
   if (targetState.type === "other") {
     console.error(`ERROR: ${installTarget} exists but is not a directory or symlink.`);
@@ -121,17 +146,10 @@ function main() {
     process.exit(1);
   }
 
-  if (targetState.type === "symlink") {
-    console.log(`${label}Replacing existing symlink with a real directory install.`);
-  } else if (targetState.type === "directory") {
-    console.log(`${label}Refreshing existing Lore install directory.`);
-  } else {
-    console.log(`${label}Installing Lore into Copilot extensions.`);
-  }
+  describeTargetAction(targetState.type, label);
 
   if (args.dryRun) {
-    console.log("[dry-run] Copilot CLI discovery is more reliable with a real directory install than a symlink.");
-    console.log("[dry-run] No changes made.");
+    logDryRunNoChanges();
     return;
   }
 

--- a/scripts/dev-install.mjs
+++ b/scripts/dev-install.mjs
@@ -85,6 +85,7 @@ function isSameInstall(sourcePath, targetPath) {
   return realpathSync(sourcePath) === realpathSync(targetPath);
 }
 
+// fallow-ignore-next-line complexity
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const copilotHome = args.copilotHome ?? path.join(os.homedir(), ".copilot");

--- a/tests/helpers/browser-dom.mjs
+++ b/tests/helpers/browser-dom.mjs
@@ -125,25 +125,21 @@ export function createAppRunner() {
     runApp(document, window, fetch, history, () => 1, URLSearchParams);
 }
 
+function buildDefaultFetchResponses(overrides) {
+  return new Map([
+    ["/api/health", { repository: "owner/repo" }],
+    ["/api/overview", { data: {} }],
+    ["/api/maintenance", overrides.maintenanceData !== undefined ? { data: overrides.maintenanceData } : { data: {} }],
+    ["/api/episodes", { data: {} }],
+    ["/api/memories/filters", { data: {} }],
+  ]);
+}
+
 export function createDefaultFetch(overrides = {}) {
-// fallow-ignore-next-line complexity
+  const responses = buildDefaultFetchResponses(overrides);
   return async (requestPath) => {
-    if (requestPath === "/api/health") {
-      return createResponse({ repository: "owner/repo" });
-    }
-    if (requestPath === "/api/overview") {
-      return createResponse({ data: {} });
-    }
-    if (requestPath === "/api/maintenance") {
-      return createResponse(
-        overrides.maintenanceData !== undefined ? { data: overrides.maintenanceData } : { data: {} },
-      );
-    }
-    if (requestPath === "/api/episodes") {
-      return createResponse({ data: {} });
-    }
-    if (requestPath === "/api/memories/filters") {
-      return createResponse({ data: {} });
+    if (responses.has(requestPath)) {
+      return createResponse(responses.get(requestPath));
     }
     if (requestPath.startsWith("/api/memories?")) {
       return createResponse({ data: { rows: [] } });

--- a/tests/helpers/browser-dom.mjs
+++ b/tests/helpers/browser-dom.mjs
@@ -126,6 +126,7 @@ export function createAppRunner() {
 }
 
 export function createDefaultFetch(overrides = {}) {
+// fallow-ignore-next-line complexity
   return async (requestPath) => {
     if (requestPath === "/api/health") {
       return createResponse({ repository: "owner/repo" });

--- a/tests/unit/capability-inventory-helpers.test.mjs
+++ b/tests/unit/capability-inventory-helpers.test.mjs
@@ -7,6 +7,8 @@ describe("capability inventory helpers", () => {
   it("does not require capability matches for direct router assertions", () => {
     const { evaluateRouterAssertions } = loadCapabilityFunctions([
       "buildRouterAssertion",
+      "buildExpectedValueAssertion",
+      "buildCountAssertion",
       "buildBaseRouterAssertions",
       "buildCapabilityPresenceAssertion",
       "evaluateRouterAssertions",

--- a/tests/unit/capability-inventory-report.test.mjs
+++ b/tests/unit/capability-inventory-report.test.mjs
@@ -10,11 +10,13 @@ describe("capability inventory reporting", () => {
   it("buildCapabilityRecommendationReportSections preserves empty-match fallback and ranked sections", () => {
     const {
       takeLimited,
+      appendDelimitedValuesLine,
       buildRouteCandidateLines,
       buildCapabilityMatchLines,
       buildCapabilityRecommendationReportSections,
     } = loadCapabilityFunctions([
       "takeLimited",
+      "appendDelimitedValuesLine",
       "buildRouteCandidateLines",
       "buildCapabilityMatchLines",
       "buildCapabilityRecommendationReportSections",


### PR DESCRIPTION
## Summary
- replace the earlier complexity suppressions with real helper extraction and branching simplification across extension, browser, routing, maintenance, DB, and diagnostics paths
- repair the capability inventory extractor tests after the helper splits
- keep `npx -y fallow health` at `0 above threshold` without inline ignore comments

## Verification
- `npx -y fallow health`
- `node scripts/validate-config-schema.mjs`
- `node scripts/dev-install.mjs --dry-run --copilot-home /tmp/lore-test-home`
- `npm test`

## Notes
- `npm test` now passes 48/50 in this sandbox
- remaining failures are environment-bound here: `tests/unit/browser-maintenance-server-hotspots.test.mjs` cannot bind `127.0.0.1`, and `tests/smoke/scripts.test.mjs` still sees empty subprocess stdout under the Node test runner even though the scripts emit the expected output when invoked directly