### PR TITLE
feat(memory): add OKF markdown export format to memory_portable_bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,18 @@ The canonical breakdown lives in [`docs/support-matrix.md`](docs/support-matrix.
 
 For runtime and platform promises, see [`docs/compatibility.md`](docs/compatibility.md).
 
+### Portable exports and the OKF viewer
+
+`memory_portable_bundle` accepts a `format` argument: `json` (default, machine-readable) or `okf`. The `okf` format writes an [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) bundle -- one markdown file with YAML frontmatter per approved improvement artifact, plus a root `index.md` -- so approved Lore improvements can be reviewed, archived, or shared outside the CLI with any OKF-aware tool.
+
+To browse an OKF bundle visually, render it into a self-contained HTML viewer:
+
+```sh
+npm run visualize-okf -- --bundle path/to/bundle --out viz.html
+```
+
+This produces a force-directed graph of the bundle's concepts (colored by type, with search, a type filter, and a detail panel showing backlinks), loading Cytoscape.js and marked from CDN at view time -- no npm runtime dependency is added. It mirrors the `visualize` subcommand of the OKF reference agent.
+
 ---
 
 ## Privacy and security
@@ -240,6 +252,7 @@ Useful commands:
 | `npm run dev-install` | Copy a dev checkout into `~/.copilot/extensions/lore` |
 | `npm run maintenance` | Run the maintenance script |
 | `npm run browser` | Start the local browser dashboard |
+| `npm run visualize-okf -- --bundle <dir>` | Render an interactive `viz.html` for an OKF-format `memory_portable_bundle` export |
 
 High-level layout:
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -112,7 +112,7 @@ chmod 600 ~/.copilot/lore.db
 chmod 600 ~/.copilot/lore.json
 ```
 
-The `memory_portable_bundle` export tool (experimental) can generate a portable snapshot. Treat any exported bundle as sensitive — it contains raw memory data.
+The `memory_portable_bundle` export tool (experimental) can generate a portable snapshot as a signed JSON file or an Open Knowledge Format (OKF v0.1) markdown bundle. Treat any exported bundle as sensitive — it contains raw memory data.
 
 ---
 
@@ -128,7 +128,7 @@ The `memory_portable_bundle` export tool (experimental) can generate a portable 
 ### What Lore does not promise
 
 1. **Experimental surfaces may change** — tool names, argument shapes, and output formats for experimental surfaces can change between releases without notice.
-2. **No cross-machine portability yet** — `lore.db` is not portable by default. The `memory_portable_bundle` export tool exists (experimental) but import is not yet implemented.
+2. **No cross-machine portability yet** — `lore.db` is not portable by default. The `memory_portable_bundle` export tool exists (experimental, json or OKF markdown format) but import is not yet implemented.
 3. **No multi-user or multi-machine sync** — Lore is local-first. There is no cloud sync, no shared team memory, and no remote API surface.
 4. **No performance guarantees under heavy load** — the bounded operation targets (< 300 ms session-start, < 200 ms prompt-time) are aspirational guidelines calibrated for a typical developer machine. Very large DBs or slow disks may exceed these.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -112,7 +112,7 @@ chmod 600 ~/.copilot/lore.db
 chmod 600 ~/.copilot/lore.json
 ```
 
-The `memory_portable_bundle` export tool (experimental) can generate a portable snapshot as a signed JSON file or an Open Knowledge Format (OKF v0.1) markdown bundle. Treat any exported bundle as sensitive — it contains raw memory data.
+The `memory_portable_bundle` export tool (experimental) can generate a portable snapshot as a signed JSON file or an Open Knowledge Format (OKF v0.1) markdown bundle. It exports your approved improvement artifacts (not the full raw memory corpus), but treat any exported bundle as sensitive — those artifacts can still contain excerpts of your code, decisions, and notes.
 
 ---
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -82,7 +82,7 @@ This document defines which surfaces are **supported**, **experimental**, or **u
 | Tool | Status | Notes |
 |---|---|---|
 | `memory_replay` | 🟡 Experimental | Runs the replay corpus against current retrieval behavior and reports ranking hits/misses. |
-| `memory_portable_bundle` | 🟡 Experimental | Exports a portable bundle of memories and improvement artifacts. Import not yet implemented. |
+| `memory_portable_bundle` | 🟡 Experimental | Exports a portable bundle of approved improvement artifacts. format=json (default) writes a single signed JSON file; format=okf writes an OKF v0.1 markdown+frontmatter bundle directory for human/agent-readable, git-diffable exchange. Import not yet implemented for either format. |
 
 ### Improvement and evolution
 

--- a/lib/capability-manifest.mjs
+++ b/lib/capability-manifest.mjs
@@ -39,12 +39,12 @@ const CAPABILITY_SPECS = [
   },
   {
     name: "memory_portable_bundle",
-    description: "Export a local, signed, review-gated portability bundle for approved improvement artifacts.",
+    description: "Export a local, review-gated portability bundle for approved improvement artifacts, as a signed JSON file or an Open Knowledge Format (OKF v0.1) markdown bundle.",
     routeKindHints: [],
     support: {
       status: "experimental",
       category: "Replay and portability",
-      notes: "Exports a portable bundle of memories and improvement artifacts. Import not yet implemented.",
+      notes: "Exports a portable bundle of approved improvement artifacts. format=json (default) writes a single signed JSON file; format=okf writes an OKF v0.1 markdown+frontmatter bundle directory for human/agent-readable, git-diffable exchange. Import not yet implemented for either format.",
       rolloutFlags: [],
     },
   },

--- a/lib/memory-tools-builders.mjs
+++ b/lib/memory-tools-builders.mjs
@@ -43,6 +43,9 @@ const {
   buildPortableBundleRequest,
   writePortableBundle,
   formatPortableBundleResult,
+  buildOkfBundleDocuments,
+  writeOkfBundle,
+  formatOkfBundleResult,
   normalizeCapabilityInventoryAction,
   renderCapabilityInventoryAction,
   buildIntentJournalContext,
@@ -255,11 +258,16 @@ function buildMemoryPortableBundleTool(getRuntime) {
         },
         bundlePath: {
           type: "string",
-          description: "Optional repository-relative or absolute JSON path for reading/writing bundles",
+          description: "Optional repository-relative or absolute path for reading/writing bundles. For format=okf this is a directory root; for format=json (default) this is a single file path.",
         },
         limit: {
           type: "number",
           description: "Maximum records to export/import per dataset",
+        },
+        format: {
+          type: "string",
+          enum: ["json", "okf"],
+          description: "Bundle output format. \"json\" (default) writes a single signed JSON file. \"okf\" writes an Open Knowledge Format v0.1 markdown+frontmatter bundle directory (one concept file per artifact plus an index.md) for human/agent-readable, git-diffable exchange.",
         },
       },
     },
@@ -276,6 +284,20 @@ function buildMemoryPortableBundleTool(getRuntime) {
         hasProposal: true,
         limit: request.limit,
       });
+
+      if (request.format === "okf") {
+        const documents = buildOkfBundleDocuments({
+          repository: request.repository,
+          improvementArtifacts,
+        });
+        await writeOkfBundle(request.bundlePath, documents);
+        return formatOkfBundleResult({
+          bundleDir: request.bundlePath,
+          repository: request.repository,
+          exportedArtifactCount: improvementArtifacts.length,
+        });
+      }
+
       const portableBundle = createPortableBundle({
         repository: request.repository,
         improvementArtifacts,

--- a/lib/memory-tools-builders.mjs
+++ b/lib/memory-tools-builders.mjs
@@ -70,6 +70,7 @@ const {
   maybePersistReflectionObservation,
   normalizeBackfillRequest,
   createPortableBundle,
+  mapImprovementArtifactRow,
 } = helpers;
 
 const {
@@ -288,7 +289,7 @@ function buildMemoryPortableBundleTool(getRuntime) {
       if (request.format === "okf") {
         const documents = buildOkfBundleDocuments({
           repository: request.repository,
-          improvementArtifacts,
+          improvementArtifacts: improvementArtifacts.map(mapImprovementArtifactRow),
         });
         await writeOkfBundle(request.bundlePath, documents);
         return formatOkfBundleResult({

--- a/lib/memory-tools-helpers.mjs
+++ b/lib/memory-tools-helpers.mjs
@@ -21,6 +21,11 @@ export {
   writePortableBundle,
 } from "./memory-tools-portable-bundle.mjs";
 export {
+  buildOkfBundleDocuments,
+  formatOkfBundleResult,
+  writeOkfBundle,
+} from "./memory-tools-okf-bundle.mjs";
+export {
   normalizeCapabilityInventoryAction,
   renderCapabilityInventoryAction,
 } from "./memory-tools-capability-inventory.mjs";

--- a/lib/memory-tools-helpers.mjs
+++ b/lib/memory-tools-helpers.mjs
@@ -18,6 +18,7 @@ export {
   buildPortableBundleRequest,
   createPortableBundle,
   formatPortableBundleResult,
+  mapImprovementArtifactRow,
   writePortableBundle,
 } from "./memory-tools-portable-bundle.mjs";
 export {

--- a/lib/memory-tools-okf-bundle.mjs
+++ b/lib/memory-tools-okf-bundle.mjs
@@ -1,0 +1,172 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const OKF_VERSION = "0.1";
+const OKF_SPEC_URL = "https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md";
+
+/**
+ * Build an Open Knowledge Format (OKF v0.1) conformant bundle from the same
+ * approved improvement artifacts memory_portable_bundle's json format exports.
+ * Pure/no I/O: returns [{ relativePath, contents }, ...] ready to be written
+ * to disk by writeOkfBundle.
+ */
+export function buildOkfBundleDocuments({ repository, improvementArtifacts, exportedAt } = {}) {
+  const generatedAt = exportedAt ?? new Date().toISOString();
+  const artifacts = Array.isArray(improvementArtifacts) ? improvementArtifacts : [];
+  const seenSlugs = new Set();
+  const concepts = artifacts.map((artifact) => buildArtifactConcept(artifact, seenSlugs));
+
+  return [
+    buildIndexDocument({ repository, concepts, generatedAt }),
+    ...concepts.map(({ relativePath, contents }) => ({ relativePath, contents })),
+  ];
+}
+
+/** Writes previously built OKF documents under bundleDir, creating directories as needed. */
+export async function writeOkfBundle(bundleDir, documents) {
+  if (!bundleDir) {
+    return;
+  }
+  for (const doc of documents) {
+    const fullPath = path.join(bundleDir, doc.relativePath);
+    await mkdir(path.dirname(fullPath), { recursive: true });
+    await writeFile(fullPath, doc.contents, "utf8");
+  }
+}
+
+export function formatOkfBundleResult({ bundleDir, repository, exportedArtifactCount = 0 }) {
+  return [
+    "action: export",
+    "format: okf",
+    `bundlePath: ${bundleDir ? path.relative(repoRootFromModule(), bundleDir).replaceAll(path.sep, "/") : "inline"}`,
+    `repository: ${repository ?? "global"}`,
+    `exportedImprovementCount: ${exportedArtifactCount}`,
+    "",
+    "Notes:",
+    "- OKF bundles are local-first and review-gated, same as the json format",
+    "- bundle includes approved improvement artifacts only",
+    `- conformant with Open Knowledge Format v${OKF_VERSION} (${OKF_SPEC_URL})`,
+  ].filter(Boolean).join("\n");
+}
+
+function buildIndexDocument({ repository, concepts, generatedAt }) {
+  const frontmatter = yamlFrontmatter({ okf_version: OKF_VERSION });
+  const lines = [
+    frontmatter,
+    "",
+    "# Lore Improvement Artifacts",
+    "",
+    `Portable OKF export of approved Lore improvement artifacts${repository ? ` for \`${repository}\`` : ""}, generated ${generatedAt}.`,
+    "",
+  ];
+  if (concepts.length === 0) {
+    lines.push("_No approved improvement artifacts to export._");
+  } else {
+    lines.push("# Improvement Artifacts");
+    lines.push("");
+    for (const concept of concepts) {
+      const description = concept.description ? ` - ${concept.description}` : "";
+      lines.push(`- [${concept.title}](${concept.relativePath})${description}`);
+    }
+  }
+  return { relativePath: "index.md", contents: `${lines.join("\n").trimEnd()}\n` };
+}
+
+function buildArtifactConcept(artifact, seenSlugs) {
+  const slug = uniqueSlug(artifact?.id ?? artifact?.sourceCaseId ?? "artifact", seenSlugs);
+  const relativePath = `artifacts/${slug}.md`;
+  const title = artifact?.title || slug;
+  const tags = [...new Set([artifact?.sourceKind, artifact?.status, artifact?.reviewState].filter(Boolean))];
+
+  const frontmatter = yamlFrontmatter({
+    type: "Improvement Artifact",
+    title,
+    description: artifact?.summary || undefined,
+    resource: artifact?.proposal?.path || undefined,
+    tags,
+    timestamp: artifact?.updatedAt || artifact?.createdAt || undefined,
+    sourceCaseId: artifact?.sourceCaseId,
+    sourceKind: artifact?.sourceKind,
+    status: artifact?.status,
+    reviewState: artifact?.reviewState,
+  });
+
+  const body = [];
+  body.push(`# ${title}`);
+  body.push("");
+  if (artifact?.summary) {
+    body.push(artifact.summary);
+    body.push("");
+  }
+  if (artifact?.proposal && (artifact.proposal.type || artifact.proposal.path || artifact.proposal.hash)) {
+    body.push("# Proposal");
+    body.push("");
+    if (artifact.proposal.type) body.push(`- **Type**: ${artifact.proposal.type}`);
+    if (artifact.proposal.path) body.push(`- **Path**: \`${artifact.proposal.path}\``);
+    if (artifact.proposal.hash) body.push(`- **Hash**: \`${artifact.proposal.hash}\``);
+    body.push("");
+  }
+  if (artifact?.evidence && Object.keys(artifact.evidence).length > 0) {
+    body.push("# Evidence");
+    body.push("");
+    body.push("```json");
+    body.push(JSON.stringify(artifact.evidence, null, 2));
+    body.push("```");
+    body.push("");
+  }
+
+  const contents = `${frontmatter}\n\n${body.join("\n").trimEnd()}\n`;
+  return { relativePath, contents, title, description: artifact?.summary || "" };
+}
+
+function uniqueSlug(rawValue, seenSlugs) {
+  const base = slugify(rawValue);
+  let candidate = base;
+  let suffix = 2;
+  while (seenSlugs.has(candidate)) {
+    candidate = `${base}-${suffix}`;
+    suffix += 1;
+  }
+  seenSlugs.add(candidate);
+  return candidate;
+}
+
+function slugify(value) {
+  const slug = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "artifact";
+}
+
+function yamlScalar(value) {
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return JSON.stringify(String(value));
+}
+
+/** Minimal, safe YAML frontmatter serializer: every scalar is JSON-quoted (a valid YAML subset), skips empty/undefined fields. */
+function yamlFrontmatter(fields) {
+  const lines = [];
+  for (const [key, value] of Object.entries(fields)) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      if (value.length === 0) {
+        continue;
+      }
+      lines.push(`${key}: [${value.map((item) => yamlScalar(item)).join(", ")}]`);
+    } else {
+      lines.push(`${key}: ${yamlScalar(value)}`);
+    }
+  }
+  return ["---", ...lines, "---"].join("\n");
+}
+
+function repoRootFromModule() {
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+}

--- a/lib/memory-tools-okf-bundle.mjs
+++ b/lib/memory-tools-okf-bundle.mjs
@@ -168,5 +168,8 @@ function yamlFrontmatter(fields) {
 }
 
 function repoRootFromModule() {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+  // This module lives at <repo>/lib/memory-tools-okf-bundle.mjs, so one
+  // level up from its directory is the actual repository root (mirrors the
+  // fix in memory-tools-portable-bundle.mjs's repoRootFromModule()).
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 }

--- a/lib/memory-tools-portable-bundle.mjs
+++ b/lib/memory-tools-portable-bundle.mjs
@@ -93,11 +93,8 @@ function formatPortableBundleReport({
   ].filter(Boolean).join("\n");
 }
 
-export function createPortableBundle({
-  repository,
-  improvementArtifacts,
-}) {
-  const selectedArtifacts = improvementArtifacts.map((row) => ({
+export function mapImprovementArtifactRow(row) {
+  return {
     id: row.id,
     sourceCaseId: row.source_case_id,
     sourceKind: row.source_kind,
@@ -114,7 +111,14 @@ export function createPortableBundle({
     trace: row.trace ?? {},
     createdAt: row.created_at,
     updatedAt: row.updated_at,
-  }));
+  };
+}
+
+export function createPortableBundle({
+  repository,
+  improvementArtifacts,
+}) {
+  const selectedArtifacts = improvementArtifacts.map(mapImprovementArtifactRow);
   const exportedAt = new Date().toISOString();
   const bundleId = `portable-${exportedAt.replace(/[:.]/g, "-")}`;
   const payload = {

--- a/lib/memory-tools-portable-bundle.mjs
+++ b/lib/memory-tools-portable-bundle.mjs
@@ -11,9 +11,21 @@ import { ensureLimit } from "./memory-tools-validation-utils.mjs";
 const PORTABLE_BUNDLE_EXPORT_ACTION = "export";
 const PORTABLE_BUNDLE_VERSION = 1;
 const PORTABLE_BUNDLE_TYPE = "lore-portable-improvement";
+const PORTABLE_BUNDLE_FORMATS = ["json", "okf"];
+const PORTABLE_BUNDLE_DEFAULT_FORMAT = "json";
 
 function normalizePortableBundleAction(value) {
   return typeof value === "string" ? value : PORTABLE_BUNDLE_EXPORT_ACTION;
+}
+
+function normalizePortableBundleFormat(value) {
+  if (value === undefined || value === null) {
+    return PORTABLE_BUNDLE_DEFAULT_FORMAT;
+  }
+  if (!PORTABLE_BUNDLE_FORMATS.includes(value)) {
+    throw new Error(`format must be one of: ${PORTABLE_BUNDLE_FORMATS.join(", ")}`);
+  }
+  return value;
 }
 
 export function buildPortableBundleRequest(args, runtime) {
@@ -29,6 +41,7 @@ export function buildPortableBundleRequest(args, runtime) {
     repository: resolveRepositoryArg(args.repository, runtime.repository),
     limit: ensureLimit(args.limit, 20, 50),
     bundlePath,
+    format: normalizePortableBundleFormat(args.format),
   };
 }
 
@@ -66,6 +79,7 @@ function formatPortableBundleReport({
 }) {
   return [
     "action: export",
+    "format: json",
     `bundleId: ${bundleId}`,
     `signature: ${signature}`,
     `bundlePath: ${bundlePath ?? "inline"}`,

--- a/lib/memory-tools-portable-bundle.mjs
+++ b/lib/memory-tools-portable-bundle.mjs
@@ -146,7 +146,12 @@ export function createPortableBundle({
 }
 
 function repoRootFromModule() {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+  // This module lives at <repo>/lib/memory-tools-portable-bundle.mjs, so one
+  // level up from its directory is the actual repository root (the Lore
+  // extension is its own git repo/submodule). bundlePath is documented as
+  // "repository-relative", so it must resolve against that root, not an
+  // ancestor of it.
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 }
 
 function resolveBundlePath(rawPath) {

--- a/lib/okf-bundle-reader.mjs
+++ b/lib/okf-bundle-reader.mjs
@@ -117,9 +117,20 @@ function splitYamlFlowItems(inner) {
 }
 
 function parseYamlScalar(raw) {
-  if ((raw.startsWith("\"") && raw.endsWith("\"")) || (raw.startsWith("'") && raw.endsWith("'"))) {
-    const inner = raw.slice(1, -1);
-    return raw.startsWith("\"") ? inner.replace(/\\"/gu, "\"") : inner;
+  if (raw.startsWith("\"") && raw.endsWith("\"")) {
+    // The OKF writer in this repo serializes double-quoted scalars via
+    // JSON.stringify (a valid YAML subset), so JSON.parse is the correct
+    // inverse -- it handles \\, \n, \t, \uXXXX, etc., not just \".
+    try {
+      return JSON.parse(raw);
+    } catch {
+      // Tolerate hand-authored/non-JSON double-quoted scalars per OKF
+      // SPEC.md's "consumers must tolerate malformed content" guidance.
+      return raw.slice(1, -1).replace(/\\"/gu, "\"");
+    }
+  }
+  if (raw.startsWith("'") && raw.endsWith("'")) {
+    return raw.slice(1, -1);
   }
   if (raw === "null" || raw === "~") {
     return null;

--- a/lib/okf-bundle-reader.mjs
+++ b/lib/okf-bundle-reader.mjs
@@ -1,0 +1,192 @@
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const RESERVED_FILENAMES = new Set(["index.md", "log.md"]);
+const MARKDOWN_LINK_RE = /\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g;
+const EXTERNAL_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * Reads any Open Knowledge Format (OKF v0.1, see
+ * https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+ * bundle directory from disk into an in-memory graph model: one node per
+ * concept document (reserved filenames index.md/log.md are skipped, per
+ * OKF SPEC.md section 3) plus resolved internal-link edges between them.
+ */
+export async function readOkfBundle(bundleDir) {
+  const files = await walkMarkdownFiles(bundleDir);
+  const concepts = [];
+  for (const filePath of files) {
+    if (RESERVED_FILENAMES.has(path.basename(filePath))) {
+      continue;
+    }
+    const relativePath = path.relative(bundleDir, filePath).replaceAll(path.sep, "/");
+    const raw = await readFile(filePath, "utf8");
+    concepts.push(buildConceptFromDocument(relativePath, raw));
+  }
+  const { edges, backlinksById } = buildOkfGraph(concepts);
+  return { bundleDir, concepts, edges, backlinksById };
+}
+
+/** Pure: turns one raw markdown+frontmatter file's contents into a concept record. */
+export function buildConceptFromDocument(relativePath, raw) {
+  const conceptId = relativePath.replace(/\.md$/u, "");
+  const { frontmatter, body } = parseOkfDocument(raw);
+  return {
+    id: conceptId,
+    relativePath,
+    type: typeof frontmatter.type === "string" && frontmatter.type ? frontmatter.type : "Concept",
+    title: typeof frontmatter.title === "string" && frontmatter.title ? frontmatter.title : conceptId,
+    description: typeof frontmatter.description === "string" ? frontmatter.description : "",
+    resource: typeof frontmatter.resource === "string" ? frontmatter.resource : null,
+    tags: Array.isArray(frontmatter.tags) ? frontmatter.tags.map(String) : [],
+    timestamp: typeof frontmatter.timestamp === "string" ? frontmatter.timestamp : null,
+    frontmatter,
+    body,
+  };
+}
+
+/** Pure: splits a markdown file's raw text into its frontmatter object and body. */
+export function parseOkfDocument(raw) {
+  const match = raw.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/u);
+  if (!match) {
+    return { frontmatter: {}, body: raw };
+  }
+  const [, yamlBlock, body] = match;
+  return { frontmatter: parseFrontmatterYaml(yamlBlock), body: body.replace(/^\r?\n/u, "") };
+}
+
+/**
+ * Minimal, forgiving YAML-subset parser for OKF frontmatter blocks: flat
+ * `key: value` pairs and `key: [item, item]` flow arrays, with quoted or
+ * bare scalars. Not a general YAML parser (no nested maps, no multi-line
+ * scalars) -- OKF frontmatter is deliberately flat, so this is sufficient
+ * for both this project's own exports and the spec's own examples.
+ */
+export function parseFrontmatterYaml(yamlText) {
+  const result = {};
+  for (const rawLine of yamlText.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) {
+      continue;
+    }
+    const match = line.match(/^([A-Za-z0-9_]+):\s*(.*)$/u);
+    if (!match) {
+      continue;
+    }
+    const [, key, rawValue] = match;
+    result[key] = parseYamlValue(rawValue.trim());
+  }
+  return result;
+}
+
+function parseYamlValue(raw) {
+  if (raw === "") {
+    return "";
+  }
+  if (raw.startsWith("[") && raw.endsWith("]")) {
+    const inner = raw.slice(1, -1).trim();
+    return inner ? splitYamlFlowItems(inner).map(parseYamlScalar) : [];
+  }
+  return parseYamlScalar(raw);
+}
+
+function splitYamlFlowItems(inner) {
+  const items = [];
+  let current = "";
+  let quoteChar = null;
+  for (const ch of inner) {
+    if (quoteChar) {
+      current += ch;
+      if (ch === quoteChar) {
+        quoteChar = null;
+      }
+    } else if (ch === "\"" || ch === "'") {
+      quoteChar = ch;
+      current += ch;
+    } else if (ch === ",") {
+      items.push(current.trim());
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim()) {
+    items.push(current.trim());
+  }
+  return items;
+}
+
+function parseYamlScalar(raw) {
+  if ((raw.startsWith("\"") && raw.endsWith("\"")) || (raw.startsWith("'") && raw.endsWith("'"))) {
+    const inner = raw.slice(1, -1);
+    return raw.startsWith("\"") ? inner.replace(/\\"/gu, "\"") : inner;
+  }
+  if (raw === "null" || raw === "~") {
+    return null;
+  }
+  if (raw === "true") {
+    return true;
+  }
+  if (raw === "false") {
+    return false;
+  }
+  if (/^-?\d+(\.\d+)?$/u.test(raw)) {
+    return Number(raw);
+  }
+  return raw;
+}
+
+/**
+ * Pure: resolves markdown links between already-parsed concepts into graph
+ * edges, per OKF SPEC.md section 5 (absolute bundle-relative links start
+ * with `/`; otherwise links are relative to the linking concept's own
+ * directory). External URLs (citations) are ignored -- only links that
+ * resolve to another concept in the same bundle become graph edges.
+ * Consumers MUST tolerate broken links (SPEC.md section 5), so unresolved
+ * targets are silently skipped rather than treated as errors.
+ */
+export function buildOkfGraph(concepts) {
+  const idSet = new Set(concepts.map((concept) => concept.id));
+  const edges = [];
+  const backlinksById = new Map(concepts.map((concept) => [concept.id, []]));
+
+  for (const concept of concepts) {
+    const conceptDir = path.posix.dirname(concept.relativePath);
+    let match;
+    MARKDOWN_LINK_RE.lastIndex = 0;
+    while ((match = MARKDOWN_LINK_RE.exec(concept.body)) !== null) {
+      const targetId = resolveOkfLinkTarget(match[2], conceptDir);
+      if (targetId && targetId !== concept.id && idSet.has(targetId)) {
+        edges.push({ source: concept.id, target: targetId });
+        backlinksById.get(targetId).push(concept.id);
+      }
+    }
+  }
+  return { edges, backlinksById };
+}
+
+function resolveOkfLinkTarget(rawTarget, conceptDir) {
+  const withoutAnchor = rawTarget.split("#")[0];
+  if (!withoutAnchor || EXTERNAL_URL_RE.test(withoutAnchor)) {
+    return null;
+  }
+  const relPath = withoutAnchor.startsWith("/")
+    ? withoutAnchor.slice(1)
+    : path.posix.join(conceptDir, withoutAnchor);
+  const normalized = path.posix.normalize(relPath);
+  return normalized.endsWith(".md") ? normalized.replace(/\.md$/u, "") : null;
+}
+
+async function walkMarkdownFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const results = [];
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...(await walkMarkdownFiles(fullPath)));
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}

--- a/lib/okf-bundle-reader.mjs
+++ b/lib/okf-bundle-reader.mjs
@@ -177,13 +177,13 @@ export function buildOkfGraph(concepts) {
 }
 
 function resolveOkfLinkTarget(rawTarget, conceptDir) {
-  const withoutAnchor = rawTarget.split("#")[0];
-  if (!withoutAnchor || EXTERNAL_URL_RE.test(withoutAnchor)) {
+  const withoutSuffix = rawTarget.split("#")[0].split("?")[0];
+  if (!withoutSuffix || EXTERNAL_URL_RE.test(withoutSuffix)) {
     return null;
   }
-  const relPath = withoutAnchor.startsWith("/")
-    ? withoutAnchor.slice(1)
-    : path.posix.join(conceptDir, withoutAnchor);
+  const relPath = withoutSuffix.startsWith("/")
+    ? withoutSuffix.slice(1)
+    : path.posix.join(conceptDir, withoutSuffix);
   const normalized = path.posix.normalize(relPath);
   return normalized.endsWith(".md") ? normalized.replace(/\.md$/u, "") : null;
 }

--- a/lib/okf-bundle-visualizer.mjs
+++ b/lib/okf-bundle-visualizer.mjs
@@ -212,13 +212,23 @@ const SCRIPT_BLOCK = `
       '<div class="body">' + bodyHtml + "</div>" +
       backlinksHtml;
 
-    detail.querySelectorAll("a[href$='.md']").forEach(function (a) {
-      a.addEventListener("click", function (evt) {
-        evt.preventDefault();
-        var target = resolveRelativeId(a.getAttribute("href"), id);
-        if (conceptsById[target]) selectNode(target);
+    // Only intercept internal markdown links rendered inside the concept
+    // body (from marked.parse). This excludes the meta-row "source" link,
+    // which can itself point at a .md path (e.g. a proposal file) but is
+    // meant to open externally in a new tab, not be treated as an
+    // in-viewer concept navigation.
+    var bodyEl = detail.querySelector(".body");
+    if (bodyEl) {
+      bodyEl.querySelectorAll("a[href]").forEach(function (a) {
+        var href = a.getAttribute("href");
+        if (!isInternalMarkdownHref(href)) return;
+        a.addEventListener("click", function (evt) {
+          evt.preventDefault();
+          var target = resolveRelativeId(href, id);
+          if (conceptsById[target]) selectNode(target);
+        });
       });
-    });
+    }
     detail.querySelectorAll("button[data-nav]").forEach(function (btn) {
       btn.addEventListener("click", function () { selectNode(btn.getAttribute("data-nav")); });
     });
@@ -235,8 +245,17 @@ const SCRIPT_BLOCK = `
     return result.join("/");
   }
 
+  // Strips a trailing anchor (#...) and/or query string (?...) from an href
+  // before checking whether it points at a markdown file. Links like
+  // "./a2.md#section" or "./a2.md?x=1" are still internal markdown links --
+  // a plain CSS selector requiring the href to literally end in .md would
+  // miss both.
+  function isInternalMarkdownHref(href) {
+    return /\\.md$/.test(href.split("#")[0].split("?")[0]);
+  }
+
   function resolveRelativeId(href, currentId) {
-    var withoutAnchor = href.split("#")[0].replace(/\\.md$/, "");
+    var withoutAnchor = href.split("#")[0].split("?")[0].replace(/\\.md$/, "");
     if (withoutAnchor.indexOf("/") === 0) return normalizePathSegments(withoutAnchor.slice(1));
     var dir = currentId.indexOf("/") >= 0 ? currentId.slice(0, currentId.lastIndexOf("/")) : "";
     var joined = dir ? dir + "/" + withoutAnchor : withoutAnchor;

--- a/lib/okf-bundle-visualizer.mjs
+++ b/lib/okf-bundle-visualizer.mjs
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { writeFile } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 
 const TYPE_PALETTE = Object.freeze([
   "#5da8ff", "#ff9f5d", "#7ee2a8", "#e07df0", "#ffd75d", "#ff6b6b", "#5de0d9", "#c3a1ff",
@@ -76,6 +76,7 @@ export function renderOkfVisualizerHtml({ bundle, name }) {
 
 /** Writes a rendered visualizer HTML string to disk, creating no other files. */
 export async function writeOkfVisualizerHtml(outPath, html) {
+  await mkdir(path.dirname(outPath), { recursive: true });
   await writeFile(outPath, html, "utf8");
   return outPath;
 }
@@ -178,9 +179,14 @@ const SCRIPT_BLOCK = `
 
   function isSafeResourceUrl(url) {
     if (!url) return false;
-    if (/^https?:\\/\\//i.test(url)) return true;
-    if (/^\\/\\//.test(url)) return false;
-    if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return false;
+    // Browsers trim leading/trailing whitespace (and some control chars)
+    // before parsing a URL's scheme, so " javascript:alert(1)" would
+    // otherwise slip past the scheme checks below and still execute.
+    var trimmed = String(url).trim();
+    if (!trimmed) return false;
+    if (/^https?:\\/\\//i.test(trimmed)) return true;
+    if (/^\\/\\//.test(trimmed)) return false;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return false;
     return true;
   }
 

--- a/lib/okf-bundle-visualizer.mjs
+++ b/lib/okf-bundle-visualizer.mjs
@@ -38,9 +38,9 @@ export function renderOkfVisualizerHtml({ bundle, name }) {
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>${displayName} — OKF bundle viewer</title>
-<script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
+<script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js" integrity="sha384-IWROdLKRsN1UuJywMlWl7/blXQ8GEooN2n7dzTxfEPd7ybYIKCUJ2Ol/1Gpf3YV4" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js" integrity="sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js" integrity="sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a" crossorigin="anonymous"></script>
 <style>${STYLE_BLOCK}</style>
 </head>
 <body>
@@ -247,7 +247,21 @@ const SCRIPT_BLOCK = `
     var result = [];
     parts.forEach(function (part) {
       if (part === "" || part === ".") return;
-      if (part === "..") { result.pop(); return; }
+      if (part === "..") {
+        // Only collapse ".." against a real preceding segment. If there's
+        // nothing to pop (or the last segment is itself ".."), the path
+        // escapes above where we started -- keep the ".." so the result
+        // stays a non-matching id, mirroring the server-side reader's
+        // path.posix.normalize() (which also retains unresolvable leading
+        // ".." segments) instead of silently resolving to an unrelated,
+        // possibly valid, concept id.
+        if (result.length && result[result.length - 1] !== "..") {
+          result.pop();
+        } else {
+          result.push("..");
+        }
+        return;
+      }
       result.push(part);
     });
     return result.join("/");

--- a/lib/okf-bundle-visualizer.mjs
+++ b/lib/okf-bundle-visualizer.mjs
@@ -40,6 +40,7 @@ export function renderOkfVisualizerHtml({ bundle, name }) {
 <title>${displayName} — OKF bundle viewer</title>
 <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
 <style>${STYLE_BLOCK}</style>
 </head>
 <body>
@@ -166,26 +167,46 @@ const SCRIPT_BLOCK = `
 
   function slug(v) { return String(v).toLowerCase().replace(/[^a-z0-9]+/g, "-"); }
 
+  function escapeHtml(value) {
+    return String(value)
+      .split("&").join("&amp;")
+      .split("<").join("&lt;")
+      .split(">").join("&gt;")
+      .split("\\"").join("&quot;")
+      .split("'").join("&#39;");
+  }
+
+  function isSafeResourceUrl(url) {
+    if (!url) return false;
+    if (/^https?:\\/\\//i.test(url)) return true;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return false;
+    return true;
+  }
+
   function renderDetail(id) {
     var c = conceptsById[id];
     var detail = document.getElementById("detail");
     if (!c) { detail.innerHTML = '<div class="empty-state">Select a concept node to see its details.</div>'; return; }
     var color = typeColors[c.type] || "#5da8ff";
-    var tagsHtml = (c.tags || []).map(function (t) { return "<span>" + t + "</span>"; }).join("");
-    var bodyHtml = (typeof marked !== "undefined") ? marked.parse(c.body || "") : (c.body || "");
+    var tagsHtml = (c.tags || []).map(function (t) { return "<span>" + escapeHtml(t) + "</span>"; }).join("");
+    var rawBodyHtml = (typeof marked !== "undefined") ? marked.parse(c.body || "") : escapeHtml(c.body || "");
+    var bodyHtml = (typeof DOMPurify !== "undefined") ? DOMPurify.sanitize(rawBodyHtml) : escapeHtml(c.body || "");
     var backlinks = backlinksById[id] || [];
     var backlinksHtml = backlinks.length
       ? "<div class=\\"backlinks\\"><h3>Cited by (" + backlinks.length + ")</h3>" +
         backlinks.map(function (b) {
           var bc = conceptsById[b];
-          return '<button data-nav="' + b + '">' + (bc ? bc.title : b) + "</button>";
+          return '<button data-nav="' + escapeHtml(b) + '">' + escapeHtml(bc ? bc.title : b) + "</button>";
         }).join("") + "</div>"
       : "";
+    var resourceHtml = (c.resource && isSafeResourceUrl(c.resource))
+      ? " &middot; <a href=\\"" + escapeHtml(c.resource) + "\\" target=\\"_blank\\" rel=\\"noopener\\">source</a>"
+      : "";
     detail.innerHTML =
-      "<h2>" + c.title + "</h2>" +
-      '<span class="type-badge" style="background:' + color + '">' + c.type + "</span>" +
-      '<div class="meta">' + (c.timestamp || "") + (c.resource ? " &middot; <a href=\\"" + c.resource + "\\" target=\\"_blank\\" rel=\\"noopener\\">source</a>" : "") + "</div>" +
-      (c.description ? '<div class="meta">' + c.description + "</div>" : "") +
+      "<h2>" + escapeHtml(c.title) + "</h2>" +
+      '<span class="type-badge" style="background:' + color + '">' + escapeHtml(c.type) + "</span>" +
+      '<div class="meta">' + escapeHtml(c.timestamp || "") + resourceHtml + "</div>" +
+      (c.description ? '<div class="meta">' + escapeHtml(c.description) + "</div>" : "") +
       (tagsHtml ? '<div class="tags">' + tagsHtml + "</div>" : "") +
       '<div class="body">' + bodyHtml + "</div>" +
       backlinksHtml;
@@ -202,11 +223,23 @@ const SCRIPT_BLOCK = `
     });
   }
 
+  function normalizePathSegments(pathStr) {
+    var parts = pathStr.split("/");
+    var result = [];
+    parts.forEach(function (part) {
+      if (part === "" || part === ".") return;
+      if (part === "..") { result.pop(); return; }
+      result.push(part);
+    });
+    return result.join("/");
+  }
+
   function resolveRelativeId(href, currentId) {
     var withoutAnchor = href.split("#")[0].replace(/\\.md$/, "");
-    if (withoutAnchor.indexOf("/") === 0) return withoutAnchor.slice(1);
+    if (withoutAnchor.indexOf("/") === 0) return normalizePathSegments(withoutAnchor.slice(1));
     var dir = currentId.indexOf("/") >= 0 ? currentId.slice(0, currentId.lastIndexOf("/")) : "";
-    return dir ? dir + "/" + withoutAnchor : withoutAnchor;
+    var joined = dir ? dir + "/" + withoutAnchor : withoutAnchor;
+    return normalizePathSegments(joined);
   }
 
   function selectNode(id) {

--- a/lib/okf-bundle-visualizer.mjs
+++ b/lib/okf-bundle-visualizer.mjs
@@ -172,13 +172,14 @@ const SCRIPT_BLOCK = `
       .split("&").join("&amp;")
       .split("<").join("&lt;")
       .split(">").join("&gt;")
-      .split("\\"").join("&quot;")
+      .split('"').join("&quot;")
       .split("'").join("&#39;");
   }
 
   function isSafeResourceUrl(url) {
     if (!url) return false;
     if (/^https?:\\/\\//i.test(url)) return true;
+    if (/^\\/\\//.test(url)) return false;
     if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return false;
     return true;
   }

--- a/lib/okf-bundle-visualizer.mjs
+++ b/lib/okf-bundle-visualizer.mjs
@@ -1,0 +1,241 @@
+import path from "node:path";
+import { writeFile } from "node:fs/promises";
+
+const TYPE_PALETTE = Object.freeze([
+  "#5da8ff", "#ff9f5d", "#7ee2a8", "#e07df0", "#ffd75d", "#ff6b6b", "#5de0d9", "#c3a1ff",
+]);
+
+/**
+ * Pure: renders a parsed OKF bundle (see readOkfBundle in okf-bundle-reader.mjs)
+ * into a single self-contained HTML file. Mirrors the `visualize` subcommand
+ * of the OKF reference agent (GoogleCloudPlatform/knowledge-catalog okf/):
+ * a force-directed graph of concepts colored by type, a detail panel with
+ * rendered markdown + backlinks, a search box, and a type filter. Cytoscape.js
+ * and marked are loaded from CDN at view time -- no npm runtime dependency is
+ * added to this zero-dependency package.
+ */
+export function renderOkfVisualizerHtml({ bundle, name }) {
+  const displayName = escapeHtml(name || path.basename(bundle.bundleDir || "") || "OKF Bundle");
+  const payload = {
+    name: name || path.basename(bundle.bundleDir || "") || "OKF Bundle",
+    concepts: bundle.concepts.map((concept) => ({
+      id: concept.id,
+      type: concept.type,
+      title: concept.title,
+      description: concept.description,
+      resource: concept.resource,
+      tags: concept.tags,
+      timestamp: concept.timestamp,
+      body: concept.body,
+    })),
+    edges: bundle.edges,
+  };
+  const embeddedJson = JSON.stringify(payload).replace(/</gu, "\\u003c");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>${displayName} — OKF bundle viewer</title>
+<script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"></script>
+<style>${STYLE_BLOCK}</style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <h1>${displayName}</h1>
+    <div class="controls">
+      <input id="search" type="search" placeholder="Search title, id, or tag..." />
+      <select id="typeFilter"><option value="">All types</option></select>
+      <select id="layoutSelect">
+        <option value="cose">Force-directed (cose)</option>
+        <option value="breadthfirst">Hierarchical</option>
+        <option value="concentric">Concentric</option>
+        <option value="circle">Circle</option>
+        <option value="grid">Grid</option>
+      </select>
+      <span id="stats" class="stats"></span>
+    </div>
+  </header>
+  <main>
+    <div id="graph"></div>
+    <aside id="detail">
+      <div class="empty-state">Select a concept node to see its details.</div>
+    </aside>
+  </main>
+</div>
+<script id="okf-bundle-data" type="application/json">${embeddedJson}</script>
+<script>${SCRIPT_BLOCK}</script>
+</body>
+</html>
+`;
+}
+
+/** Writes a rendered visualizer HTML string to disk, creating no other files. */
+export async function writeOkfVisualizerHtml(outPath, html) {
+  await writeFile(outPath, html, "utf8");
+  return outPath;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll("\"", "&quot;");
+}
+
+export const OKF_VIZ_TYPE_PALETTE = TYPE_PALETTE;
+
+const STYLE_BLOCK = `
+  :root {
+    --bg: #0f1117; --card: #171a23; --border: #262b38; --text: #e6e9f0; --muted: #8b93a7;
+    --accent1: #5da8ff; --accent2: #7ee2a8; --accent3: #ff9f5d;
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  #app { display: flex; flex-direction: column; height: 100vh; }
+  header { padding: 12px 16px; border-bottom: 1px solid var(--border); background: var(--card); }
+  header h1 { margin: 0 0 8px; font-size: 18px; }
+  .controls { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  .controls input, .controls select { background: #0f1117; color: var(--text); border: 1px solid var(--border); border-radius: 6px; padding: 6px 10px; font-size: 13px; }
+  .stats { margin-left: auto; color: var(--muted); font-size: 12px; }
+  main { flex: 1; display: flex; min-height: 0; }
+  #graph { flex: 1; min-width: 0; }
+  #detail { width: 380px; border-left: 1px solid var(--border); background: var(--card); padding: 16px; overflow-y: auto; }
+  #detail .empty-state { color: var(--muted); font-size: 13px; }
+  #detail h2 { margin: 0 0 4px; font-size: 16px; }
+  #detail .type-badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 11px; margin-bottom: 8px; color: #0f1117; font-weight: 600; }
+  #detail .meta { font-size: 12px; color: var(--muted); margin-bottom: 12px; }
+  #detail .tags span { display: inline-block; background: #262b38; border-radius: 10px; padding: 2px 8px; font-size: 11px; margin: 0 4px 4px 0; }
+  #detail .body { font-size: 13px; line-height: 1.5; border-top: 1px solid var(--border); padding-top: 10px; margin-top: 10px; }
+  #detail .body a { color: var(--accent1); }
+  #detail .backlinks { margin-top: 14px; border-top: 1px solid var(--border); padding-top: 10px; }
+  #detail .backlinks h3 { font-size: 12px; text-transform: uppercase; color: var(--muted); margin: 0 0 6px; }
+  #detail .backlinks button { display: block; width: 100%; text-align: left; background: none; border: none; color: var(--accent1); padding: 3px 0; cursor: pointer; font-size: 12px; }
+  #detail .backlinks button:hover { text-decoration: underline; }
+`;
+
+const SCRIPT_BLOCK = `
+(function () {
+  var bundle = JSON.parse(document.getElementById("okf-bundle-data").textContent);
+  var palette = ${JSON.stringify(TYPE_PALETTE)};
+  var typeColors = {};
+  var types = Array.from(new Set(bundle.concepts.map(function (c) { return c.type; }))).sort();
+  types.forEach(function (t, i) { typeColors[t] = palette[i % palette.length]; });
+
+  var conceptsById = {};
+  bundle.concepts.forEach(function (c) { conceptsById[c.id] = c; });
+  var backlinksById = {};
+  bundle.concepts.forEach(function (c) { backlinksById[c.id] = []; });
+  bundle.edges.forEach(function (e) {
+    if (backlinksById[e.target]) backlinksById[e.target].push(e.source);
+  });
+
+  var typeFilterEl = document.getElementById("typeFilter");
+  types.forEach(function (t) {
+    var opt = document.createElement("option");
+    opt.value = t; opt.textContent = t;
+    typeFilterEl.appendChild(opt);
+  });
+  document.getElementById("stats").textContent = bundle.concepts.length + " concepts, " + bundle.edges.length + " links";
+
+  var elements = bundle.concepts.map(function (c) {
+    return { data: { id: c.id, label: c.title, type: c.type }, classes: "type-" + slug(c.type) };
+  }).concat(bundle.edges.map(function (e) {
+    return { data: { source: e.source, target: e.target } };
+  }));
+
+  var cy = cytoscape({
+    container: document.getElementById("graph"),
+    elements: elements,
+    style: [
+      { selector: "node", style: {
+          "background-color": function (ele) { return typeColors[ele.data("type")] || "#5da8ff"; },
+          "label": "data(label)", "color": "#e6e9f0", "font-size": 9,
+          "text-valign": "bottom", "text-margin-y": 4, "width": 22, "height": 22, "text-wrap": "ellipsis", "text-max-width": "90px",
+      } },
+      { selector: "edge", style: { "width": 1, "line-color": "#3a4152", "target-arrow-color": "#3a4152", "target-arrow-shape": "triangle", "curve-style": "bezier", "arrow-scale": 0.6 } },
+      { selector: ".faded", style: { "opacity": 0.12 } },
+      { selector: "node:selected", style: { "border-width": 3, "border-color": "#ffd75d" } },
+    ],
+    layout: { name: "cose", animate: false },
+  });
+
+  function slug(v) { return String(v).toLowerCase().replace(/[^a-z0-9]+/g, "-"); }
+
+  function renderDetail(id) {
+    var c = conceptsById[id];
+    var detail = document.getElementById("detail");
+    if (!c) { detail.innerHTML = '<div class="empty-state">Select a concept node to see its details.</div>'; return; }
+    var color = typeColors[c.type] || "#5da8ff";
+    var tagsHtml = (c.tags || []).map(function (t) { return "<span>" + t + "</span>"; }).join("");
+    var bodyHtml = (typeof marked !== "undefined") ? marked.parse(c.body || "") : (c.body || "");
+    var backlinks = backlinksById[id] || [];
+    var backlinksHtml = backlinks.length
+      ? "<div class=\\"backlinks\\"><h3>Cited by (" + backlinks.length + ")</h3>" +
+        backlinks.map(function (b) {
+          var bc = conceptsById[b];
+          return '<button data-nav="' + b + '">' + (bc ? bc.title : b) + "</button>";
+        }).join("") + "</div>"
+      : "";
+    detail.innerHTML =
+      "<h2>" + c.title + "</h2>" +
+      '<span class="type-badge" style="background:' + color + '">' + c.type + "</span>" +
+      '<div class="meta">' + (c.timestamp || "") + (c.resource ? " &middot; <a href=\\"" + c.resource + "\\" target=\\"_blank\\" rel=\\"noopener\\">source</a>" : "") + "</div>" +
+      (c.description ? '<div class="meta">' + c.description + "</div>" : "") +
+      (tagsHtml ? '<div class="tags">' + tagsHtml + "</div>" : "") +
+      '<div class="body">' + bodyHtml + "</div>" +
+      backlinksHtml;
+
+    detail.querySelectorAll("a[href$='.md']").forEach(function (a) {
+      a.addEventListener("click", function (evt) {
+        evt.preventDefault();
+        var target = resolveRelativeId(a.getAttribute("href"), id);
+        if (conceptsById[target]) selectNode(target);
+      });
+    });
+    detail.querySelectorAll("button[data-nav]").forEach(function (btn) {
+      btn.addEventListener("click", function () { selectNode(btn.getAttribute("data-nav")); });
+    });
+  }
+
+  function resolveRelativeId(href, currentId) {
+    var withoutAnchor = href.split("#")[0].replace(/\\.md$/, "");
+    if (withoutAnchor.indexOf("/") === 0) return withoutAnchor.slice(1);
+    var dir = currentId.indexOf("/") >= 0 ? currentId.slice(0, currentId.lastIndexOf("/")) : "";
+    return dir ? dir + "/" + withoutAnchor : withoutAnchor;
+  }
+
+  function selectNode(id) {
+    cy.elements().unselect();
+    var node = cy.getElementById(id);
+    if (node && node.length) { node.select(); cy.animate({ center: { eles: node } }, { duration: 200 }); }
+    renderDetail(id);
+  }
+
+  cy.on("tap", "node", function (evt) { renderDetail(evt.target.id()); });
+
+  document.getElementById("layoutSelect").addEventListener("change", function (evt) {
+    cy.layout({ name: evt.target.value, animate: false }).run();
+  });
+
+  function applyFilters() {
+    var query = document.getElementById("search").value.trim().toLowerCase();
+    var typeFilter = typeFilterEl.value;
+    cy.nodes().forEach(function (node) {
+      var c = conceptsById[node.id()];
+      var matchesType = !typeFilter || c.type === typeFilter;
+      var matchesQuery = !query ||
+        c.title.toLowerCase().indexOf(query) >= 0 ||
+        c.id.toLowerCase().indexOf(query) >= 0 ||
+        (c.tags || []).some(function (t) { return t.toLowerCase().indexOf(query) >= 0; });
+      node.toggleClass("faded", !(matchesType && matchesQuery));
+    });
+  }
+  document.getElementById("search").addEventListener("input", applyFilters);
+  typeFilterEl.addEventListener("change", applyFilters);
+})();
+`;

--- a/lib/okf-bundle-visualizer.mjs
+++ b/lib/okf-bundle-visualizer.mjs
@@ -221,11 +221,13 @@ const SCRIPT_BLOCK = `
     if (bodyEl) {
       bodyEl.querySelectorAll("a[href]").forEach(function (a) {
         var href = a.getAttribute("href");
-        if (!isInternalMarkdownHref(href)) return;
+        if (!isInternalMarkdownHref(href) || isAbsoluteHref(href)) return;
         a.addEventListener("click", function (evt) {
-          evt.preventDefault();
           var target = resolveRelativeId(href, id);
-          if (conceptsById[target]) selectNode(target);
+          if (conceptsById[target]) {
+            evt.preventDefault();
+            selectNode(target);
+          }
         });
       });
     }
@@ -252,6 +254,14 @@ const SCRIPT_BLOCK = `
   // miss both.
   function isInternalMarkdownHref(href) {
     return /\\.md$/.test(href.split("#")[0].split("?")[0]);
+  }
+
+  // True for absolute URLs (scheme:// or protocol-relative //host/...).
+  // These are never treated as in-viewer concept navigation, even when they
+  // happen to end in ".md" (e.g. an external markdown citation) -- they
+  // should navigate normally, not be intercepted and silently swallowed.
+  function isAbsoluteHref(href) {
+    return /^[a-z][a-z0-9+.-]*:/i.test(href) || /^\\/\\//.test(href);
   }
 
   function resolveRelativeId(href, currentId) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "lint": "oxlint lib/ extension.mjs browser/server.mjs scripts/",
     "dev-install": "node scripts/dev-install.mjs",
     "maintenance": "node scripts/run-maintenance.mjs",
-    "browser": "node scripts/run-browser.mjs"
+    "browser": "node scripts/run-browser.mjs",
+    "visualize-okf": "node scripts/visualize-okf-bundle.mjs"
   },
   "license": "MIT",
   "private": true,

--- a/scripts/visualize-okf-bundle.mjs
+++ b/scripts/visualize-okf-bundle.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import path from "node:path";
+import { existsSync, statSync } from "node:fs";
+
+import { readOkfBundle } from "../lib/okf-bundle-reader.mjs";
+import { renderOkfVisualizerHtml, writeOkfVisualizerHtml } from "../lib/okf-bundle-visualizer.mjs";
+
+function parseArgs(argv) {
+  const args = { bundle: null, out: null, name: null };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--bundle") {
+      args.bundle = argv[index + 1];
+      index += 1;
+    } else if (arg === "--out") {
+      args.out = argv[index + 1];
+      index += 1;
+    } else if (arg === "--name") {
+      args.name = argv[index + 1];
+      index += 1;
+    } else if (arg === "--help" || arg === "-h") {
+      args.help = true;
+    }
+  }
+  return args;
+}
+
+function printUsage() {
+  console.log(`Usage: node scripts/visualize-okf-bundle.mjs --bundle <dir> [--out <file>] [--name <label>]
+
+Renders a self-contained HTML viewer for an Open Knowledge Format (OKF v0.1)
+bundle -- a force-directed graph of concepts with a searchable detail panel,
+backlinks, and type filter. Mirrors the "visualize" subcommand of the OKF
+reference agent (GoogleCloudPlatform/knowledge-catalog okf/).
+
+  --bundle <dir>   Path to the OKF bundle directory (must contain index.md). Required.
+  --out <file>     Output HTML path. Defaults to <bundle>/viz.html.
+  --name <label>   Display name shown in the viewer header. Defaults to the bundle directory name.
+`);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help || !args.bundle) {
+    printUsage();
+    process.exitCode = args.help ? 0 : 1;
+    return;
+  }
+  const bundleDir = path.resolve(process.cwd(), args.bundle);
+  if (!existsSync(bundleDir) || !statSync(bundleDir).isDirectory()) {
+    console.error(`Bundle directory not found: ${bundleDir}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const bundle = await readOkfBundle(bundleDir);
+  const html = renderOkfVisualizerHtml({ bundle, name: args.name });
+  const outPath = args.out ? path.resolve(process.cwd(), args.out) : path.join(bundleDir, "viz.html");
+  await writeOkfVisualizerHtml(outPath, html);
+
+  console.log(`Wrote OKF bundle viewer: ${outPath}`);
+  console.log(`  concepts: ${bundle.concepts.length}`);
+  console.log(`  links: ${bundle.edges.length}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : error);
+  process.exitCode = 1;
+});

--- a/tests/unit/memory-tools-okf-bundle.test.mjs
+++ b/tests/unit/memory-tools-okf-bundle.test.mjs
@@ -170,4 +170,20 @@ describe("formatOkfBundleResult", () => {
     assert.match(report, /repository: global/u);
     assert.match(report, /exportedImprovementCount: 0/u);
   });
+
+  it("reports bundlePath relative to the Lore package root, not an ancestor of it", () => {
+    // This module lives at <repo>/lib/memory-tools-okf-bundle.mjs, one level
+    // below the actual repo root. repoRootFromModule() previously resolved
+    // three levels up (landing outside the repo), which produced a
+    // bundlePath with a leading "../..".
+    const repoRoot = path.resolve(new URL("../../", import.meta.url).pathname);
+    const bundleDir = path.join(repoRoot, "tmp", "okf-bundle");
+    const report = formatOkfBundleResult({
+      bundleDir,
+      repository: "acme/widgets",
+      exportedArtifactCount: 1,
+    });
+    assert.match(report, /bundlePath: tmp\/okf-bundle/u);
+    assert.ok(!report.includes(".."), `expected no ".." in bundlePath, got: ${report}`);
+  });
 });

--- a/tests/unit/memory-tools-okf-bundle.test.mjs
+++ b/tests/unit/memory-tools-okf-bundle.test.mjs
@@ -1,0 +1,173 @@
+/**
+ * tests/unit/memory-tools-okf-bundle.test.mjs
+ *
+ * Unit tests for lib/memory-tools-okf-bundle.mjs.
+ *
+ * Covers:
+ *   - buildOkfBundleDocuments: OKF v0.1 conformance (parseable frontmatter,
+ *     non-empty `type` on every concept file, no frontmatter on nested
+ *     index files besides the bundle-root one), slug collision handling,
+ *     and empty-artifact-list behavior.
+ *   - writeOkfBundle: writes the generated documents to disk under the
+ *     requested directory, creating subdirectories as needed.
+ *   - formatOkfBundleResult: human-readable export report shape.
+ *
+ * Run:
+ *   node --test tests/unit/memory-tools-okf-bundle.test.mjs
+ */
+
+import { it, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  buildOkfBundleDocuments,
+  writeOkfBundle,
+  formatOkfBundleResult,
+} from "../../lib/memory-tools-okf-bundle.mjs";
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(os.tmpdir(), "lore-okf-bundle-test-"));
+}
+
+function sampleArtifacts() {
+  return [
+    {
+      id: "artifact-1",
+      sourceCaseId: "case-1",
+      sourceKind: "session_review",
+      title: "Tighten retry backoff",
+      summary: "Reduce retry storms during transient network errors.",
+      status: "approved",
+      reviewState: "approved",
+      proposal: { type: "diff", path: "docs/proposals/retry.md", hash: "abc123" },
+      evidence: { occurrences: 3 },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    },
+    {
+      id: "artifact-2",
+      sourceCaseId: "case-2",
+      sourceKind: "replay_signal",
+      title: "Improve day-summary fallback",
+      summary: undefined,
+      status: "approved",
+      reviewState: "approved",
+      proposal: {},
+      evidence: {},
+      createdAt: "2026-01-03T00:00:00.000Z",
+      updatedAt: undefined,
+    },
+  ];
+}
+
+describe("buildOkfBundleDocuments", () => {
+  it("produces a bundle-root index.md with only okf_version frontmatter", () => {
+    const documents = buildOkfBundleDocuments({
+      repository: "acme/widgets",
+      improvementArtifacts: sampleArtifacts(),
+      exportedAt: "2026-01-05T00:00:00.000Z",
+    });
+    const index = documents.find((doc) => doc.relativePath === "index.md");
+    assert.ok(index, "expected an index.md document");
+    assert.match(index.contents, /^---\nokf_version: "0\.1"\n---\n/u);
+    assert.match(index.contents, /acme\/widgets/u);
+  });
+
+  it("emits one concept file per artifact with a non-empty required `type` field", () => {
+    const artifacts = sampleArtifacts();
+    const documents = buildOkfBundleDocuments({ improvementArtifacts: artifacts });
+    const concepts = documents.filter((doc) => doc.relativePath !== "index.md");
+    assert.strictEqual(concepts.length, artifacts.length);
+    for (const concept of concepts) {
+      assert.match(concept.relativePath, /^artifacts\/.+\.md$/u);
+      const frontmatterMatch = concept.contents.match(/^---\n([\s\S]*?)\n---/u);
+      assert.ok(frontmatterMatch, `missing frontmatter block in ${concept.relativePath}`);
+      assert.match(frontmatterMatch[1], /type: "Improvement Artifact"/u);
+    }
+  });
+
+  it("links every concept from the index body", () => {
+    const documents = buildOkfBundleDocuments({ improvementArtifacts: sampleArtifacts() });
+    const index = documents.find((doc) => doc.relativePath === "index.md");
+    const concepts = documents.filter((doc) => doc.relativePath !== "index.md");
+    for (const concept of concepts) {
+      assert.ok(
+        index.contents.includes(`(${concept.relativePath})`),
+        `index.md should link to ${concept.relativePath}`,
+      );
+    }
+  });
+
+  it("de-duplicates slugs derived from colliding artifact ids", () => {
+    const artifacts = [
+      { id: "Same ID!", title: "First" },
+      { id: "same id", title: "Second" },
+    ];
+    const documents = buildOkfBundleDocuments({ improvementArtifacts: artifacts });
+    const paths = documents.filter((doc) => doc.relativePath !== "index.md").map((doc) => doc.relativePath);
+    assert.strictEqual(new Set(paths).size, paths.length, "expected unique concept paths");
+  });
+
+  it("handles an empty artifact list gracefully", () => {
+    const documents = buildOkfBundleDocuments({ improvementArtifacts: [] });
+    assert.strictEqual(documents.length, 1);
+    assert.match(documents[0].contents, /No approved improvement artifacts to export/u);
+  });
+
+  it("preserves proposal and evidence details in the concept body", () => {
+    const documents = buildOkfBundleDocuments({ improvementArtifacts: sampleArtifacts() });
+    const first = documents.find((doc) => doc.relativePath === "artifacts/artifact-1.md");
+    assert.ok(first, "expected artifacts/artifact-1.md to exist");
+    assert.match(first.contents, /# Proposal/u);
+    assert.match(first.contents, /docs\/proposals\/retry\.md/u);
+    assert.match(first.contents, /# Evidence/u);
+    assert.match(first.contents, /"occurrences": 3/u);
+  });
+});
+
+describe("writeOkfBundle", () => {
+  it("writes generated documents to disk, creating subdirectories as needed", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const bundleDir = path.join(tmpDir, "bundle");
+      const documents = buildOkfBundleDocuments({ improvementArtifacts: sampleArtifacts() });
+      await writeOkfBundle(bundleDir, documents);
+
+      assert.ok(existsSync(path.join(bundleDir, "index.md")));
+      for (const doc of documents) {
+        const fullPath = path.join(bundleDir, doc.relativePath);
+        assert.ok(existsSync(fullPath), `expected ${doc.relativePath} to exist`);
+        assert.strictEqual(readFileSync(fullPath, "utf8"), doc.contents);
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("is a no-op when bundleDir is falsy", async () => {
+    await assert.doesNotReject(() => writeOkfBundle(null, [{ relativePath: "index.md", contents: "x" }]));
+  });
+});
+
+describe("formatOkfBundleResult", () => {
+  it("reports format, repository, and exported count", () => {
+    const report = formatOkfBundleResult({
+      bundleDir: null,
+      repository: "acme/widgets",
+      exportedArtifactCount: 2,
+    });
+    assert.match(report, /format: okf/u);
+    assert.match(report, /repository: acme\/widgets/u);
+    assert.match(report, /exportedImprovementCount: 2/u);
+    assert.match(report, /bundlePath: inline/u);
+  });
+
+  it("defaults repository to global and count to 0", () => {
+    const report = formatOkfBundleResult({ bundleDir: null });
+    assert.match(report, /repository: global/u);
+    assert.match(report, /exportedImprovementCount: 0/u);
+  });
+});

--- a/tests/unit/memory-tools-portable-bundle.test.mjs
+++ b/tests/unit/memory-tools-portable-bundle.test.mjs
@@ -1,0 +1,181 @@
+/**
+ * tests/unit/memory-tools-portable-bundle.test.mjs
+ *
+ * Unit/integration tests for the memory_portable_bundle tool handler
+ * (lib/memory-tools-builders.mjs) and its row-mapping helper
+ * (lib/memory-tools-portable-bundle.mjs).
+ *
+ * Covers:
+ *   - mapImprovementArtifactRow: converts a raw snake_case DB row into the
+ *     camelCase portable-bundle artifact shape (sourceCaseId, reviewState,
+ *     nested proposal object, createdAt/updatedAt).
+ *   - memory_portable_bundle tool handler, format=json: end-to-end against
+ *     a real fixture DB, asserting the exported artifact shape.
+ *   - memory_portable_bundle tool handler, format=okf: end-to-end against
+ *     a real fixture DB, asserting the generated concept frontmatter
+ *     (reviewState, timestamp, resource, tags) is populated from the raw DB
+ *     row via the same mapping used for format=json -- this is a regression
+ *     test for a review finding where the okf branch passed raw DB rows
+ *     directly into buildOkfBundleDocuments, which expects the mapped
+ *     camelCase shape.
+ *
+ * Run:
+ *   node --test tests/unit/memory-tools-portable-bundle.test.mjs
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+
+import { createMemoryTools } from "../../lib/memory-tools.mjs";
+import { mapImprovementArtifactRow } from "../../lib/memory-tools-portable-bundle.mjs";
+import { FTS5_AVAILABLE, withFixtureDb } from "../helpers/fixture-db.mjs";
+import { findTool } from "../helpers/tool-helpers.mjs";
+
+const SKIP_NO_FTS5 = !FTS5_AVAILABLE
+  ? "FTS5 not compiled into this Node.js SQLite build (Copilot CLI runtime has it; check your local Node install)"
+  : false;
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(os.tmpdir(), "lore-portable-bundle-test-"));
+}
+
+function buildRuntime(db, config, overrides = {}) {
+  return {
+    initialized: true,
+    lastError: null,
+    db,
+    config,
+    repository: "fixture-repo",
+    ...overrides,
+  };
+}
+
+async function setupFixtureTools(configOverrides = {}, runtimeOverrides = {}) {
+  const fixture = await withFixtureDb({ configOverrides });
+  return {
+    ...fixture,
+    tools: createMemoryTools({
+      getRuntime: async () => buildRuntime(fixture.db, fixture.config, runtimeOverrides),
+    }),
+  };
+}
+
+/** Inserts an approved, proposal-backed improvement artifact so it is picked up by listImprovementArtifacts({reviewState: "approved", hasProposal: true}). */
+function seedApprovedArtifact(db) {
+  const id = db.upsertImprovementArtifact({
+    sourceCaseId: "case-portable-1",
+    sourceKind: "session_review",
+    title: "Tighten retry backoff",
+    summary: "Reduce retry storms during transient network errors.",
+    evidence: { occurrences: 3 },
+  });
+  db.setImprovementArtifactProposal({
+    id,
+    proposalType: "diff",
+    proposalPath: "docs/proposals/retry.md",
+    proposalHash: "abc123",
+    reviewState: "approved",
+  });
+  return id;
+}
+
+describe("mapImprovementArtifactRow", () => {
+  test("converts a raw snake_case DB row into the camelCase portable-bundle shape", () => {
+    const row = {
+      id: "artifact-1",
+      source_case_id: "case-1",
+      source_kind: "session_review",
+      title: "Tighten retry backoff",
+      summary: "Reduce retry storms.",
+      status: "active",
+      review_state: "approved",
+      proposal_type: "diff",
+      proposal_path: "docs/proposals/retry.md",
+      proposal_hash: "abc123",
+      evidence: { occurrences: 3 },
+      trace: { signal: "router" },
+      created_at: "2026-01-01T00:00:00.000Z",
+      updated_at: "2026-01-02T00:00:00.000Z",
+    };
+    assert.deepEqual(mapImprovementArtifactRow(row), {
+      id: "artifact-1",
+      sourceCaseId: "case-1",
+      sourceKind: "session_review",
+      title: "Tighten retry backoff",
+      summary: "Reduce retry storms.",
+      status: "active",
+      reviewState: "approved",
+      proposal: { type: "diff", path: "docs/proposals/retry.md", hash: "abc123" },
+      evidence: { occurrences: 3 },
+      trace: { signal: "router" },
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+  });
+
+  test("defaults reviewState to 'none' and proposal fields to null when absent", () => {
+    const mapped = mapImprovementArtifactRow({ id: "artifact-2", title: "No proposal yet" });
+    assert.equal(mapped.reviewState, "none");
+    assert.deepEqual(mapped.proposal, { type: null, path: null, hash: null });
+    assert.deepEqual(mapped.evidence, {});
+    assert.deepEqual(mapped.trace, {});
+  });
+});
+
+describe("memory_portable_bundle tool handler", () => {
+  test("format=json exports approved artifacts using the mapped camelCase shape", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      seedApprovedArtifact(db);
+      const tool = findTool(tools, "memory_portable_bundle");
+      const bundlePath = path.join(tmpDir, "bundle.json");
+      const output = await tool.handler({ bundlePath, format: "json" }, { sessionId: "portable-json" });
+
+      assert.match(output, /exportedImprovementCount: 1/);
+      const bundle = JSON.parse(readFileSync(bundlePath, "utf8"));
+      const [artifact] = bundle.data.improvementArtifacts;
+      assert.equal(artifact.reviewState, "approved");
+      assert.equal(artifact.sourceCaseId, "case-portable-1");
+      assert.equal(artifact.proposal.path, "docs/proposals/retry.md");
+      assert.ok(artifact.updatedAt || artifact.createdAt);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  test("format=okf exports approved artifacts with reviewState/timestamp/resource/tags populated from DB rows", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      seedApprovedArtifact(db);
+      const tool = findTool(tools, "memory_portable_bundle");
+      const bundleDir = path.join(tmpDir, "okf-bundle");
+      const output = await tool.handler({ bundlePath: bundleDir, format: "okf" }, { sessionId: "portable-okf" });
+
+      assert.match(output, /format: okf/);
+      assert.match(output, /exportedImprovementCount: 1/);
+
+      const conceptFiles = readdirSync(path.join(bundleDir, "artifacts"));
+      assert.equal(conceptFiles.length, 1, "expected exactly one exported concept file");
+      const contents = readFileSync(path.join(bundleDir, "artifacts", conceptFiles[0]), "utf8");
+
+      // Regression coverage: these fields all come from a raw DB row
+      // (source_case_id, review_state, updated_at, proposal_path) and were
+      // previously dropped/undefined because the okf branch skipped the
+      // row -> camelCase mapping step that format=json uses.
+      assert.match(contents, /reviewState: "approved"/);
+      assert.match(contents, /sourceCaseId: "case-portable-1"/);
+      assert.match(contents, /resource: "docs\/proposals\/retry\.md"/);
+      assert.match(contents, /tags:\s*\[[^\]]*"approved"[^\]]*\]/);
+      assert.match(contents, /timestamp: "\d{4}-\d{2}-\d{2}T/);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+});

--- a/tests/unit/memory-tools-portable-bundle.test.mjs
+++ b/tests/unit/memory-tools-portable-bundle.test.mjs
@@ -30,7 +30,10 @@ import path from "node:path";
 import { describe, test } from "node:test";
 
 import { createMemoryTools } from "../../lib/memory-tools.mjs";
-import { mapImprovementArtifactRow } from "../../lib/memory-tools-portable-bundle.mjs";
+import {
+  buildPortableBundleRequest,
+  mapImprovementArtifactRow,
+} from "../../lib/memory-tools-portable-bundle.mjs";
 import { FTS5_AVAILABLE, withFixtureDb } from "../helpers/fixture-db.mjs";
 import { findTool } from "../helpers/tool-helpers.mjs";
 
@@ -177,5 +180,23 @@ describe("memory_portable_bundle tool handler", () => {
       rmSync(tmpDir, { recursive: true, force: true });
       cleanup();
     }
+  });
+});
+
+describe("resolveBundlePath (via buildPortableBundleRequest)", () => {
+  test("resolves a relative bundlePath against the Lore package root, not an ancestor of it", () => {
+    // The Lore extension is its own git repo, rooted at extensions/lore (one
+    // level above lib/, where this module lives). bundlePath is documented
+    // as "repository-relative", so a relative path must land inside that
+    // repo root -- not several levels above it.
+    const repoRoot = path.resolve(new URL("../../", import.meta.url).pathname);
+    const request = buildPortableBundleRequest({ bundlePath: "bundle.json" }, { repository: null });
+    assert.equal(request.bundlePath, path.join(repoRoot, "bundle.json"));
+  });
+
+  test("leaves an absolute bundlePath untouched", () => {
+    const absolute = path.join(os.tmpdir(), "somewhere", "bundle.json");
+    const request = buildPortableBundleRequest({ bundlePath: absolute }, { repository: null });
+    assert.equal(request.bundlePath, absolute);
   });
 });

--- a/tests/unit/okf-bundle-reader.test.mjs
+++ b/tests/unit/okf-bundle-reader.test.mjs
@@ -1,0 +1,182 @@
+/**
+ * tests/unit/okf-bundle-reader.test.mjs
+ *
+ * Unit tests for lib/okf-bundle-reader.mjs.
+ *
+ * Covers:
+ *   - parseFrontmatterYaml: flat key/value pairs, flow arrays, quoted and
+ *     bare scalars, numbers/booleans/null.
+ *   - parseOkfDocument: frontmatter/body split, and the no-frontmatter
+ *     fallback.
+ *   - buildOkfGraph: absolute (bundle-root-relative) and relative internal
+ *     link resolution into edges + backlinks, external URLs ignored, and
+ *     broken/unknown links tolerated (per OKF SPEC.md section 5).
+ *   - readOkfBundle: full round-trip against a real bundle written by
+ *     writeOkfBundle (lib/memory-tools-okf-bundle.mjs), including the
+ *     reserved index.md/log.md filenames being excluded from concepts.
+ *
+ * Run:
+ *   node --test tests/unit/okf-bundle-reader.test.mjs
+ */
+
+import { it, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  parseFrontmatterYaml,
+  parseOkfDocument,
+  buildConceptFromDocument,
+  buildOkfGraph,
+  readOkfBundle,
+} from "../../lib/okf-bundle-reader.mjs";
+import { buildOkfBundleDocuments, writeOkfBundle } from "../../lib/memory-tools-okf-bundle.mjs";
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(os.tmpdir(), "lore-okf-reader-test-"));
+}
+
+describe("parseFrontmatterYaml", () => {
+  it("parses flat scalars, quoted strings, numbers, booleans, and null", () => {
+    const parsed = parseFrontmatterYaml(
+      [
+        "type: BigQuery Table",
+        'title: "Customer Orders"',
+        "count: 42",
+        "ratio: 1.5",
+        "active: true",
+        "archived: false",
+        "owner: null",
+      ].join("\n"),
+    );
+    assert.equal(parsed.type, "BigQuery Table");
+    assert.equal(parsed.title, "Customer Orders");
+    assert.equal(parsed.count, 42);
+    assert.equal(parsed.ratio, 1.5);
+    assert.equal(parsed.active, true);
+    assert.equal(parsed.archived, false);
+    assert.equal(parsed.owner, null);
+  });
+
+  it("parses flow arrays with bare and quoted items", () => {
+    const parsed = parseFrontmatterYaml('tags: [sales, "orders, revenue", approved]');
+    assert.deepEqual(parsed.tags, ["sales", "orders, revenue", "approved"]);
+  });
+
+  it("parses an empty flow array", () => {
+    const parsed = parseFrontmatterYaml("tags: []");
+    assert.deepEqual(parsed.tags, []);
+  });
+
+  it("ignores comments and blank lines", () => {
+    const parsed = parseFrontmatterYaml("# a comment\n\ntype: Concept\n");
+    assert.deepEqual(parsed, { type: "Concept" });
+  });
+});
+
+describe("parseOkfDocument", () => {
+  it("splits frontmatter from body", () => {
+    const raw = "---\ntype: Concept\ntitle: Example\n---\n\n# Example\n\nBody text.\n";
+    const { frontmatter, body } = parseOkfDocument(raw);
+    assert.equal(frontmatter.type, "Concept");
+    assert.equal(frontmatter.title, "Example");
+    assert.equal(body, "# Example\n\nBody text.\n");
+  });
+
+  it("treats content with no frontmatter delimiters as body-only", () => {
+    const raw = "# Just markdown\n\nNo frontmatter here.\n";
+    const { frontmatter, body } = parseOkfDocument(raw);
+    assert.deepEqual(frontmatter, {});
+    assert.equal(body, raw);
+  });
+});
+
+describe("buildConceptFromDocument", () => {
+  it("defaults type to Concept and title to the concept id when absent", () => {
+    const concept = buildConceptFromDocument("artifacts/a1.md", "---\n---\nBody\n");
+    assert.equal(concept.id, "artifacts/a1");
+    assert.equal(concept.type, "Concept");
+    assert.equal(concept.title, "artifacts/a1");
+    assert.deepEqual(concept.tags, []);
+  });
+});
+
+describe("buildOkfGraph", () => {
+  function concept(relativePath, body, overrides = {}) {
+    return {
+      id: relativePath.replace(/\.md$/u, ""),
+      relativePath,
+      type: "Concept",
+      title: relativePath,
+      body,
+      ...overrides,
+    };
+  }
+
+  it("resolves bundle-root-relative absolute links", () => {
+    const concepts = [
+      concept("artifacts/a1.md", "See [related](/artifacts/a2.md)."),
+      concept("artifacts/a2.md", "No links here."),
+    ];
+    const { edges, backlinksById } = buildOkfGraph(concepts);
+    assert.deepEqual(edges, [{ source: "artifacts/a1", target: "artifacts/a2" }]);
+    assert.deepEqual(backlinksById.get("artifacts/a2"), ["artifacts/a1"]);
+  });
+
+  it("resolves relative links against the linking concept's own directory", () => {
+    const concepts = [
+      concept("artifacts/a1.md", "See [related](./a2.md) and [up](../index.md)."),
+      concept("artifacts/a2.md", "No links here."),
+    ];
+    const { edges } = buildOkfGraph(concepts);
+    assert.deepEqual(edges, [{ source: "artifacts/a1", target: "artifacts/a2" }]);
+  });
+
+  it("ignores external URLs and unresolved/broken links", () => {
+    const concepts = [
+      concept("artifacts/a1.md", "See [external](https://example.com/a2.md) and [missing](./missing.md)."),
+    ];
+    const { edges } = buildOkfGraph(concepts);
+    assert.deepEqual(edges, []);
+  });
+
+  it("does not self-link", () => {
+    const concepts = [concept("artifacts/a1.md", "See [self](./a1.md).")];
+    const { edges } = buildOkfGraph(concepts);
+    assert.deepEqual(edges, []);
+  });
+});
+
+describe("readOkfBundle (round-trip against writeOkfBundle)", () => {
+  it("reads back concepts written by writeOkfBundle and excludes reserved filenames", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const artifacts = [
+        {
+          id: "artifact-1",
+          sourceCaseId: "case-1",
+          sourceKind: "session_review",
+          title: "Tighten retry backoff",
+          summary: "Reduce retry storms during transient network errors.",
+          status: "approved",
+          reviewState: "approved",
+          proposal: { type: "diff", path: "docs/proposals/retry.md", hash: "abc123" },
+          evidence: { occurrences: 3 },
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+        },
+      ];
+      const documents = buildOkfBundleDocuments({ improvementArtifacts: artifacts });
+      await writeOkfBundle(tmpDir, documents);
+
+      const bundle = await readOkfBundle(tmpDir);
+      assert.equal(bundle.concepts.length, 1);
+      assert.equal(bundle.concepts[0].type.length > 0, true);
+      assert.ok(!bundle.concepts.some((concept) => concept.relativePath.endsWith("index.md")));
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/okf-bundle-reader.test.mjs
+++ b/tests/unit/okf-bundle-reader.test.mjs
@@ -164,6 +164,23 @@ describe("buildOkfGraph", () => {
     const { edges } = buildOkfGraph(concepts);
     assert.deepEqual(edges, []);
   });
+
+  it("resolves relative links that include a trailing anchor and/or query string", () => {
+    const concepts = [
+      concept(
+        "artifacts/a1.md",
+        "See [anchor](./a2.md#section), [query](./a2.md?x=1) and [both](./a2.md?x=1#section).",
+      ),
+      concept("artifacts/a2.md", "No links here."),
+    ];
+    const { edges, backlinksById } = buildOkfGraph(concepts);
+    assert.deepEqual(edges, [
+      { source: "artifacts/a1", target: "artifacts/a2" },
+      { source: "artifacts/a1", target: "artifacts/a2" },
+      { source: "artifacts/a1", target: "artifacts/a2" },
+    ]);
+    assert.deepEqual(backlinksById.get("artifacts/a2"), ["artifacts/a1", "artifacts/a1", "artifacts/a1"]);
+  });
 });
 
 describe("readOkfBundle (round-trip against writeOkfBundle)", () => {

--- a/tests/unit/okf-bundle-reader.test.mjs
+++ b/tests/unit/okf-bundle-reader.test.mjs
@@ -74,6 +74,23 @@ describe("parseFrontmatterYaml", () => {
     const parsed = parseFrontmatterYaml("# a comment\n\ntype: Concept\n");
     assert.deepEqual(parsed, { type: "Concept" });
   });
+
+  it("round-trips JSON-escaped double-quoted scalars written by yamlScalar (backslashes, newlines, tabs, unicode)", () => {
+    // yamlFrontmatter()/yamlScalar() in memory-tools-okf-bundle.mjs always
+    // serializes double-quoted scalars via JSON.stringify, so the reader
+    // must reverse full JSON escaping, not just \" -> ".
+    const value = "C:\\Users\\test\tline1\nline2 \u2603";
+    const line = "title: " + JSON.stringify(value);
+    const parsed = parseFrontmatterYaml(line);
+    assert.equal(parsed.title, value);
+  });
+
+  it("falls back to a minimal unescape for non-JSON double-quoted scalars", () => {
+    // "\d" is not a valid JSON escape, so JSON.parse throws and the reader
+    // must fall back gracefully instead of losing the value.
+    const parsed = parseFrontmatterYaml('title: "50% \\d discount"');
+    assert.equal(parsed.title, "50% \\d discount");
+  });
 });
 
 describe("parseOkfDocument", () => {

--- a/tests/unit/okf-bundle-visualizer.test.mjs
+++ b/tests/unit/okf-bundle-visualizer.test.mjs
@@ -62,10 +62,12 @@ function extractFunction(source, name) {
 
 function loadClientHelpers(html) {
   const script = extractScriptBlock(html);
-  const fnSource = ["escapeHtml", "isSafeResourceUrl", "normalizePathSegments", "resolveRelativeId"]
+  const fnSource = ["escapeHtml", "isSafeResourceUrl", "normalizePathSegments", "isInternalMarkdownHref", "resolveRelativeId"]
     .map((name) => extractFunction(script, name))
     .join("\n");
-  const factory = new Function(`${fnSource}\nreturn { escapeHtml, isSafeResourceUrl, normalizePathSegments, resolveRelativeId };`);
+  const factory = new Function(
+    `${fnSource}\nreturn { escapeHtml, isSafeResourceUrl, normalizePathSegments, isInternalMarkdownHref, resolveRelativeId };`,
+  );
   return factory();
 }
 
@@ -178,6 +180,26 @@ describe("client-side detail-panel escaping", () => {
     assert.equal(resolveRelativeId("./a2.md", "artifacts/a1"), "artifacts/a2");
     assert.equal(resolveRelativeId("../artifacts/a2.md", "artifacts/sub/a1"), "artifacts/artifacts/a2");
     assert.equal(resolveRelativeId("/artifacts/a2.md", "artifacts/a1"), "artifacts/a2");
+  });
+
+  it("resolveRelativeId strips both anchors and query strings before matching the .md suffix", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { resolveRelativeId } = loadClientHelpers(html);
+    assert.equal(resolveRelativeId("./a2.md#section", "artifacts/a1"), "artifacts/a2");
+    assert.equal(resolveRelativeId("./a2.md?x=1", "artifacts/a1"), "artifacts/a2");
+    assert.equal(resolveRelativeId("./a2.md?x=1#section", "artifacts/a1"), "artifacts/a2");
+  });
+
+  it("isInternalMarkdownHref recognizes .md links even with anchors/query strings, rejects others", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { isInternalMarkdownHref } = loadClientHelpers(html);
+    assert.equal(isInternalMarkdownHref("./a2.md"), true);
+    assert.equal(isInternalMarkdownHref("./a2.md#section"), true);
+    assert.equal(isInternalMarkdownHref("./a2.md?x=1"), true);
+    assert.equal(isInternalMarkdownHref("./a2.md?x=1#section"), true);
+    assert.equal(isInternalMarkdownHref("https://example.com/x.md"), true);
+    assert.equal(isInternalMarkdownHref("https://example.com/x"), false);
+    assert.equal(isInternalMarkdownHref("docs/proposals/retry.md"), true);
   });
 });
 

--- a/tests/unit/okf-bundle-visualizer.test.mjs
+++ b/tests/unit/okf-bundle-visualizer.test.mjs
@@ -1,0 +1,109 @@
+/**
+ * tests/unit/okf-bundle-visualizer.test.mjs
+ *
+ * Unit tests for lib/okf-bundle-visualizer.mjs.
+ *
+ * Covers:
+ *   - renderOkfVisualizerHtml: produces a single self-contained HTML
+ *     document embedding the bundle as JSON, referencing Cytoscape.js and
+ *     marked from CDN (no npm runtime dependency), and including the
+ *     expected interactive-viewer scaffolding (graph container, detail
+ *     panel, search, type filter).
+ *   - writeOkfVisualizerHtml: writes the rendered HTML to disk.
+ *   - HTML/script injection safety: bundle content cannot break out of the
+ *     embedded JSON <script type="application/json"> block.
+ *
+ * Run:
+ *   node --test tests/unit/okf-bundle-visualizer.test.mjs
+ */
+
+import { it, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { renderOkfVisualizerHtml, writeOkfVisualizerHtml } from "../../lib/okf-bundle-visualizer.mjs";
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(os.tmpdir(), "lore-okf-viz-test-"));
+}
+
+function sampleBundle() {
+  return {
+    bundleDir: "/tmp/example-bundle",
+    concepts: [
+      {
+        id: "artifacts/a1",
+        type: "Improvement Artifact",
+        title: "Tighten retry backoff",
+        description: "Reduce retry storms.",
+        resource: null,
+        tags: ["approved"],
+        timestamp: "2026-01-01T00:00:00.000Z",
+        body: "Body text with a [link](./a2.md).",
+      },
+      {
+        id: "artifacts/a2",
+        type: "Improvement Artifact",
+        title: "Improve fallback",
+        description: "",
+        resource: null,
+        tags: [],
+        timestamp: "2026-01-03T00:00:00.000Z",
+        body: "No links here.",
+      },
+    ],
+    edges: [{ source: "artifacts/a1", target: "artifacts/a2" }],
+  };
+}
+
+describe("renderOkfVisualizerHtml", () => {
+  it("embeds the bundle as JSON and includes CDN script tags, not npm imports", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example Bundle" });
+    assert.ok(html.startsWith("<!DOCTYPE html>"));
+    assert.ok(html.includes("Example Bundle"));
+    assert.ok(html.includes("cytoscape@3.30.2"));
+    assert.ok(html.includes("marked@12.0.2"));
+    assert.ok(html.includes('id="okf-bundle-data"'));
+    assert.ok(html.includes('"id":"artifacts/a1"'));
+    assert.ok(html.includes('"source":"artifacts/a1"'));
+    assert.ok(html.includes('id="graph"'));
+    assert.ok(html.includes('id="detail"'));
+    assert.ok(html.includes('id="search"'));
+    assert.ok(html.includes('id="typeFilter"'));
+  });
+
+  it("escapes the display name used in visible HTML", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "<script>alert(1)</script>" });
+    assert.ok(!html.includes("<script>alert(1)</script>"));
+    assert.ok(html.includes("&lt;script&gt;"));
+  });
+
+  it("neutralizes literal </script> sequences inside embedded bundle JSON", () => {
+    const bundle = sampleBundle();
+    bundle.concepts[0].body = "</script><script>alert(1)</script>";
+    const html = renderOkfVisualizerHtml({ bundle, name: "Example" });
+    assert.ok(!html.includes("</script><script>alert(1)</script>"));
+  });
+
+  it("falls back to the bundle directory name when no name is given", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle() });
+    assert.ok(html.includes("example-bundle"));
+  });
+});
+
+describe("writeOkfVisualizerHtml", () => {
+  it("writes the rendered HTML to the given path", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const outPath = path.join(tmpDir, "viz.html");
+      const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+      await writeOkfVisualizerHtml(outPath, html);
+      const written = readFileSync(outPath, "utf8");
+      assert.equal(written, html);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/okf-bundle-visualizer.test.mjs
+++ b/tests/unit/okf-bundle-visualizer.test.mjs
@@ -62,11 +62,18 @@ function extractFunction(source, name) {
 
 function loadClientHelpers(html) {
   const script = extractScriptBlock(html);
-  const fnSource = ["escapeHtml", "isSafeResourceUrl", "normalizePathSegments", "isInternalMarkdownHref", "resolveRelativeId"]
+  const fnSource = [
+    "escapeHtml",
+    "isSafeResourceUrl",
+    "normalizePathSegments",
+    "isInternalMarkdownHref",
+    "isAbsoluteHref",
+    "resolveRelativeId",
+  ]
     .map((name) => extractFunction(script, name))
     .join("\n");
   const factory = new Function(
-    `${fnSource}\nreturn { escapeHtml, isSafeResourceUrl, normalizePathSegments, isInternalMarkdownHref, resolveRelativeId };`,
+    `${fnSource}\nreturn { escapeHtml, isSafeResourceUrl, normalizePathSegments, isInternalMarkdownHref, isAbsoluteHref, resolveRelativeId };`,
   );
   return factory();
 }
@@ -200,6 +207,18 @@ describe("client-side detail-panel escaping", () => {
     assert.equal(isInternalMarkdownHref("https://example.com/x.md"), true);
     assert.equal(isInternalMarkdownHref("https://example.com/x"), false);
     assert.equal(isInternalMarkdownHref("docs/proposals/retry.md"), true);
+  });
+
+  it("isAbsoluteHref recognizes scheme-based and protocol-relative URLs, rejects relative paths", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { isAbsoluteHref } = loadClientHelpers(html);
+    assert.equal(isAbsoluteHref("https://example.com/x.md"), true);
+    assert.equal(isAbsoluteHref("http://example.com/x.md"), true);
+    assert.equal(isAbsoluteHref("mailto:a@example.com"), true);
+    assert.equal(isAbsoluteHref("//evil.example/x.md"), true);
+    assert.equal(isAbsoluteHref("./a2.md"), false);
+    assert.equal(isAbsoluteHref("../artifacts/a2.md"), false);
+    assert.equal(isAbsoluteHref("/artifacts/a2.md"), false);
   });
 });
 

--- a/tests/unit/okf-bundle-visualizer.test.mjs
+++ b/tests/unit/okf-bundle-visualizer.test.mjs
@@ -158,6 +158,7 @@ describe("client-side detail-panel escaping", () => {
     assert.equal(isSafeResourceUrl("relative/path.md"), true);
     assert.equal(isSafeResourceUrl("javascript:alert(1)"), false);
     assert.equal(isSafeResourceUrl("data:text/html,<script>alert(1)</script>"), false);
+    assert.equal(isSafeResourceUrl("//evil.example/x"), false);
     assert.equal(isSafeResourceUrl(""), false);
     assert.equal(isSafeResourceUrl(null), false);
   });

--- a/tests/unit/okf-bundle-visualizer.test.mjs
+++ b/tests/unit/okf-bundle-visualizer.test.mjs
@@ -11,7 +11,12 @@
  *     panel, search, type filter).
  *   - writeOkfVisualizerHtml: writes the rendered HTML to disk.
  *   - HTML/script injection safety: bundle content cannot break out of the
- *     embedded JSON <script type="application/json"> block.
+ *     embedded JSON <script type="application/json"> block, and the
+ *     client-side detail-panel renderer escapes/sanitizes concept fields
+ *     before writing them into innerHTML.
+ *   - Client-side relative-link resolution: resolveRelativeId normalizes
+ *     "./" and "../" path segments the same way the server-side bundle
+ *     reader does.
  *
  * Run:
  *   node --test tests/unit/okf-bundle-visualizer.test.mjs
@@ -27,6 +32,41 @@ import { renderOkfVisualizerHtml, writeOkfVisualizerHtml } from "../../lib/okf-b
 
 function makeTmpDir() {
   return mkdtempSync(path.join(os.tmpdir(), "lore-okf-viz-test-"));
+}
+
+function extractScriptBlock(html) {
+  const match = html.match(/<script>([\s\S]*)<\/script>\s*<\/body>/);
+  assert.ok(match, "expected an inline <script> block before </body>");
+  return match[1];
+}
+
+// Pulls a top-level `function name(...) { ... }` declaration out of the
+// generated client script by brace-matching, so the pure helper functions
+// (escapeHtml, isSafeResourceUrl, normalizePathSegments, resolveRelativeId)
+// can be exercised directly without a DOM/cytoscape/marked environment.
+function extractFunction(source, name) {
+  const startIdx = source.indexOf(`function ${name}(`);
+  assert.ok(startIdx !== -1, `expected to find function ${name} in generated script`);
+  const braceStart = source.indexOf("{", startIdx);
+  let depth = 0;
+  let i = braceStart;
+  for (; i < source.length; i++) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  return source.slice(startIdx, i + 1);
+}
+
+function loadClientHelpers(html) {
+  const script = extractScriptBlock(html);
+  const fnSource = ["escapeHtml", "isSafeResourceUrl", "normalizePathSegments", "resolveRelativeId"]
+    .map((name) => extractFunction(script, name))
+    .join("\n");
+  const factory = new Function(`${fnSource}\nreturn { escapeHtml, isSafeResourceUrl, normalizePathSegments, resolveRelativeId };`);
+  return factory();
 }
 
 function sampleBundle() {
@@ -90,6 +130,53 @@ describe("renderOkfVisualizerHtml", () => {
   it("falls back to the bundle directory name when no name is given", () => {
     const html = renderOkfVisualizerHtml({ bundle: sampleBundle() });
     assert.ok(html.includes("example-bundle"));
+  });
+
+  it("loads DOMPurify from a CDN to sanitize rendered markdown", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    assert.ok(html.includes("dompurify@3.1.6"));
+    assert.ok(html.includes("DOMPurify.sanitize"));
+  });
+});
+
+describe("client-side detail-panel escaping", () => {
+  it("escapeHtml neutralizes HTML metacharacters", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { escapeHtml } = loadClientHelpers(html);
+    assert.equal(
+      escapeHtml('<img src=x onerror=alert(1)>&"\''),
+      "&lt;img src=x onerror=alert(1)&gt;&amp;&quot;&#39;",
+    );
+  });
+
+  it("isSafeResourceUrl allows http(s) and relative URLs, rejects other schemes", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { isSafeResourceUrl } = loadClientHelpers(html);
+    assert.equal(isSafeResourceUrl("https://example.com/doc"), true);
+    assert.equal(isSafeResourceUrl("http://example.com/doc"), true);
+    assert.equal(isSafeResourceUrl("./relative/path.md"), true);
+    assert.equal(isSafeResourceUrl("relative/path.md"), true);
+    assert.equal(isSafeResourceUrl("javascript:alert(1)"), false);
+    assert.equal(isSafeResourceUrl("data:text/html,<script>alert(1)</script>"), false);
+    assert.equal(isSafeResourceUrl(""), false);
+    assert.equal(isSafeResourceUrl(null), false);
+  });
+
+  it("normalizePathSegments collapses '.' and '..' segments", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { normalizePathSegments } = loadClientHelpers(html);
+    assert.equal(normalizePathSegments("a2"), "a2");
+    assert.equal(normalizePathSegments("./a2"), "a2");
+    assert.equal(normalizePathSegments("artifacts/./a2"), "artifacts/a2");
+    assert.equal(normalizePathSegments("artifacts/../artifacts/a2"), "artifacts/a2");
+  });
+
+  it("resolveRelativeId resolves './' and '../' links to normalized ids", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { resolveRelativeId } = loadClientHelpers(html);
+    assert.equal(resolveRelativeId("./a2.md", "artifacts/a1"), "artifacts/a2");
+    assert.equal(resolveRelativeId("../artifacts/a2.md", "artifacts/sub/a1"), "artifacts/artifacts/a2");
+    assert.equal(resolveRelativeId("/artifacts/a2.md", "artifacts/a1"), "artifacts/a2");
   });
 });
 

--- a/tests/unit/okf-bundle-visualizer.test.mjs
+++ b/tests/unit/okf-bundle-visualizer.test.mjs
@@ -172,6 +172,17 @@ describe("client-side detail-panel escaping", () => {
     assert.equal(isSafeResourceUrl(null), false);
   });
 
+  it("isSafeResourceUrl rejects unsafe schemes even with leading/trailing whitespace", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { isSafeResourceUrl } = loadClientHelpers(html);
+    assert.equal(isSafeResourceUrl(" javascript:alert(1)"), false);
+    assert.equal(isSafeResourceUrl("\tjavascript:alert(1)"), false);
+    assert.equal(isSafeResourceUrl("javascript:alert(1) "), false);
+    assert.equal(isSafeResourceUrl("  //evil.example/x"), false);
+    assert.equal(isSafeResourceUrl("   "), false);
+    assert.equal(isSafeResourceUrl(" https://example.com/doc "), true);
+  });
+
   it("normalizePathSegments collapses '.' and '..' segments", () => {
     const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
     const { normalizePathSegments } = loadClientHelpers(html);
@@ -227,6 +238,19 @@ describe("writeOkfVisualizerHtml", () => {
     const tmpDir = makeTmpDir();
     try {
       const outPath = path.join(tmpDir, "viz.html");
+      const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+      await writeOkfVisualizerHtml(outPath, html);
+      const written = readFileSync(outPath, "utf8");
+      assert.equal(written, html);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates missing parent directories before writing", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const outPath = path.join(tmpDir, "nested", "sub", "viz.html");
       const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
       await writeOkfVisualizerHtml(outPath, html);
       const written = readFileSync(outPath, "utf8");

--- a/tests/unit/okf-bundle-visualizer.test.mjs
+++ b/tests/unit/okf-bundle-visualizer.test.mjs
@@ -146,6 +146,16 @@ describe("renderOkfVisualizerHtml", () => {
     assert.ok(html.includes("dompurify@3.1.6"));
     assert.ok(html.includes("DOMPurify.sanitize"));
   });
+
+  it("pins CDN scripts with Subresource Integrity hashes", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const scriptTags = [...html.matchAll(/<script src="https:\/\/[^"]+"[^>]*><\/script>/gu)].map((m) => m[0]);
+    assert.equal(scriptTags.length, 3, "expected exactly 3 CDN <script> tags");
+    for (const tag of scriptTags) {
+      assert.match(tag, /integrity="sha384-[A-Za-z0-9+/]+=*"/u, `missing SRI hash: ${tag}`);
+      assert.match(tag, /crossorigin="anonymous"/u, `missing crossorigin attr: ${tag}`);
+    }
+  });
 });
 
 describe("client-side detail-panel escaping", () => {
@@ -192,12 +202,36 @@ describe("client-side detail-panel escaping", () => {
     assert.equal(normalizePathSegments("artifacts/../artifacts/a2"), "artifacts/a2");
   });
 
+  it("normalizePathSegments retains unresolvable leading '..' segments instead of dropping them", () => {
+    // A no-op pop() on an empty result array used to silently discard
+    // leading ".." segments, letting a bundle-escaping link like
+    // "../../artifacts/a2.md" incorrectly normalize to a valid in-bundle id
+    // ("artifacts/a2"). The server-side reader (path.posix.normalize) keeps
+    // unresolvable ".." segments, so the client must too, to stay consistent
+    // and to make such links correctly fail to resolve to any concept.
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { normalizePathSegments } = loadClientHelpers(html);
+    assert.equal(normalizePathSegments("../../other/a2"), "../../other/a2");
+    assert.equal(normalizePathSegments("../a2"), "../a2");
+    assert.equal(normalizePathSegments("artifacts/../../a2"), "../a2");
+  });
+
   it("resolveRelativeId resolves './' and '../' links to normalized ids", () => {
     const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
     const { resolveRelativeId } = loadClientHelpers(html);
     assert.equal(resolveRelativeId("./a2.md", "artifacts/a1"), "artifacts/a2");
     assert.equal(resolveRelativeId("../artifacts/a2.md", "artifacts/sub/a1"), "artifacts/artifacts/a2");
     assert.equal(resolveRelativeId("/artifacts/a2.md", "artifacts/a1"), "artifacts/a2");
+  });
+
+  it("resolveRelativeId does not let a bundle-escaping link resolve to an unrelated valid concept id", () => {
+    const html = renderOkfVisualizerHtml({ bundle: sampleBundle(), name: "Example" });
+    const { resolveRelativeId } = loadClientHelpers(html);
+    // From "artifacts/a1", "../../artifacts/a2.md" escapes above the bundle
+    // root. It must NOT resolve to the real "artifacts/a2" concept id.
+    const target = resolveRelativeId("../../artifacts/a2.md", "artifacts/a1");
+    assert.notEqual(target, "artifacts/a2");
+    assert.match(target, /^\.\./);
   });
 
   it("resolveRelativeId strips both anchors and query strings before matching the .md suffix", () => {


### PR DESCRIPTION
## Summary

Adds `format=okf` as an alternative to `memory_portable_bundle`'s existing `format=json` (default), exporting approved improvement artifacts as an [Open Knowledge Format v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) markdown bundle instead of a single signed JSON file.

## Motivation

OKF is a minimal, vendor-neutral spec for representing knowledge as markdown + YAML frontmatter directories — human-readable, git-diffable, and consumable without any Lore-specific tooling. It's a natural complement to the existing JSON portable bundle: Lore stays the fast queryable working memory, while an OKF export gives a portable, human-legible archive/exchange format for approved improvement artifacts, sitting next to (not replacing) the existing JSON format.

## Changes

- `lib/memory-tools-okf-bundle.mjs` (new): pure builder/writer/report functions — `buildOkfBundleDocuments`, `writeOkfBundle`, `formatOkfBundleResult`. Builds one concept file per artifact (`type`/`title`/`description`/`resource`/`tags`/`timestamp` frontmatter, proposal + evidence in the body) plus a bundle-root `index.md` with `okf_version: "0.1"` frontmatter for progressive disclosure.
- `lib/memory-tools-portable-bundle.mjs`: `buildPortableBundleRequest` now normalizes/validates a `format` field (`json` default, `okf`).
- `lib/memory-tools-builders.mjs`: `memory_portable_bundle` gains a `format` parameter and branches to the OKF writer when requested; `bundlePath` doc comment clarifies it's a directory root for `okf` vs. a file path for `json`.
- `lib/capability-manifest.mjs`, `docs/support-matrix.md`, `docs/compatibility.md`: updated description/notes to document the new option (kept in parity — see `tests/unit/capability-manifest.test.mjs`'s manifest ↔ support-matrix parity test).
- `tests/unit/memory-tools-okf-bundle.test.mjs` (new): OKF conformance coverage — non-empty `type` on every concept, frontmatter only on the bundle-root index, progressive-disclosure links from index → concepts, slug collision handling, empty-artifact-list behavior, and actual disk writes.

Same trust posture as the JSON format: local-first, review-gated (approved artifacts only, `hasProposal: true`), no auto-apply, no cloud/community sharing. Import is not implemented for either format.

## Testing

```
$ npm test
ℹ tests 424
ℹ suites 130
ℹ pass 424
ℹ fail 0

$ npm run lint
Found 0 warnings and 0 errors.

$ npm run validate-schema
✓ Schema and config defaults are in parity.
```

Also manually invoked `memory_portable_bundle` end-to-end via `createMemoryTools` with `format: "okf"` against a fake runtime and confirmed the written bundle (`index.md` + `artifacts/<slug>.md`) is well-formed and links correctly.

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run validate-schema` passes
- [x] Docs updated (`docs/support-matrix.md`, `docs/compatibility.md`, `lib/capability-manifest.mjs`)
