### PR TITLE
fix: stop persisting assistant_identity noise from generic interjections

### DIFF
--- a/lib/memory-scope.mjs
+++ b/lib/memory-scope.mjs
@@ -62,15 +62,54 @@ const GLOBAL_PREFERENCE_PATTERNS = [
   /\bjokes?\b/i,
 ];
 
-const ASSISTANT_IDENTITY_PATTERNS = [
+// Explicit naming vocabulary ("call you X", "your name is X", ...). Used both
+// as part of the general-purpose patterns below and, on their own, as the
+// strict set for persisting new assistant_identity memories (see
+// ASSISTANT_IDENTITY_DECLARATION_PATTERNS).
+const ASSISTANT_IDENTITY_DECLARATION_PATTERNS = [
   /\bcall (?:you|yourself)\s+([a-z][a-z0-9_-]{1,31})\b/i,
   /\byour name is\s+([a-z][a-z0-9_-]{1,31})\b/i,
   /\buse (?:the )?name\s+([a-z][a-z0-9_-]{1,31})\b/i,
   /\bused the name\s+([a-z][a-z0-9_-]{1,31})\b/i,
   /\bwhy i used the name\s+([a-z][a-z0-9_-]{1,31})\b/i,
+];
+
+// General-purpose detection of "this text is addressing/naming the assistant".
+// Used at prompt time (capsule-assembler.mjs, db.mjs) to decide whether the
+// *current* prompt is greeting/addressing the assistant by a name it already
+// knows, so identity context can be retrieved. False positives here are cheap
+// (worst case: an extra identity lookup) so the loose greeting/vocative shapes
+// below are fine for this purpose - they are NOT fine for persisting new
+// memories (see ASSISTANT_IDENTITY_DECLARATION_PATTERNS).
+const ASSISTANT_IDENTITY_PATTERNS = [
+  ...ASSISTANT_IDENTITY_DECLARATION_PATTERNS,
   /^(?:hi|hello|hey)\s+([a-z][a-z0-9_-]{2,20})(?:[!?,.\s]|$)/i,
   /^([a-z][a-z0-9_-]{2,20})[,:!?]\s/i,
 ];
+
+// Restrictive check used only when *persisting* a new assistant_identity
+// memory (rule-extractor.mjs, scanning historical messages). Only the
+// explicit naming-verb patterns above count here - a greeting prefix
+// ("hi/hello/hey X") or a bare vocative ("X, ..." / "X: ..." / "X! ...") is
+// too ambiguous to write to permanent memory: auditing every
+// assistant_identity row ever produced found 0 correct extractions from
+// those two loose shapes out of 14 total (13 false positives - "Sorry,",
+// "Error:", "Review:", "Hey dude,", etc. - any sentence-initial word followed
+// by punctuation matches that shape, not just a name).
+export function detectAssistantIdentityDeclaration(text) {
+  const normalized = normalizeText(text);
+  if (!normalized) {
+    return null;
+  }
+  for (const pattern of ASSISTANT_IDENTITY_DECLARATION_PATTERNS) {
+    const match = normalized.match(pattern);
+    const candidate = toAssistantDisplayName(match?.[1]);
+    if (candidate) {
+      return candidate;
+    }
+  }
+  return null;
+}
 
 const ASSISTANT_IDENTITY_STOPWORDS = new Set([
   "again",

--- a/lib/rule-extractor.mjs
+++ b/lib/rule-extractor.mjs
@@ -1,5 +1,5 @@
 import {
-  detectAssistantIdentityName,
+  detectAssistantIdentityDeclaration,
   detectUserIdentityName,
   MEMORY_SCOPE,
 } from "./memory-scope.mjs";
@@ -437,7 +437,7 @@ function extractAssistantIdentityMemories(turns, sessionId) {
   const recentTurns = turns.slice(-12);
   for (const turn of recentTurns) {
     const message = normalizeTurnText(turn.user_message);
-    const assistantName = detectAssistantIdentityName(message);
+    const assistantName = detectAssistantIdentityDeclaration(message);
     if (!assistantName) {
       continue;
     }

--- a/tests/unit/memory-scope-assistant-identity.test.mjs
+++ b/tests/unit/memory-scope-assistant-identity.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  detectAssistantIdentityDeclaration,
+  detectAssistantIdentityName,
+} from "../../lib/memory-scope.mjs";
+
+// detectAssistantIdentityName is the loose, general-purpose detector used at
+// prompt time (capsule-assembler.mjs, db.mjs) to recognize when the *current*
+// prompt is greeting/addressing the assistant, so identity context can be
+// retrieved. False positives here are cheap (worst case: an extra identity
+// lookup), so it intentionally still matches greeting/vocative shapes.
+describe("detectAssistantIdentityName", () => {
+  test("matches explicit naming phrases", () => {
+    assert.equal(detectAssistantIdentityName("Shall I call you Coda from now on?"), "Coda");
+    assert.equal(detectAssistantIdentityName("Ok, call yourself Nova please."), "Nova");
+    assert.equal(detectAssistantIdentityName("Your name is Juno now."), "Juno");
+    assert.equal(detectAssistantIdentityName("Please use the name Zed for this."), "Zed");
+    assert.equal(detectAssistantIdentityName("I used the name Axel in that doc."), "Axel");
+    assert.equal(detectAssistantIdentityName("Why I used the name Vega is a long story."), "Vega");
+  });
+
+  test("still recognizes greeting-shaped direct address for prompt-time lookups", () => {
+    // e.g. "Hi Jules, how are you?" - this is the exact shape diagnostics.mjs's
+    // "identity-greeting" validation case exercises to decide whether to fetch
+    // identity context for the current prompt.
+    assert.equal(detectAssistantIdentityName("Hi Jules, how are you?"), "Jules");
+    assert.equal(detectAssistantIdentityName("Coda, can you check this?"), "Coda");
+  });
+
+  test("returns null for text with no identity signal", () => {
+    assert.equal(detectAssistantIdentityName(""), null);
+    assert.equal(detectAssistantIdentityName("What patterns should we keep using for hotspot refactors?"), null);
+  });
+});
+
+// detectAssistantIdentityDeclaration is the strict detector used only when
+// *persisting* a new assistant_identity memory (rule-extractor.mjs, scanning
+// historical messages). Only explicit naming vocabulary counts here.
+describe("detectAssistantIdentityDeclaration", () => {
+  test("matches explicit naming phrases", () => {
+    assert.equal(detectAssistantIdentityDeclaration("Shall I call you Coda from now on?"), "Coda");
+    assert.equal(detectAssistantIdentityDeclaration("Ok, call yourself Nova please."), "Nova");
+    assert.equal(detectAssistantIdentityDeclaration("Your name is Juno now."), "Juno");
+    assert.equal(detectAssistantIdentityDeclaration("Please use the name Zed for this."), "Zed");
+    assert.equal(detectAssistantIdentityDeclaration("I used the name Axel in that doc."), "Axel");
+    assert.equal(detectAssistantIdentityDeclaration("Why I used the name Vega is a long story."), "Vega");
+  });
+
+  test("does not treat sentence-initial interjections as a name", () => {
+    // Regression coverage: detectAssistantIdentityName used to be the only
+    // detector, and its bare vocative pattern
+    // (`/^([a-z][a-z0-9_-]{2,20})[,:!?]\s/i`) fired on the first word of any
+    // message followed by punctuation, producing garbage assistant_identity
+    // memories ("Sorry", "Error", "Review", "E5108", "Nope", "Commit", ...).
+    assert.equal(detectAssistantIdentityDeclaration("Sorry, spw-lead-scoring-response-transport can be ignored"), null);
+    assert.equal(detectAssistantIdentityDeclaration("Error: something failed during the build"), null);
+    assert.equal(detectAssistantIdentityDeclaration("Review: this branch and make sure it passes"), null);
+    assert.equal(detectAssistantIdentityDeclaration("E5108: Lua error in nvim_exec2()"), null);
+    assert.equal(detectAssistantIdentityDeclaration("Nope, that's not what I meant"), null);
+    assert.equal(detectAssistantIdentityDeclaration("Commit: fix the flaky test"), null);
+    assert.equal(detectAssistantIdentityDeclaration("Hiya! I would like to replace tpack with tpm"), null);
+  });
+
+  test("does not treat a casual greeting target as a name", () => {
+    // Regression coverage: the old greeting pattern
+    // (`/^(?:hi|hello|hey)\s+([a-z][a-z0-9_-]{2,20})(?:[!?,.\s]|$)/i`) matched
+    // "Hey dude, ..." and produced an assistant_identity memory for "Dude".
+    assert.equal(detectAssistantIdentityDeclaration("Hey dude, #902 has a comment about console.info logs"), null);
+    assert.equal(detectAssistantIdentityDeclaration("Hi there, quick question about the release"), null);
+    assert.equal(detectAssistantIdentityDeclaration("Hello team, status update below"), null);
+  });
+
+  test("returns null for text with no identity signal", () => {
+    assert.equal(detectAssistantIdentityDeclaration(""), null);
+    assert.equal(detectAssistantIdentityDeclaration("What patterns should we keep using for hotspot refactors?"), null);
+  });
+
+  test("still applies the stopword guard for explicit patterns", () => {
+    assert.equal(detectAssistantIdentityDeclaration("Please use the name please for this"), null);
+    assert.equal(detectAssistantIdentityDeclaration("Call yourself assistant from now on"), null);
+  });
+});


### PR DESCRIPTION
## Bug

`extractAssistantIdentityMemories()` used `detectAssistantIdentityName()`, whose pattern list included:
- a greeting prefix: `/^(?:hi|hello|hey)\s+X/`
- a bare vocative: `/^X[,:!?]\s/`

Neither requires actual naming vocabulary, so they matched the first word of almost any message. Auditing every `assistant_identity` row ever produced in `lore.db` found **13 garbage entries** (Sorry, Error, Review, E5108, Nope, Commit, Dude, Hiya, Right, E492, NOPE, Now, Yeah) against a **single correct one** (Coda, from the well-anchored "call you Coda" phrasing).

## Why it's trickier than deleting the patterns

`detectAssistantIdentityName` is also used at **prompt time** (`capsule-assembler.mjs`, `db.mjs`) to recognize when the *current* prompt greets/addresses the assistant by an already-known name, so identity context can be retrieved. `diagnostics.mjs`'s `identity-greeting` validation case depends on exactly this shape (`"Hi Jules, how are you?"`). False positives there are cheap (an extra lookup), so the loose greeting/vocative shapes are legitimate for that purpose. I found this out the hard way — an initial version of this fix removed the patterns outright and broke that diagnostic case.

## Fix

Split the concerns:
- `detectAssistantIdentityName` keeps its original full pattern set, unchanged, for prompt-time direct-address detection.
- New `detectAssistantIdentityDeclaration` only matches the explicit naming-verb patterns (`call you X` / `your name is X` / `use the name X` / `used the name X` / `why I used the name X`) and is now what `extractAssistantIdentityMemories()` calls before writing a new permanent memory.

Added regression tests for both functions covering the previously-broken false positives and the diagnostics greeting case.

## Testing

- `node --test tests/unit/memory-scope-assistant-identity.test.mjs tests/unit/diagnostics.test.mjs` — 20/20 pass
- `npm test` — full suite, 377/377 pass
- `npm run lint` — 0 warnings/errors

## Follow-up (not in this PR)

The 13 existing garbage rows in production `lore.db` are being cleaned up separately via the `memory_forget` tool (soft-delete/supersede) since that's data cleanup, not a code change.