### PR TITLE
test: cover lore_reflect persistObservation success path

### DIFF
--- a/tests/unit/reflect-tool.test.mjs
+++ b/tests/unit/reflect-tool.test.mjs
@@ -109,4 +109,52 @@ describe("lore_reflect tool", () => {
       cleanup();
     }
   });
+
+  test("persists a refreshable observation when rollout is enabled", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+        rollout: {
+          memoryOperations: true,
+          temporalQueryNormalization: true,
+          memoryDomains: true,
+          refreshableObservations: true,
+        },
+      },
+    });
+
+    try {
+      db.insertSemanticMemory({
+        id: "reflect-observation-seed",
+        type: "user_preference",
+        content: "Prefer helper-driven report formatting for hotspot refactors.",
+        repository: "fixture-repo",
+        scope: "repo",
+        confidence: 1,
+        tags: ["refactor"],
+      });
+
+      const tools = createMemoryTools({
+        getRuntime: async () => buildRuntime(db, config),
+      });
+      const output = await findTool(tools, "lore_reflect").handler({
+        prompt: "What patterns should we keep using for hotspot refactors?",
+        focus: "patterns",
+        persistObservation: true,
+        observationKey: "reflect-tool-test-observation",
+      }, {
+        sessionId: "reflect-persist-observation",
+      });
+
+      assert.match(output, /Saved observation reflect-tool-test-observation\./);
+
+      const observation = db.getObservation("reflect-tool-test-observation");
+      assert.ok(observation, "expected the observation row to be persisted");
+      assert.equal(observation.title, "Patterns reflection");
+      assert.equal(observation.focus, "patterns");
+      assert.ok(observation.summary.length > 0);
+    } finally {
+      cleanup();
+    }
+  });
 });


### PR DESCRIPTION
## Original bug

`lore_reflect` with `persistObservation: true` used to always throw, because `buildObservationUpsertInput()` called `humanizeFocus()` before it was exported/imported correctly.

## Update after rebase

This PR's branch was originally opened against an older `main` and hit merge conflicts after the fallow maintainability refactor (#26) landed, which relocated `buildObservationUpsertInput` into `lib/memory-tools-retention.mjs` with its own self-contained `humanizeFocus`. That refactor incidentally fixed the original bug already — verified directly against current `main` in an isolated worktree before touching anything.

So the source fix in this PR is no longer needed and has been dropped. What's still missing and genuinely useful: **regression test coverage for the persist success path**, which no existing test exercised (only the disabled-rollout early return was covered). This PR now only adds that test.

## Testing

- `node --test tests/unit/reflect-tool.test.mjs` — 3/3 pass (including new test)
- `npm test` — full suite, 370/370 pass
- `npm run lint` — 0 warnings/errors