### PR TITLE
feat: surface ambient Working Profile section in session-start capsule

### DIFF
--- a/lib/capsule-assembler.mjs
+++ b/lib/capsule-assembler.mjs
@@ -1,5 +1,6 @@
 import { detectAssistantIdentityName, MEMORY_SCOPE } from "./memory-scope.mjs";
 import { buildOnboardingSection } from "./onboarding.mjs";
+import { buildWorkingProfileSection } from "./working-profile.mjs";
 import {
   buildStyleAddressingSection,
   isStyleAddressingMemory,
@@ -803,6 +804,25 @@ function appendProceduralProfileSection({
   }
   if (state.trace) {
     state.trace.omissions.push({ stage: "procedural_profile", reason: "not_available" });
+  }
+}
+
+function appendWorkingProfileCapsulePhase(state, { db, config }) {
+  const workingProfileSection = buildWorkingProfileSection({ db, config });
+  if (state.trace) {
+    state.trace.lookups.workingProfile = workingProfileSection.trace;
+  }
+  if (workingProfileSection.text) {
+    appendCapsuleSection(state, {
+      title: workingProfileSection.title,
+      text: workingProfileSection.text,
+      source: "working_profile",
+      budget: config.budgets.workingProfile,
+    });
+    return;
+  }
+  if (state.trace) {
+    state.trace.omissions.push({ stage: "working_profile", reason: workingProfileSection.trace.reason });
   }
 }
 
@@ -1653,6 +1673,7 @@ export async function assembleMemoryCapsule({
   });
 
   appendProceduralProfileSection({ state, proceduralProfile, config });
+  appendWorkingProfileCapsulePhase(state, { db, config });
 
   const knowledgeContext = buildCapsuleKnowledgeContext({
     prompt,

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -29,6 +29,7 @@ export const USER_CONFIG_DEFAULTS = Object.freeze({
     semantic: 420,
     episodes: 320,
     commitments: 180,
+    workingProfile: 240,
     total: 1200,
   },
   limits: {
@@ -125,6 +126,7 @@ export const USER_CONFIG_DEFAULTS = Object.freeze({
     reviewGate: true,
     approvalSubstrate: true,
     hybridRetrieval: true,
+    ambientWorkingProfile: true,
   },
 });
 
@@ -305,6 +307,10 @@ export function normalizeRolloutConfig(rollout = {}) {
     hybridRetrieval: normalizeBoolean(
       rollout.hybridRetrieval,
       USER_CONFIG_DEFAULTS.rollout.hybridRetrieval,
+    ),
+    ambientWorkingProfile: normalizeBoolean(
+      rollout.ambientWorkingProfile,
+      USER_CONFIG_DEFAULTS.rollout.ambientWorkingProfile,
     ),
   };
 }

--- a/lib/working-profile.mjs
+++ b/lib/working-profile.mjs
@@ -1,0 +1,119 @@
+import { normalizeText } from "./text-normalizer.mjs";
+import { estimateTokens } from "./token-estimator.mjs";
+
+const MS_PER_HOUR = 60 * 60 * 1000;
+const USER_DOMAIN_KIND = "user";
+const DEFAULT_WORKING_PROFILE_BUDGET = 240;
+const SECTION_TITLE = "Working Profile";
+
+function truncateToBudget(text, budgetTokens) {
+  const normalized = normalizeText(text);
+  if (!normalized) {
+    return "";
+  }
+  const maxChars = Math.max(0, Math.floor(budgetTokens) * 4);
+  if (normalized.length <= maxChars) {
+    return normalized;
+  }
+  return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+// Finds the freshest active "user" domain and its most recently refreshed,
+// current-status observation. Freshness is computed live against
+// freshness_hours rather than trusting the stored status column, since
+// nothing in this codebase flips status to "stale" over time on its own.
+function findActiveUserProfileObservation({ db }) {
+  const domains = db
+    .listMemoryDomains({ status: "active", includeOtherRepositories: true })
+    .filter((domain) => domain.kind === USER_DOMAIN_KIND);
+  if (domains.length === 0) {
+    return { domain: null, observation: null, reason: "no_user_domain", ageHours: null };
+  }
+
+  const domain = domains[0];
+  const observations = db.listObservations({
+    domainKey: domain.domainKey,
+    status: "current",
+    includeOtherRepositories: true,
+  });
+  if (observations.length === 0) {
+    return { domain, observation: null, reason: "no_observation", ageHours: null };
+  }
+
+  const observation = observations[0];
+  const referenceIso = observation.lastRefreshedAt || observation.updatedAt;
+  const ageMs = Date.now() - Date.parse(referenceIso);
+  const ageHours = Number.isFinite(ageMs) ? Math.round((ageMs / MS_PER_HOUR) * 10) / 10 : null;
+  if (ageHours === null || ageHours > observation.freshnessHours) {
+    return { domain, observation, reason: "stale", ageHours };
+  }
+
+  return { domain, observation, reason: null, ageHours };
+}
+
+function buildDisabledSection(reason, extra = {}) {
+  return {
+    title: SECTION_TITLE,
+    text: "",
+    trace: {
+      enabled: false,
+      reason,
+      ...extra,
+    },
+  };
+}
+
+// Ambient, session-start-only surfacing of the on-demand `matt-profile`-style
+// working profile observation (see lore_reflect / persistObservation). Kept
+// deliberately lightweight: only the condensed summary is shown, capped by
+// config.budgets.workingProfile, and gated behind both a rollout flag and a
+// live freshness check so a stale profile never silently pollutes context.
+export function buildWorkingProfileSection({ db, config }) {
+  if (!config?.rollout?.ambientWorkingProfile) {
+    return buildDisabledSection("rollout_disabled");
+  }
+  if (!db) {
+    return buildDisabledSection("no_db");
+  }
+
+  const lookup = findActiveUserProfileObservation({ db });
+  if (!lookup.observation) {
+    return buildDisabledSection(lookup.reason, {
+      domainKey: lookup.domain?.domainKey ?? null,
+    });
+  }
+  if (lookup.reason === "stale") {
+    return buildDisabledSection("stale", {
+      domainKey: lookup.domain.domainKey,
+      observationKey: lookup.observation.observationKey,
+      ageHours: lookup.ageHours,
+      freshnessHours: lookup.observation.freshnessHours,
+    });
+  }
+
+  const budget = Number.isFinite(config?.budgets?.workingProfile)
+    ? config.budgets.workingProfile
+    : DEFAULT_WORKING_PROFILE_BUDGET;
+  const summary = truncateToBudget(lookup.observation.summary, budget);
+  if (!summary) {
+    return buildDisabledSection("empty_summary", {
+      domainKey: lookup.domain.domainKey,
+      observationKey: lookup.observation.observationKey,
+    });
+  }
+
+  const text = `## ${SECTION_TITLE}\n\n${summary}`;
+  return {
+    title: SECTION_TITLE,
+    text,
+    trace: {
+      enabled: true,
+      reason: "included",
+      domainKey: lookup.domain.domainKey,
+      observationKey: lookup.observation.observationKey,
+      ageHours: lookup.ageHours,
+      freshnessHours: lookup.observation.freshnessHours,
+      estimatedTokens: estimateTokens(text),
+    },
+  };
+}

--- a/lore.example.json
+++ b/lore.example.json
@@ -46,6 +46,7 @@
     "overlayAutoHydration": true,
     "loreDoctor": true,
     "reviewGate": true,
-    "hybridRetrieval": true
+    "hybridRetrieval": true,
+    "ambientWorkingProfile": true
   }
 }

--- a/schemas/lore.schema.json
+++ b/schemas/lore.schema.json
@@ -61,6 +61,10 @@
           "type": "integer",
           "default": 180
         },
+        "workingProfile": {
+          "type": "integer",
+          "default": 240
+        },
         "total": {
           "type": "integer",
           "default": 1200
@@ -422,6 +426,10 @@
           "default": true
         },
         "hybridRetrieval": {
+          "type": "boolean",
+          "default": true
+        },
+        "ambientWorkingProfile": {
           "type": "boolean",
           "default": true
         }

--- a/tests/helpers/fixture-config.mjs
+++ b/tests/helpers/fixture-config.mjs
@@ -53,6 +53,7 @@ function buildFixtureConfig(home, overrides = {}) {
       semantic: 420,
       episodes: 320,
       commitments: 180,
+      workingProfile: 240,
       total: 1200,
     },
     limits: {
@@ -124,6 +125,7 @@ function buildFixtureConfig(home, overrides = {}) {
       reviewGate: false,
       approvalSubstrate: false,
       hybridRetrieval: false,
+      ambientWorkingProfile: false,
     },
   };
 

--- a/tests/unit/config.test.mjs
+++ b/tests/unit/config.test.mjs
@@ -74,6 +74,7 @@ describe("loadConfig", () => {
         reviewGate: true,
         approvalSubstrate: true,
         hybridRetrieval: false,
+        ambientWorkingProfile: true,
       },
     );
   });

--- a/tests/unit/working-profile.test.mjs
+++ b/tests/unit/working-profile.test.mjs
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { assembleMemoryCapsule } from "../../lib/capsule-assembler.mjs";
+import { buildWorkingProfileSection } from "../../lib/working-profile.mjs";
+import { FTS5_AVAILABLE, withFixtureDb } from "../helpers/fixture-db.mjs";
+
+const SKIP_NO_FTS5 = !FTS5_AVAILABLE
+  ? "FTS5 not compiled into this Node.js SQLite build (Copilot CLI runtime has it; check your local Node install)"
+  : false;
+
+function isoHoursAgo(hours) {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+}
+
+describe("buildWorkingProfileSection", () => {
+  test("is disabled when the rollout flag is off", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb();
+    try {
+      const section = buildWorkingProfileSection({ db, config });
+      assert.equal(section.text, "");
+      assert.equal(section.trace.enabled, false);
+      assert.equal(section.trace.reason, "rollout_disabled");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reports no_user_domain when no user-kind domain exists", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: { rollout: { ambientWorkingProfile: true } },
+    });
+    try {
+      db.upsertMemoryDomain({
+        domainKey: "repo:core",
+        kind: "repo",
+        title: "Core Lore",
+        scope: "repo",
+        repository: "owner/repo",
+      });
+
+      const section = buildWorkingProfileSection({ db, config });
+      assert.equal(section.text, "");
+      assert.equal(section.trace.reason, "no_user_domain");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reports no_observation when the user domain has no observation yet", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: { rollout: { ambientWorkingProfile: true } },
+    });
+    try {
+      db.upsertMemoryDomain({
+        domainKey: "matt",
+        kind: "user",
+        title: "Matt — Working Profile",
+        scope: "global",
+      });
+
+      const section = buildWorkingProfileSection({ db, config });
+      assert.equal(section.text, "");
+      assert.equal(section.trace.reason, "no_observation");
+      assert.equal(section.trace.domainKey, "matt");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("includes a fresh observation's summary, capped by config.budgets.workingProfile", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: { rollout: { ambientWorkingProfile: true } },
+    });
+    try {
+      db.upsertMemoryDomain({
+        domainKey: "matt",
+        kind: "user",
+        title: "Matt — Working Profile",
+        scope: "global",
+      });
+      db.upsertObservation({
+        observationKey: "matt-profile",
+        domainKey: "matt",
+        title: "Matt profile",
+        focus: "patterns",
+        summary: "Matt prefers concise, direct answers and conventional-commit messages.",
+        scope: "global",
+        freshnessHours: 24,
+        source: "lore_reflect",
+        lastRefreshedAt: isoHoursAgo(1),
+      });
+
+      const section = buildWorkingProfileSection({ db, config });
+      assert.match(section.text, /^## Working Profile\n\n/);
+      assert.match(section.text, /Matt prefers concise, direct answers/);
+      assert.equal(section.trace.enabled, true);
+      assert.equal(section.trace.reason, "included");
+      assert.equal(section.trace.domainKey, "matt");
+      assert.equal(section.trace.observationKey, "matt-profile");
+      assert.equal(section.trace.ageHours, 1);
+      assert.equal(section.trace.freshnessHours, 24);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reports stale when the observation has aged past freshnessHours", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: { rollout: { ambientWorkingProfile: true } },
+    });
+    try {
+      db.upsertMemoryDomain({
+        domainKey: "matt",
+        kind: "user",
+        title: "Matt — Working Profile",
+        scope: "global",
+      });
+      db.upsertObservation({
+        observationKey: "matt-profile",
+        domainKey: "matt",
+        title: "Matt profile",
+        focus: "patterns",
+        summary: "Stale summary that should not surface.",
+        scope: "global",
+        freshnessHours: 1,
+        source: "lore_reflect",
+        lastRefreshedAt: isoHoursAgo(10),
+      });
+
+      const section = buildWorkingProfileSection({ db, config });
+      assert.equal(section.text, "");
+      assert.equal(section.trace.reason, "stale");
+      assert.equal(section.trace.observationKey, "matt-profile");
+      assert.equal(section.trace.freshnessHours, 1);
+      assert.ok(section.trace.ageHours >= 10);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("truncates long summaries to the configured token budget", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        rollout: { ambientWorkingProfile: true },
+        budgets: { workingProfile: 10 },
+      },
+    });
+    try {
+      db.upsertMemoryDomain({
+        domainKey: "matt",
+        kind: "user",
+        title: "Matt — Working Profile",
+        scope: "global",
+      });
+      db.upsertObservation({
+        observationKey: "matt-profile",
+        domainKey: "matt",
+        title: "Matt profile",
+        focus: "patterns",
+        summary: "This summary is intentionally much longer than the tiny ten token budget allows for this test case.",
+        scope: "global",
+        freshnessHours: 24,
+        source: "lore_reflect",
+        lastRefreshedAt: isoHoursAgo(1),
+      });
+
+      const section = buildWorkingProfileSection({ db, config });
+      const summaryLine = section.text.split("\n\n")[1];
+      // 10 tokens * 4 chars/token = 40 char budget, plus the "## Working Profile\n\n" header.
+      assert.ok(summaryLine.length <= 40);
+      assert.match(summaryLine, /…$/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("assembleMemoryCapsule Working Profile integration", () => {
+  test("surfaces the working profile section when enabled with a fresh observation", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: { rollout: { ambientWorkingProfile: true } },
+    });
+    try {
+      db.upsertMemoryDomain({
+        domainKey: "matt",
+        kind: "user",
+        title: "Matt — Working Profile",
+        scope: "global",
+      });
+      db.upsertObservation({
+        observationKey: "matt-profile",
+        domainKey: "matt",
+        title: "Matt profile",
+        focus: "patterns",
+        summary: "Matt prefers concise, direct answers.",
+        scope: "global",
+        freshnessHours: 24,
+        source: "lore_reflect",
+        lastRefreshedAt: isoHoursAgo(1),
+      });
+
+      const result = await assembleMemoryCapsule({
+        prompt: "let's keep going on the migration",
+        repository: "owner/repo",
+        proceduralProfile: "",
+        db,
+        sessionStore: {
+          searchIndex: () => [],
+          findRelevantSessions: () => [],
+          getRecentSessions: () => [],
+        },
+        config,
+        includeTrace: true,
+      });
+
+      assert.match(result.text, /## Working Profile/);
+      assert.match(result.text, /Matt prefers concise, direct answers/);
+      assert.equal(result.trace.lookups.workingProfile.reason, "included");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("omits the working profile section when the rollout flag is disabled", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb();
+    try {
+      const result = await assembleMemoryCapsule({
+        prompt: "let's keep going on the migration",
+        repository: "owner/repo",
+        proceduralProfile: "",
+        db,
+        sessionStore: {
+          searchIndex: () => [],
+          findRelevantSessions: () => [],
+          getRecentSessions: () => [],
+        },
+        config,
+        includeTrace: true,
+      });
+
+      assert.doesNotMatch(result.text, /## Working Profile/);
+      assert.equal(result.trace.lookups.workingProfile.reason, "rollout_disabled");
+      assert.ok(
+        result.trace.omissions.some(
+          (omission) => omission.stage === "working_profile" && omission.reason === "rollout_disabled",
+        ),
+      );
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## What

Surfaces the on-demand `matt-profile`-style working-profile observation (persisted via `lore_reflect` + `persistObservation`) **ambiently** at session start, instead of requiring an explicit tool call to see it.

## Why

Follow-on to #45. Once `lookbackHours` made the daily profile-refresh automation reliable, the natural next question was: does this persisted profile actually shape future conversations? Answer was no — `refreshable_observation` was on-demand only. This closes that gap with explicit context-pollution guardrails.

## How

- **`lib/working-profile.mjs`** (new): `buildWorkingProfileSection({ db, config })` finds the freshest active `kind: "user"` `memory_domain` and its most recent `current`-status `refreshable_observation`, checks freshness live against `freshness_hours` (nothing in the codebase flips `status` to `stale` automatically over time), and truncates the summary to `config.budgets.workingProfile` tokens.
- **`lib/capsule-assembler.mjs`**: wires the section into `assembleMemoryCapsule` (the session-start-only capsule, not the per-prompt `db.mjs::explainPromptContext` path) via a new `appendWorkingProfileCapsulePhase`, gated behind `rollout.ambientWorkingProfile`, mirroring the existing onboarding-section trace/omission conventions.
- **Config**: adds `budgets.workingProfile` (240) and `rollout.ambientWorkingProfile` (`true`, on by default) to `lib/config.mjs`, `schemas/lore.schema.json`, and `lore.example.json` — verified in parity via `scripts/validate-config-schema.mjs`.

## Context-pollution guardrails (per explicit ask)

- Runs **once per session** (session-start capsule), not on every prompt.
- Hard-capped at a dedicated **240-token budget**, condensed to just the observation's summary (not full insights/trace).
- **Freshness-gated**: a stale profile (past its `freshness_hours`) is silently omitted rather than surfacing outdated info.
- Fully **opt-out** via `rollout.ambientWorkingProfile: false`.
- Full trace/omission reporting for transparency (`trace.lookups.workingProfile`, `trace.omissions`).

## Testing

- `tests/unit/working-profile.test.mjs` (new): unit coverage for the domain/observation lookup, freshness check, and budget truncation; `assembleMemoryCapsule` integration coverage for inclusion and disabled-rollout omission.
- Updated `tests/helpers/fixture-config.mjs` and `tests/unit/config.test.mjs` to stay in sync with the new config keys.
- `npm test`: 393/393 pass. `npm run lint`: clean. `node scripts/validate-config-schema.mjs`: parity confirmed.