### PR TITLE
chore: bump matt-riley-ci workflow refs to latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@0d1d8e7a149a53fcaaca6e128f62e0e3d8fdf293 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       config-file: release-please-config.json
       manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Bumps all matt-riley-ci reusable workflow references to the latest commit.

Old SHAs replaced: 0d1d8e7a149a53fcaaca6e128f62e0e3d8fdf293
New SHA: bcaf4ae43edf7d26421741424b82c842c83e55ce