### PR TITLE
chore: bump matt-riley-ci release-please ref to 071c2c2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@071c2c2bbe410f73126d3cefd0a0b6812b3565f6 # v2
     with:
       config-file: release-please-config.json
       manifest-file: .release-please-manifest.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@0d1d8e7a149a53fcaaca6e128f62e0e3d8fdf293 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       config-file: release-please-config.json
       manifest-file: .release-please-manifest.json


### PR DESCRIPTION
CI workflow SHA drift update.

Updates the matt-riley-ci release-please.yml workflow reference from bcaf4ae to 071c2c2.