### PR TITLE
feat: add explicit lookbackHours param to lore_reflect

### DIFF
--- a/lib/memory-operations.mjs
+++ b/lib/memory-operations.mjs
@@ -143,7 +143,7 @@ const NEXT_ACTION_SIGNAL_PATTERN = /\b(next action|next step|next steps|what(?:'
 const PATTERN_SIGNAL_PATTERN = /\b(pattern|patterns|theme|themes|trend|trends|recurring|repeat(?:ed|ing)?|lesson|insight|insights|debug(?:ging)?|regression|routing|trace|retrieval|reflect priorit(?:y|ies))\b/i;
 const REFLECT_DECISION_KINDS = new Set(["decision", "reflect_priority", "rejected_approach", "user_preference", "recurring_mistake"]);
 const REFLECT_NEXT_ACTION_KINDS = new Set(["next_action", "objective", "mission", "open_loop", "assistant_goal", "commitment"]);
-const REFLECT_PATTERN_KINDS = new Set(["reflect_priority", "decision", "blocker"]);
+const REFLECT_PATTERN_KINDS = new Set(["reflect_priority", "decision", "blocker", "recent_session"]);
 const EXPLICIT_REFLECT_FOCUS = new Set(Object.values(REFLECT_FOCUS));
 const REFLECT_SIGNAL_FOCUS_RULES = Object.freeze([
   [BLOCKER_SIGNAL_PATTERN, REFLECT_FOCUS.BLOCKERS],
@@ -448,6 +448,39 @@ function buildWorkstreamEvidenceEntries(overlays) {
   return entries;
 }
 
+function buildRecentSessionEvidenceText(session) {
+  const repoLabel = session?.repository ? `${session.repository}: ` : "";
+  const detail = truncateText(normalizeText(session?.summary || session?.workspaceSummary || ""), 160);
+  if (detail) {
+    return `${repoLabel}${detail}`;
+  }
+  const when = session?.updated_at ?? session?.created_at ?? "";
+  return when ? `${repoLabel}session activity at ${when}`.trim() : "";
+}
+
+function buildRecentSessionEvidenceEntries(sessions) {
+  return (Array.isArray(sessions) ? sessions : [])
+    .map((session, index) => {
+      const repository = session?.repository ?? null;
+      return {
+        lookupName: "recentSessions",
+        bucket: "included",
+        index,
+        text: buildRecentSessionEvidenceText(session),
+        row: {
+          type: "recent_session",
+          repository,
+          crossRepo: false,
+        },
+        source: "recent session activity",
+        kind: "recent_session",
+        repository,
+        crossRepo: false,
+      };
+    })
+    .filter((entry) => entry.text.length > 0);
+}
+
 function matchesReflectTextPattern(text, focus) {
   if (focus === REFLECT_FOCUS.BLOCKERS) {
     return BLOCKER_SIGNAL_PATTERN.test(text);
@@ -496,9 +529,10 @@ function scoreReflectEntry(entry, focus) {
   return baseScore - (entry.index ?? 0) * 0.1;
 }
 
-function selectReflectEntries(envelope, focus) {
+function selectReflectEntries(envelope, focus, extraEntries = []) {
   const overlayEntries = buildWorkstreamEvidenceEntries(envelope.workstreamOverlays);
   const candidates = dedupeEvidenceEntries([
+    ...extraEntries,
     ...overlayEntries,
     ...envelope.evidenceEntries,
   ], 20);
@@ -760,6 +794,28 @@ export function recallMemory({
   };
 }
 
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+function fetchRecentSessionsForLookback({
+  sessionStore,
+  repository,
+  includeOtherRepositories,
+  lookbackHours,
+  limit,
+}) {
+  const numericHours = Number(lookbackHours);
+  if (!sessionStore || !Number.isFinite(numericHours) || numericHours <= 0) {
+    return [];
+  }
+  const sinceIso = new Date(Date.now() - numericHours * MS_PER_HOUR).toISOString();
+  return sessionStore.findSessionsSince({
+    sinceIso,
+    repository,
+    includeOtherRepositories,
+    limit: Math.max(3, Math.min(limit * 2, 20)),
+  });
+}
+
 export function reflectMemory({
   db,
   prompt,
@@ -769,6 +825,7 @@ export function reflectMemory({
   sessionStore = null,
   promptNeed = null,
   focus = null,
+  lookbackHours = null,
 }) {
   const recall = recallMemory({
     db,
@@ -781,7 +838,15 @@ export function reflectMemory({
   });
   const resolvedFocus = detectReflectFocus(prompt, focus);
   const envelope = buildEvidenceEnvelope(recall);
-  const selectedEntries = selectReflectEntries(envelope, resolvedFocus);
+  const recentSessions = fetchRecentSessionsForLookback({
+    sessionStore,
+    repository,
+    includeOtherRepositories,
+    lookbackHours,
+    limit,
+  });
+  const recentSessionEntries = buildRecentSessionEvidenceEntries(recentSessions);
+  const selectedEntries = selectReflectEntries(envelope, resolvedFocus, recentSessionEntries);
   const insights = selectedEntries.map((entry) => ({
     text: buildReflectInsight(entry, resolvedFocus),
     source: entry.source,
@@ -803,5 +868,10 @@ export function reflectMemory({
       envelope,
     }),
     insights,
+    lookbackHours: Number.isFinite(Number(lookbackHours)) && Number(lookbackHours) > 0
+      ? Number(lookbackHours)
+      : null,
+    recentSessionCount: recentSessions.length,
   };
 }
+

--- a/lib/memory-tools-builders.mjs
+++ b/lib/memory-tools-builders.mjs
@@ -822,6 +822,10 @@ function buildLoreReflectTool(getRuntime) {
           description: "When true, allow transferable cross-repository fallback where applicable",
         },
         limit: { type: "number", description: "Optional result budget" },
+        lookbackHours: {
+          type: "number",
+          description: "Optional explicit time window (in hours) to directly pull real session activity from across repositories, bypassing free-text date detection. E.g. 24 for \"last day\".",
+        },
         detailLevel: {
           type: "string",
           enum: ["summary", "evidence", "full"],
@@ -862,6 +866,7 @@ function buildLoreReflectTool(getRuntime) {
         limit: request.limit,
         sessionStore: runtime.sessionStore,
         focus: request.focus,
+        lookbackHours: request.lookbackHours,
       });
       const observationLine = maybePersistReflectionObservation({
         runtime,

--- a/lib/memory-tools-reports.mjs
+++ b/lib/memory-tools-reports.mjs
@@ -156,11 +156,15 @@ export function formatReflectionReport(result, { detailLevel = "summary" } = {})
 }
 
 function buildReflectionHeaderLines(result) {
+  const lookbackLine = result.lookbackHours
+    ? [`lookbackHours: ${result.lookbackHours} (sessions found: ${result.recentSessionCount ?? 0})`]
+    : [];
   return [
     `repository: ${result.repository ?? "global-only"}`,
     `focus: ${humanizeFocus(result.focus)}`,
     `estimatedTokens: ${result.recall?.estimatedTokens ?? 0}`,
     `sections: ${(result.envelope?.sections ?? []).join(", ") || "none"}`,
+    ...lookbackLine,
     "",
     "## Reflection",
     "",

--- a/lib/memory-tools-retention.mjs
+++ b/lib/memory-tools-retention.mjs
@@ -82,6 +82,17 @@ export function formatRetainResult(retained, kind) {
   return `Retained semantic memory ${retained.id}`;
 }
 
+const MIN_REFLECT_LOOKBACK_HOURS = 1;
+const MAX_REFLECT_LOOKBACK_HOURS = 720;
+
+function normalizeLookbackHours(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return null;
+  }
+  return Math.min(MAX_REFLECT_LOOKBACK_HOURS, Math.max(MIN_REFLECT_LOOKBACK_HOURS, numeric));
+}
+
 export function normalizeReflectionRequest(args, runtime) {
   return {
     prompt: ensureString(args.prompt, "prompt"),
@@ -91,6 +102,7 @@ export function normalizeReflectionRequest(args, runtime) {
     includeOtherRepositories: args.includeOtherRepositories === true,
     limit: ensureLimit(args.limit, runtime.config.limits.promptContextLimit, 50),
     focus: typeof args.focus === "string" ? args.focus : null,
+    lookbackHours: normalizeLookbackHours(args.lookbackHours),
   };
 }
 
@@ -125,6 +137,8 @@ function buildObservationUpsertInput({ runtime, reflection, request, args, domai
     trace: {
       sectionCount: Array.isArray(reflection.envelope?.sections) ? reflection.envelope.sections.length : 0,
       insightCount: Array.isArray(reflection.insights) ? reflection.insights.length : 0,
+      lookbackHours: reflection.lookbackHours ?? null,
+      recentSessionCount: reflection.recentSessionCount ?? 0,
     },
     metadata: {
       prompt: request.prompt,

--- a/lib/session-store-reader.mjs
+++ b/lib/session-store-reader.mjs
@@ -215,6 +215,37 @@ export class SessionStoreReader {
     return filtered.slice(0, boundedLimit).map(buildDateSessionMatchRecord);
   }
 
+  findSessionsSince({
+    sinceIso,
+    repository,
+    includeOtherRepositories = false,
+    limit = 20,
+  } = {}) {
+    this.ensureOpen();
+    const numericLimit = Number(limit);
+    const boundedLimit = Number.isFinite(numericLimit)
+      ? Math.max(1, Math.floor(numericLimit))
+      : 20;
+    const scopedToRepository = Boolean(repository) && includeOtherRepositories !== true;
+    const fetchLimit = scopedToRepository
+      ? Math.max(boundedLimit * 20, 100)
+      : Math.max(boundedLimit * 5, 100);
+    const rows = this.db.prepare(`
+      SELECT id, repository, branch, summary, created_at, updated_at
+      FROM sessions
+      WHERE COALESCE(updated_at, created_at, '') >= ?
+      ORDER BY COALESCE(updated_at, created_at, '') DESC, id DESC
+      LIMIT ?
+    `).all(sinceIso, fetchLimit);
+
+    const hydrated = rows.map((row) => this.hydrateSessionRow(row));
+    const filtered = scopedToRepository
+      ? hydrated.filter((row) => row?.repository === repository)
+      : hydrated;
+
+    return filtered.slice(0, boundedLimit).map(buildDateSessionMatchRecord);
+  }
+
   getSessionArtifacts(sessionId) {
     this.ensureOpen();
     const sessionRow = this.db.prepare(`

--- a/tests/unit/reflect-tool.test.mjs
+++ b/tests/unit/reflect-tool.test.mjs
@@ -9,7 +9,7 @@ const SKIP_NO_FTS5 = !FTS5_AVAILABLE
   ? "FTS5 not compiled into this Node.js SQLite build (Copilot CLI runtime has it; check your local Node install)"
   : false;
 
-function buildRuntime(db, config) {
+function buildRuntime(db, config, overrides = {}) {
   return {
     initialized: true,
     lastError: null,
@@ -17,6 +17,7 @@ function buildRuntime(db, config) {
     config,
     repository: "fixture-repo",
     sessionStore: null,
+    ...overrides,
   };
 }
 
@@ -153,6 +154,153 @@ describe("lore_reflect tool", () => {
       assert.equal(observation.title, "Patterns reflection");
       assert.equal(observation.focus, "patterns");
       assert.ok(observation.summary.length > 0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("surfaces recent session evidence and trace metadata when lookbackHours is set", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+        rollout: {
+          memoryOperations: true,
+          temporalQueryNormalization: true,
+          memoryDomains: true,
+          refreshableObservations: true,
+        },
+      },
+    });
+
+    try {
+      const findSessionsSinceCalls = [];
+      const sessionStore = {
+        findRelevantSessions() {
+          return [];
+        },
+        findSessionsSince(args) {
+          findSessionsSinceCalls.push(args);
+          return [
+            {
+              session_id: "session-recent-1",
+              repository: "fixture-repo",
+              branch: "main",
+              summary: "Fixed the reflect tool lookback bug end to end.",
+              created_at: "2026-07-03T08:00:00.000Z",
+              updated_at: "2026-07-03T11:00:00.000Z",
+              workspaceSummary: null,
+            },
+          ];
+        },
+      };
+
+      const tools = createMemoryTools({
+        getRuntime: async () => buildRuntime(db, config, { sessionStore }),
+      });
+      const reflect = findTool(tools, "lore_reflect");
+
+      const output = await reflect.handler({
+        prompt: "Analyze the last day of activity across repos and summarize my patterns and preferences.",
+        focus: "patterns",
+        detailLevel: "full",
+        lookbackHours: 24,
+        persistObservation: true,
+        observationKey: "reflect-tool-lookback-observation",
+      }, {
+        sessionId: "reflect-lookback",
+      });
+
+      assert.equal(findSessionsSinceCalls.length, 1);
+      assert.equal(findSessionsSinceCalls[0].repository, "fixture-repo");
+      assert.match(findSessionsSinceCalls[0].sinceIso, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+      assert.match(output, /lookbackHours: 24 \(sessions found: 1\)/);
+      assert.match(output, /Fixed the reflect tool lookback bug end to end\./);
+
+      const observation = db.getObservation("reflect-tool-lookback-observation");
+      assert.ok(observation, "expected the observation row to be persisted");
+      assert.equal(observation.trace?.lookbackHours, 24);
+      assert.equal(observation.trace?.recentSessionCount, 1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reports zero recent sessions gracefully when no sessionStore is available", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+        rollout: {
+          memoryOperations: true,
+          temporalQueryNormalization: true,
+        },
+      },
+    });
+
+    try {
+      const tools = createMemoryTools({
+        getRuntime: async () => buildRuntime(db, config, { sessionStore: null }),
+      });
+      const reflect = findTool(tools, "lore_reflect");
+
+      const output = await reflect.handler({
+        prompt: "Analyze the last day of activity across repos and summarize my patterns and preferences.",
+        focus: "patterns",
+        lookbackHours: 24,
+      }, {
+        sessionId: "reflect-lookback-no-store",
+      });
+
+      assert.match(output, /lookbackHours: 24 \(sessions found: 0\)/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("clamps out-of-range lookbackHours and ignores non-positive values", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+        rollout: {
+          memoryOperations: true,
+          temporalQueryNormalization: true,
+        },
+      },
+    });
+
+    try {
+      const sinceIsoCalls = [];
+      const sessionStore = {
+        findRelevantSessions() {
+          return [];
+        },
+        findSessionsSince({ sinceIso }) {
+          sinceIsoCalls.push(sinceIso);
+          return [];
+        },
+      };
+      const tools = createMemoryTools({
+        getRuntime: async () => buildRuntime(db, config, { sessionStore }),
+      });
+      const reflect = findTool(tools, "lore_reflect");
+
+      const overLimitOutput = await reflect.handler({
+        prompt: "Analyze the last month of activity across repos and summarize my patterns.",
+        focus: "patterns",
+        lookbackHours: 10000,
+      }, {
+        sessionId: "reflect-lookback-clamped",
+      });
+      assert.match(overLimitOutput, /lookbackHours: 720 \(sessions found: 0\)/);
+
+      const zeroOutput = await reflect.handler({
+        prompt: "Summarize current patterns.",
+        focus: "patterns",
+        lookbackHours: 0,
+      }, {
+        sessionId: "reflect-lookback-zero",
+      });
+      assert.doesNotMatch(zeroOutput, /lookbackHours:/);
+      assert.equal(sinceIsoCalls.length, 1, "findSessionsSince should only run for the valid lookbackHours request");
     } finally {
       cleanup();
     }

--- a/tests/unit/session-store-reader.test.mjs
+++ b/tests/unit/session-store-reader.test.mjs
@@ -399,6 +399,133 @@ describe("SessionStoreReader.findSessionsByDate", () => {
   });
 });
 
+describe("SessionStoreReader.findSessionsSince", () => {
+  test("filters sessions at or after the provided ISO cutoff", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(tempHome, [
+        ["session-before", "repo-one", "main", "too old", "2026-03-28T08:00:00Z", "2026-03-28T09:00:00Z"],
+        ["session-at-cutoff", "repo-one", "main", "exactly at cutoff", "2026-03-29T08:00:00Z", "2026-03-29T12:00:00Z"],
+        ["session-after", "repo-two", "feature", "well within window", "2026-03-30T09:00:00Z", null],
+      ]);
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+      const rows = reader.findSessionsSince({
+        sinceIso: "2026-03-29T12:00:00Z",
+        includeOtherRepositories: true,
+        limit: 10,
+      });
+
+      assert.deepStrictEqual(
+        rows.map((row) => row.session_id),
+        ["session-after", "session-at-cutoff"],
+      );
+      assert.strictEqual(rows[0].repository, "repo-two");
+      assert.strictEqual(rows[1].summary, "exactly at cutoff");
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("honors cross-repo inclusion and local-only restrictions", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(tempHome, [
+        ["local-session", "repo-local", "main", "local", "2026-03-30T08:00:00Z", "2026-03-30T11:00:00Z"],
+        ["other-session", "repo-other", "main", "other", "2026-03-30T08:00:00Z", "2026-03-30T10:00:00Z"],
+      ]);
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+
+      const localOnly = reader.findSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        repository: "repo-local",
+        includeOtherRepositories: false,
+        limit: 5,
+      });
+      const crossRepo = reader.findSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        repository: "repo-local",
+        includeOtherRepositories: true,
+        limit: 5,
+      });
+
+      assert.deepStrictEqual(
+        localOnly.map((row) => row.session_id),
+        ["local-session"],
+      );
+      assert.deepStrictEqual(
+        crossRepo.map((row) => row.session_id),
+        ["local-session", "other-session"],
+      );
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("returns bounded rows using deterministic updated-at ordering", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(tempHome, [
+        ["session-a", "repo-one", "main", "a", "2026-03-30T06:00:00Z", "2026-03-30T10:00:00Z"],
+        ["session-c", "repo-one", "main", "c", "2026-03-30T06:00:00Z", "2026-03-30T10:00:00Z"],
+        ["session-b", "repo-one", "main", "b", "2026-03-30T06:00:00Z", "2026-03-30T10:00:00Z"],
+        ["session-new", "repo-one", "main", "new", "2026-03-30T07:00:00Z", "2026-03-30T11:00:00Z"],
+      ]);
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+      const rows = reader.findSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        includeOtherRepositories: true,
+        limit: 3,
+      });
+
+      assert.deepStrictEqual(
+        rows.map((row) => row.session_id),
+        ["session-new", "session-c", "session-b"],
+      );
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("falls back to the default limit when passed a non-numeric limit", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(
+        tempHome,
+        Array.from({ length: 22 }, (_, i) => [
+          `session-${i}`,
+          "repo-one",
+          "main",
+          `summary ${i}`,
+          `2026-03-30T${String(i).padStart(2, "0")}:00:00Z`,
+          `2026-03-30T${String(i).padStart(2, "0")}:30:00Z`,
+        ]),
+      );
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+      const rows = reader.findSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        includeOtherRepositories: true,
+        limit: "abc",
+      });
+
+      assert.strictEqual(rows.length, 20);
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("SessionStoreReader.collectRelevantSessionMatches", () => {
   test("keeps the strongest hydrated match per session and drops repository mismatches", () => {
     const reader = new SessionStoreReader({


### PR DESCRIPTION
## Problem

Free-text "last day"/"last week" temporal detection is unreliable for compound analytical prompts:
- `inferDateFromPrompt` doesn't recognize "last day" phrasing at all.
- Even if it did, `pureTemporalRecall` requires **zero** non-date content terms, so any multi-topic prompt (e.g. a daily profile-refresh reflection prompt with 40+ content terms) can never trigger the session-lookup path (`sessionStore.findSessionsByDate`), regardless of date-phrase fixes.

This caused a real daily automation (Matt's profile-refresh prompt) to silently degrade: `lore_reflect` persisted an observation, but with zero real last-day session evidence, only stale generic style reminders.

## Fix

Adds an independent, additive `lookbackHours` parameter to `lore_reflect` that bypasses the fragile `db.mjs` temporal classification pipeline entirely (that shared pipeline is used for every prompt's context assembly and was too risky to modify for this scoped need):

- **`SessionStoreReader.findSessionsSince()`** — direct ISO-cutoff session query, mirroring `findSessionsByDate`'s structure, hydration, and repo-scoping behavior exactly.
- **`memory-operations.mjs`** — `fetchRecentSessionsForLookback()` computes the cutoff from `lookbackHours` and feeds real session rows into `selectReflectEntries()` as first-class evidence entries (`kind: recent_session`, added to `REFLECT_PATTERN_KINDS` so they qualify for the `patterns` focus bonus).
- **`memory-tools-retention.mjs`** — `normalizeLookbackHours()` clamps to `[1, 720]` hours; persisted observations now carry `lookbackHours`/`recentSessionCount` in their `trace` field, so degradation is a **structural signal** instead of narrated text.
- **`memory-tools-builders.mjs` / `memory-tools-reports.mjs`** — `lookbackHours` tool parameter, plus a `lookbackHours: N (sessions found: N)` report header line for transparency.

## Tests

- `findSessionsSince` unit coverage mirroring `findSessionsByDate`'s existing suite (cutoff filtering, cross-repo/local-only scoping, bounded/ordered results, non-numeric limit fallback).
- End-to-end `lore_reflect` tests: recent-session evidence surfacing + trace persistence, graceful zero-sessionStore handling, and `lookbackHours` clamping/non-positive-value handling.
- `npm test`: 385/385 pass. `npm run lint`: clean.

## Follow-up

The daily automation prompt itself will be redesigned separately to pass `lookbackHours: 24` explicitly and check `recentSessionCount` as the degradation signal.