### PR TITLE
fix(memory): durable writes + accurate session counts

### DIFF
--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -1229,7 +1229,10 @@ export class LoreDb {
       return;
     }
     try {
-      this.db.exec(`PRAGMA wal_checkpoint(TRUNCATE);`);
+      // PASSIVE never blocks or disrupts other connections mid-write; TRUNCATE
+      // requires a stronger lock and can race a concurrent writer's in-flight
+      // commit when multiple Copilot CLI processes hold lore.db open at once.
+      this.db.exec(`PRAGMA wal_checkpoint(PASSIVE);`);
     } catch {
       // best-effort checkpoint before close
     }
@@ -3202,9 +3205,43 @@ export class LoreDb {
     this.ensureOpen();
     const timestamp = nowIso();
     const write = this.buildSemanticMemoryWriteContext(memory, timestamp);
-    return this.upsertManualSemanticMemory(memory, write, timestamp)
+    const id = this.upsertManualSemanticMemory(memory, write, timestamp)
       ?? this.upsertScopedSemanticMemory(memory, write, timestamp)
       ?? this.insertNewSemanticMemory(memory, write, timestamp);
+    this.verifySemanticMemoryDurability(id);
+    return id;
+  }
+
+  // Re-reads the row via an independent connection right after writing it.
+  // A same-connection read can't catch a cross-process WAL checkpoint race
+  // (multiple Copilot CLI processes can hold lore.db open concurrently);
+  // this call, from a fresh connection, mirrors what an external reader
+  // would actually see and turns a silent data-loss into a real failure
+  // instead of a false "Retained semantic memory <id>" success message.
+  verifySemanticMemoryDurability(id) {
+    const dbPath = this.config.paths.derivedStorePath;
+    let verifyDb;
+    try {
+      verifyDb = new DatabaseSync(dbPath, { readOnly: true });
+      verifyDb.exec("PRAGMA busy_timeout = 2000;");
+      const row = verifyDb.prepare(`
+        SELECT id FROM semantic_memory WHERE id = ? LIMIT 1
+      `).get(id);
+      if (!row) {
+        throw new Error(
+          `semantic memory ${id} did not durably persist: not visible via an ` +
+          "independent connection immediately after insert. This can happen when " +
+          "multiple concurrent Copilot CLI processes hold lore.db open and a WAL " +
+          "checkpoint races an in-flight write. The memory was NOT saved - retry.",
+        );
+      }
+    } finally {
+      try {
+        verifyDb?.close();
+      } catch {
+        // best-effort close of the verification connection
+      }
+    }
   }
 
   upsertMemoryDomain(domain) {

--- a/lib/memory-operations.mjs
+++ b/lib/memory-operations.mjs
@@ -805,15 +805,27 @@ function fetchRecentSessionsForLookback({
 }) {
   const numericHours = Number(lookbackHours);
   if (!sessionStore || !Number.isFinite(numericHours) || numericHours <= 0) {
-    return [];
+    return { recentSessions: [], recentSessionCount: 0, recentSessionCountCapped: false };
   }
   const sinceIso = new Date(Date.now() - numericHours * MS_PER_HOUR).toISOString();
-  return sessionStore.findSessionsSince({
+  const recentSessions = sessionStore.findSessionsSince({
     sinceIso,
     repository,
     includeOtherRepositories,
     limit: Math.max(3, Math.min(limit * 2, 20)),
   });
+  // recentSessions is intentionally capped above for evidence-selection
+  // quality (selectReflectEntries only ever keeps a handful of insights);
+  // that cap must never be read as an accurate "sessions found" total, so
+  // fetch the true count separately, decoupled from the evidence limit.
+  const countResult = typeof sessionStore.countSessionsSince === "function"
+    ? sessionStore.countSessionsSince({ sinceIso, repository, includeOtherRepositories })
+    : null;
+  return {
+    recentSessions,
+    recentSessionCount: countResult ? countResult.count : recentSessions.length,
+    recentSessionCountCapped: countResult ? Boolean(countResult.capped) : false,
+  };
 }
 
 export function reflectMemory({
@@ -838,7 +850,11 @@ export function reflectMemory({
   });
   const resolvedFocus = detectReflectFocus(prompt, focus);
   const envelope = buildEvidenceEnvelope(recall);
-  const recentSessions = fetchRecentSessionsForLookback({
+  const {
+    recentSessions,
+    recentSessionCount,
+    recentSessionCountCapped,
+  } = fetchRecentSessionsForLookback({
     sessionStore,
     repository,
     includeOtherRepositories,
@@ -871,7 +887,8 @@ export function reflectMemory({
     lookbackHours: Number.isFinite(Number(lookbackHours)) && Number(lookbackHours) > 0
       ? Number(lookbackHours)
       : null,
-    recentSessionCount: recentSessions.length,
+    recentSessionCount,
+    recentSessionCountCapped,
   };
 }
 

--- a/lib/memory-tools-reports.mjs
+++ b/lib/memory-tools-reports.mjs
@@ -156,8 +156,9 @@ export function formatReflectionReport(result, { detailLevel = "summary" } = {})
 }
 
 function buildReflectionHeaderLines(result) {
+  const cappedSuffix = result.recentSessionCountCapped ? "+ (capped)" : "";
   const lookbackLine = result.lookbackHours
-    ? [`lookbackHours: ${result.lookbackHours} (sessions found: ${result.recentSessionCount ?? 0})`]
+    ? [`lookbackHours: ${result.lookbackHours} (sessions found: ${result.recentSessionCount ?? 0}${cappedSuffix})`]
     : [];
   return [
     `repository: ${result.repository ?? "global-only"}`,

--- a/lib/memory-tools-retention.mjs
+++ b/lib/memory-tools-retention.mjs
@@ -139,6 +139,7 @@ function buildObservationUpsertInput({ runtime, reflection, request, args, domai
       insightCount: Array.isArray(reflection.insights) ? reflection.insights.length : 0,
       lookbackHours: reflection.lookbackHours ?? null,
       recentSessionCount: reflection.recentSessionCount ?? 0,
+      recentSessionCountCapped: Boolean(reflection.recentSessionCountCapped),
     },
     metadata: {
       prompt: request.prompt,

--- a/lib/session-store-reader.mjs
+++ b/lib/session-store-reader.mjs
@@ -246,6 +246,50 @@ export class SessionStoreReader {
     return filtered.slice(0, boundedLimit).map(buildDateSessionMatchRecord);
   }
 
+  // True count of sessions at/after `sinceIso`, decoupled from any
+  // evidence-fetch limit (findSessionsSince caps its result for evidence
+  // selection quality, not for accurate reporting - see lore_reflect's
+  // recentSessionCount). Cross-repo (or no repository given) counts are an
+  // exact SQL COUNT(*). Repository-scoped counts need the same
+  // workspace.yaml hydration/overlay findSessionsSince uses to resolve the
+  // *effective* repository (which can differ from the raw sessions.repository
+  // column), so those are capped at a generous ceiling and flagged via
+  // `capped` rather than silently reported as exact.
+  countSessionsSince({
+    sinceIso,
+    repository,
+    includeOtherRepositories = false,
+  } = {}) {
+    this.ensureOpen();
+    const scopedToRepository = Boolean(repository) && includeOtherRepositories !== true;
+
+    if (!scopedToRepository) {
+      const row = this.db.prepare(`
+        SELECT COUNT(*) AS count
+        FROM sessions
+        WHERE COALESCE(updated_at, created_at, '') >= ?
+      `).get(sinceIso);
+      return { count: row?.count ?? 0, capped: false };
+    }
+
+    const countCeiling = 500;
+    const rows = this.db.prepare(`
+      SELECT id, repository, branch, summary, created_at, updated_at
+      FROM sessions
+      WHERE COALESCE(updated_at, created_at, '') >= ?
+      ORDER BY COALESCE(updated_at, created_at, '') DESC, id DESC
+      LIMIT ?
+    `).all(sinceIso, countCeiling);
+
+    const hydrated = rows.map((row) => this.hydrateSessionRow(row));
+    const filtered = hydrated.filter((row) => row?.repository === repository);
+
+    return {
+      count: filtered.length,
+      capped: rows.length >= countCeiling,
+    };
+  }
+
   getSessionArtifacts(sessionId) {
     this.ensureOpen();
     const sessionRow = this.db.prepare(`

--- a/tests/unit/reflect-tool.test.mjs
+++ b/tests/unit/reflect-tool.test.mjs
@@ -192,6 +192,9 @@ describe("lore_reflect tool", () => {
             },
           ];
         },
+        countSessionsSince() {
+          return { count: 1, capped: false };
+        },
       };
 
       const tools = createMemoryTools({
@@ -220,6 +223,126 @@ describe("lore_reflect tool", () => {
       assert.ok(observation, "expected the observation row to be persisted");
       assert.equal(observation.trace?.lookbackHours, 24);
       assert.equal(observation.trace?.recentSessionCount, 1);
+      assert.equal(observation.trace?.recentSessionCountCapped, false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reports the true session count even when it exceeds the evidence-fetch limit", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+        rollout: {
+          memoryOperations: true,
+          temporalQueryNormalization: true,
+          memoryDomains: true,
+          refreshableObservations: true,
+        },
+      },
+    });
+
+    try {
+      const sessionStore = {
+        findRelevantSessions() {
+          return [];
+        },
+        // Evidence-fetch path stays capped (only 2 rows), simulating the
+        // pre-existing Math.max(3, Math.min(limit*2, 20)) evidence limit.
+        findSessionsSince() {
+          return [
+            {
+              session_id: "session-recent-1",
+              repository: "fixture-repo",
+              branch: "main",
+              summary: "First evidence row.",
+              created_at: "2026-07-03T08:00:00.000Z",
+              updated_at: "2026-07-03T11:00:00.000Z",
+              workspaceSummary: null,
+            },
+            {
+              session_id: "session-recent-2",
+              repository: "fixture-repo",
+              branch: "main",
+              summary: "Second evidence row.",
+              created_at: "2026-07-02T08:00:00.000Z",
+              updated_at: "2026-07-02T11:00:00.000Z",
+              workspaceSummary: null,
+            },
+          ];
+        },
+        // True count is decoupled from the evidence limit above and should
+        // be what actually gets reported, not the 2-row evidence array length.
+        countSessionsSince() {
+          return { count: 47, capped: false };
+        },
+      };
+
+      const tools = createMemoryTools({
+        getRuntime: async () => buildRuntime(db, config, { sessionStore }),
+      });
+      const reflect = findTool(tools, "lore_reflect");
+
+      const output = await reflect.handler({
+        prompt: "Analyze the last month of activity across repos and summarize my patterns and preferences.",
+        focus: "patterns",
+        lookbackHours: 720,
+        persistObservation: true,
+        observationKey: "reflect-tool-true-count-observation",
+      }, {
+        sessionId: "reflect-true-count",
+      });
+
+      assert.match(output, /lookbackHours: 720 \(sessions found: 47\)/);
+
+      const observation = db.getObservation("reflect-tool-true-count-observation");
+      assert.equal(observation.trace?.recentSessionCount, 47);
+      assert.equal(observation.trace?.recentSessionCountCapped, false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("annotates the reported session count when the repository-scoped count hits its ceiling", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb({
+      configOverrides: {
+        enabled: true,
+        rollout: {
+          memoryOperations: true,
+          temporalQueryNormalization: true,
+          memoryDomains: true,
+          refreshableObservations: true,
+        },
+      },
+    });
+
+    try {
+      const sessionStore = {
+        findRelevantSessions() {
+          return [];
+        },
+        findSessionsSince() {
+          return [];
+        },
+        countSessionsSince() {
+          return { count: 500, capped: true };
+        },
+      };
+
+      const tools = createMemoryTools({
+        getRuntime: async () => buildRuntime(db, config, { sessionStore }),
+      });
+      const reflect = findTool(tools, "lore_reflect");
+
+      const output = await reflect.handler({
+        prompt: "Analyze the last month of activity across repos and summarize my patterns and preferences.",
+        focus: "patterns",
+        lookbackHours: 720,
+      }, {
+        sessionId: "reflect-capped-count",
+      });
+
+      assert.match(output, /lookbackHours: 720 \(sessions found: 500\+ \(capped\)\)/);
     } finally {
       cleanup();
     }
@@ -276,6 +399,9 @@ describe("lore_reflect tool", () => {
         findSessionsSince({ sinceIso }) {
           sinceIsoCalls.push(sinceIso);
           return [];
+        },
+        countSessionsSince() {
+          return { count: 0, capped: false };
         },
       };
       const tools = createMemoryTools({

--- a/tests/unit/semantic-memory-durability.test.mjs
+++ b/tests/unit/semantic-memory-durability.test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { FTS5_AVAILABLE, withFixtureDb } from "../helpers/fixture-db.mjs";
+
+const SKIP_NO_FTS5 = !FTS5_AVAILABLE
+  ? "FTS5 not compiled into this Node.js SQLite build (Copilot CLI runtime has it; check your local Node install)"
+  : false;
+
+describe("LoreDb semantic memory durability verification", () => {
+  test("insertSemanticMemory returns an id that is durably visible via an independent connection", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+
+    try {
+      const id = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Durability smoke test memory.",
+        scope: "global",
+        confidence: 1,
+        tags: [],
+      });
+
+      assert.ok(id, "expected insertSemanticMemory to return a truthy id");
+      // Should not throw: the row genuinely exists and is visible from a
+      // brand-new connection, not just the writer's own cached connection.
+      assert.doesNotThrow(() => db.verifySemanticMemoryDurability(id));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("verifySemanticMemoryDurability throws when the id is not durably visible", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+
+    try {
+      assert.throws(
+        () => db.verifySemanticMemoryDurability("id-that-was-never-inserted"),
+        /did not durably persist/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("upsert paths (manual and scoped matches) still pass durability verification", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+
+    try {
+      const firstId = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Repeated preference for dedup testing.",
+        scope: "global",
+        confidence: 0.8,
+        tags: ["dedup"],
+      });
+
+      // Same type/content/scope should hit the scoped-match upsert path
+      // (existing.id branch) rather than inserting a new row - this must
+      // still pass durability verification using the existing row's id.
+      const secondId = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Repeated preference for dedup testing.",
+        scope: "global",
+        confidence: 0.95,
+        tags: ["dedup"],
+      });
+
+      assert.equal(secondId, firstId, "expected the scoped upsert to reuse the existing row's id");
+      assert.doesNotThrow(() => db.verifySemanticMemoryDurability(secondId));
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tests/unit/session-store-reader.test.mjs
+++ b/tests/unit/session-store-reader.test.mjs
@@ -526,6 +526,186 @@ describe("SessionStoreReader.findSessionsSince", () => {
   });
 });
 
+describe("SessionStoreReader.countSessionsSince", () => {
+  test("returns an exact cross-repo count that exceeds findSessionsSince's evidence-fetch limit", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(
+        tempHome,
+        Array.from({ length: 22 }, (_, i) => [
+          `session-${i}`,
+          "repo-one",
+          "main",
+          `summary ${i}`,
+          `2026-03-30T${String(i).padStart(2, "0")}:00:00Z`,
+          `2026-03-30T${String(i).padStart(2, "0")}:30:00Z`,
+        ]),
+      );
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+
+      // findSessionsSince caps its evidence array at 20 rows (see the
+      // sibling "falls back to the default limit" test above); the true
+      // count must not inherit that cap.
+      const evidenceRows = reader.findSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        includeOtherRepositories: true,
+        limit: "abc",
+      });
+      const { count, capped } = reader.countSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        includeOtherRepositories: true,
+      });
+
+      assert.strictEqual(evidenceRows.length, 20);
+      assert.strictEqual(count, 22);
+      assert.strictEqual(capped, false);
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("filters at or after the provided ISO cutoff", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(tempHome, [
+        ["session-before", "repo-one", "main", "too old", "2026-03-28T08:00:00Z", "2026-03-28T09:00:00Z"],
+        ["session-at-cutoff", "repo-one", "main", "exactly at cutoff", "2026-03-29T08:00:00Z", "2026-03-29T12:00:00Z"],
+        ["session-after", "repo-two", "feature", "well within window", "2026-03-30T09:00:00Z", null],
+      ]);
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+      const { count, capped } = reader.countSessionsSince({
+        sinceIso: "2026-03-29T12:00:00Z",
+        includeOtherRepositories: true,
+      });
+
+      assert.strictEqual(count, 2);
+      assert.strictEqual(capped, false);
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("scopes the count to the effective (hydrated) repository, not the raw column", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(tempHome, [
+        ["session-workspace", "raw-repo", "raw-branch", "raw summary", "2026-03-30T08:00:00Z", "2026-03-30T10:00:00Z"],
+        ["session-other", "repo-other", "main", "other", "2026-03-30T08:00:00Z", "2026-03-30T10:00:00Z"],
+      ]);
+
+      const workspaceDir = path.join(tempHome, "session-state", "session-workspace");
+      mkdirSync(workspaceDir, { recursive: true });
+      writeFileSync(
+        path.join(workspaceDir, "workspace.yaml"),
+        ["repository: hydrated-repo", "updated_at: 2026-03-31T07:00:00Z"].join("\n"),
+      );
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+      const { count, capped } = reader.countSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        repository: "hydrated-repo",
+        includeOtherRepositories: false,
+      });
+
+      assert.strictEqual(count, 1);
+      assert.strictEqual(capped, false);
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("honors cross-repo inclusion and local-only restrictions", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(tempHome, [
+        ["local-session", "repo-local", "main", "local", "2026-03-30T08:00:00Z", "2026-03-30T11:00:00Z"],
+        ["other-session", "repo-other", "main", "other", "2026-03-30T08:00:00Z", "2026-03-30T10:00:00Z"],
+      ]);
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+
+      const localOnly = reader.countSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        repository: "repo-local",
+        includeOtherRepositories: false,
+      });
+      const crossRepo = reader.countSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        repository: "repo-local",
+        includeOtherRepositories: true,
+      });
+
+      assert.strictEqual(localOnly.count, 1);
+      assert.strictEqual(crossRepo.count, 2);
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("flags capped:true when the repository-scoped fetch hits its ceiling", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(
+        tempHome,
+        Array.from({ length: 505 }, (_, i) => [
+          `session-${i}`,
+          "repo-one",
+          "main",
+          `summary ${i}`,
+          `2026-03-30T00:00:00Z`,
+          new Date(Date.parse("2026-03-30T00:00:00Z") + i * 1000).toISOString(),
+        ]),
+      );
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+      const { count, capped } = reader.countSessionsSince({
+        sinceIso: "2026-03-29T00:00:00Z",
+        repository: "repo-one",
+        includeOtherRepositories: false,
+      });
+
+      assert.strictEqual(count, 500);
+      assert.strictEqual(capped, true);
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("returns zero when no sessions match", () => {
+    const tempHome = makeTempDir();
+    try {
+      buildRawStore(tempHome, [
+        ["session-before", "repo-one", "main", "too old", "2026-03-28T08:00:00Z", "2026-03-28T09:00:00Z"],
+      ]);
+
+      const reader = new SessionStoreReader(buildFixtureConfig(tempHome));
+      reader.initialize();
+      const { count, capped } = reader.countSessionsSince({
+        sinceIso: "2026-03-29T12:00:00Z",
+        includeOtherRepositories: true,
+      });
+
+      assert.strictEqual(count, 0);
+      assert.strictEqual(capped, false);
+      reader.db.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("SessionStoreReader.collectRelevantSessionMatches", () => {
   test("keeps the strongest hydrated match per session and drops repository mismatches", () => {
     const reader = new SessionStoreReader({


### PR DESCRIPTION
## Summary

Fixes two bugs surfaced during investigation of a degraded daily profile-refresh run:

1. **Silent WAL durability loss** — `insertSemanticMemory` could return a generated id for a write that never became queryable. Root cause: multiple long-lived Copilot CLI processes hold `lore.db` open concurrently via `node:sqlite`'s `DatabaseSync`, and `close()`'s `PRAGMA wal_checkpoint(TRUNCATE)` could race an in-flight commit from another process.
2. **Hardcoded session-count cap** — `recentSessionCount` was silently set to the length of the (deliberately capped) evidence array used for reflection context, so any lookback window with more matching sessions than the fetch limit under-reported real coverage.

## Fix 1: Durability verification

- `close()` now uses `wal_checkpoint(PASSIVE)` instead of `TRUNCATE`, which never blocks or disrupts other connections mid-write.
- New `verifySemanticMemoryDurability(id)` re-reads the row via an independent read-only connection immediately after insert/upsert, throwing a clear error instead of silently reporting success on a write that isn't durable. Covers all three write paths (manual, scoped, new-insert) plus the workstream overlay path.

## Fix 2: Accurate session counts

- New `SessionStoreReader.countSessionsSince()`: exact SQL `COUNT(*)` for the cross-repo case; hydrated/filtered count with a `capped` flag at its own ceiling for the repository-scoped case (which needs the same `workspace.yaml` overlay logic as `findSessionsSince`).
- `fetchRecentSessionsForLookback` / `reflectMemory` now report the true count (with capped flag) alongside the existing bounded evidence array. Feature-detected so callers without `countSessionsSince` fall back to old behavior.
- Reflection report output and persisted observation trace now show a `(capped)` annotation when the true count itself was capped.

## Testing

- New `tests/unit/semantic-memory-durability.test.mjs` (3 tests: happy path, throws on missing id, upsert/dedup still verifies).
- New `SessionStoreReader.countSessionsSince` describe block in `tests/unit/session-store-reader.test.mjs` (6 tests, including a 505-row capped-ceiling case).
- Updated `tests/unit/reflect-tool.test.mjs` mocks + 2 new tests for true-count reporting and capped annotation.
- Full suite: **404/404 passing**. `npm run lint`: **0 warnings/errors**.
