### PR TITLE
feat(memory): add OKF bundle import into semantic memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,14 @@ npm run visualize-okf -- --bundle path/to/bundle --out viz.html
 
 This produces a force-directed graph of the bundle's concepts (colored by type, with search, a type filter, and a detail panel showing backlinks), loading Cytoscape.js and marked from CDN at view time -- no npm runtime dependency is added. It mirrors the `visualize` subcommand of the OKF reference agent.
 
+To import an OKF bundle back into Lore's own memory (making its concepts retrievable via `memory_search`), call `memory_portable_bundle` with `action: "import"` and `format: "okf"`:
+
+```
+memory_portable_bundle({ action: "import", bundlePath: "path/to/bundle", format: "okf" })
+```
+
+Each concept is retained as a `type: "okf_concept"` semantic memory row, tagged `okf_import`, at a lower default confidence (`0.7`) than self-authored memory (`memory_save`'s default is `0.9`) since it's externally sourced content. Import is always a manual, explicit tool call -- it is never wired into a hook or schedule. Re-importing the same bundle reinforces existing rows (matched by a stable `repository::conceptId` key) instead of duplicating them, but a later import does not overwrite already-stored content -- the first import wins. To revert an unwanted import: `memory_search(type: "okf_concept")` to find the rows, then `memory_forget(id: ..., supersededBy: "reverted okf import")` per row. `format: "json"` import is not yet implemented.
+
 ---
 
 ## Privacy and security

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -128,7 +128,7 @@ The `memory_portable_bundle` export tool (experimental) can generate a portable 
 ### What Lore does not promise
 
 1. **Experimental surfaces may change** — tool names, argument shapes, and output formats for experimental surfaces can change between releases without notice.
-2. **No cross-machine portability yet** — `lore.db` is not portable by default. The `memory_portable_bundle` export tool exists (experimental, json or OKF markdown format) but import is not yet implemented.
+2. **No cross-machine portability yet** — `lore.db` is not portable by default. The `memory_portable_bundle` tool supports export (experimental, json or OKF markdown format) and, for the OKF format only, import — reading an OKF bundle directory back into semantic memory as `type=okf_concept` rows (manually invoked only; never automatic). json format import is not yet implemented.
 3. **No multi-user or multi-machine sync** — Lore is local-first. There is no cloud sync, no shared team memory, and no remote API surface.
 4. **No performance guarantees under heavy load** — the bounded operation targets (< 300 ms session-start, < 200 ms prompt-time) are aspirational guidelines calibrated for a typical developer machine. Very large DBs or slow disks may exceed these.
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -82,7 +82,7 @@ This document defines which surfaces are **supported**, **experimental**, or **u
 | Tool | Status | Notes |
 |---|---|---|
 | `memory_replay` | 🟡 Experimental | Runs the replay corpus against current retrieval behavior and reports ranking hits/misses. |
-| `memory_portable_bundle` | 🟡 Experimental | Exports a portable bundle of approved improvement artifacts. format=json (default) writes a single signed JSON file; format=okf writes an OKF v0.1 markdown+frontmatter bundle directory for human/agent-readable, git-diffable exchange. Import not yet implemented for either format. |
+| `memory_portable_bundle` | 🟡 Experimental | Exports a portable bundle of approved improvement artifacts. format=json (default) writes a single signed JSON file; format=okf writes an OKF v0.1 markdown+frontmatter bundle directory for human/agent-readable, git-diffable exchange. action=import (format=okf only) reads an OKF bundle directory from disk and retains each concept as a `type=okf_concept` semantic memory row, retrievable via `memory_search(type="okf_concept")` — imported content defaults to a lower confidence (0.7) than self-authored memory and is always manually invoked, never automatic. Re-importing the same bundle reinforces existing rows (by a stable `repository::conceptId` canonical key) instead of duplicating them, but stored content is not overwritten by a later import — the first import's content wins. json format import is not yet implemented. |
 
 ### Improvement and evolution
 

--- a/lib/capability-manifest.mjs
+++ b/lib/capability-manifest.mjs
@@ -44,7 +44,7 @@ const CAPABILITY_SPECS = [
     support: {
       status: "experimental",
       category: "Replay and portability",
-      notes: "Exports a portable bundle of approved improvement artifacts. format=json (default) writes a single signed JSON file; format=okf writes an OKF v0.1 markdown+frontmatter bundle directory for human/agent-readable, git-diffable exchange. Import not yet implemented for either format.",
+      notes: "Exports a portable bundle of approved improvement artifacts. format=json (default) writes a single signed JSON file; format=okf writes an OKF v0.1 markdown+frontmatter bundle directory for human/agent-readable, git-diffable exchange. action=import (format=okf only) reads an OKF bundle directory from disk and retains each concept as a `type=okf_concept` semantic memory row, retrievable via `memory_search(type=\"okf_concept\")` — imported content defaults to a lower confidence (0.7) than self-authored memory and is always manually invoked, never automatic. Re-importing the same bundle reinforces existing rows (by a stable `repository::conceptId` canonical key) instead of duplicating them, but stored content is not overwritten by a later import — the first import's content wins. json format import is not yet implemented.",
       rolloutFlags: [],
     },
   },

--- a/lib/memory-scope.mjs
+++ b/lib/memory-scope.mjs
@@ -343,6 +343,14 @@ export function buildSemanticCanonicalKey(memory) {
     return buildWorkstreamOverlayCanonicalKey(metadata, content);
   }
 
+  if (type === "okf_concept") {
+    // Keyed on a stable ${repository}::${conceptId} identifier (built by the
+    // importer, not derived from body text) so re-importing the same OKF
+    // concept upserts/reinforces the existing row -- even if its body text
+    // changed upstream between imports -- instead of duplicating it.
+    return buildSimpleSemanticCanonicalKey("okf_concept", metadata.okfConceptKey);
+  }
+
   return null;
 }
 

--- a/lib/memory-tools-builders.mjs
+++ b/lib/memory-tools-builders.mjs
@@ -1,3 +1,6 @@
+import { stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { LORE_CAPABILITY_SPECS } from "./capability-manifest.mjs";
 import { processDeferredExtractions } from "./backfill.mjs";
 import {
@@ -46,6 +49,9 @@ const {
   buildOkfBundleDocuments,
   writeOkfBundle,
   formatOkfBundleResult,
+  readOkfBundle,
+  buildOkfImportMemories,
+  formatOkfImportResult,
   normalizeCapabilityInventoryAction,
   renderCapabilityInventoryAction,
   buildIntentJournalContext,
@@ -250,8 +256,8 @@ function buildMemoryPortableBundleTool(getRuntime) {
       properties: {
         action: {
           type: "string",
-          enum: ["export"],
-          description: "Export a portable bundle",
+          enum: ["export", "import"],
+          description: "Export a portable bundle, or import (format=okf only) an OKF bundle directory into semantic memory",
         },
         repository: {
           type: "string",
@@ -259,7 +265,7 @@ function buildMemoryPortableBundleTool(getRuntime) {
         },
         bundlePath: {
           type: "string",
-          description: "Optional repository-relative or absolute path for reading/writing bundles. For format=okf this is a directory root; for format=json (default) this is a single file path.",
+          description: "Optional repository-relative or absolute path for reading/writing bundles. For format=okf this is a directory root; for format=json (default) this is a single file path. Required for action=import.",
         },
         limit: {
           type: "number",
@@ -268,7 +274,11 @@ function buildMemoryPortableBundleTool(getRuntime) {
         format: {
           type: "string",
           enum: ["json", "okf"],
-          description: "Bundle output format. \"json\" (default) writes a single signed JSON file. \"okf\" writes an Open Knowledge Format v0.1 markdown+frontmatter bundle directory (one concept file per artifact plus an index.md) for human/agent-readable, git-diffable exchange.",
+          description: "Bundle output format. \"json\" (default) writes a single signed JSON file. \"okf\" writes an Open Knowledge Format v0.1 markdown+frontmatter bundle directory (one concept file per artifact plus an index.md) for human/agent-readable, git-diffable exchange. action=import currently supports format=okf only.",
+        },
+        confidence: {
+          type: "number",
+          description: "Optional confidence override for action=import (default 0.7 -- lower than self-authored memory_save's 0.9, since imported content is externally sourced)",
         },
       },
     },
@@ -280,6 +290,11 @@ function buildMemoryPortableBundleTool(getRuntime) {
       }
 
       const request = buildPortableBundleRequest(args, runtime);
+
+      if (request.action === "import") {
+        return importOkfPortableBundle({ runtime, invocation, request });
+      }
+
       const improvementArtifacts = runtime.db.listImprovementArtifacts({
         reviewState: "approved",
         hasProposal: true,
@@ -311,6 +326,56 @@ function buildMemoryPortableBundleTool(getRuntime) {
       });
     },
   });
+}
+
+/**
+ * action=import handler for memory_portable_bundle (format=okf only). Reads
+ * an OKF bundle directory from disk and retains each concept as a
+ * type=okf_concept semantic memory row (see okf-bundle-import.mjs), capped
+ * at request.limit concepts per call so one large/malicious bundle can't
+ * unboundedly flood semantic memory in a single invocation.
+ */
+async function importOkfPortableBundle({ runtime, invocation, request }) {
+  const bundleStat = await stat(request.bundlePath).catch(() => null);
+  if (!bundleStat || !bundleStat.isDirectory()) {
+    throw new Error(`bundlePath ${request.bundlePath} is not a directory`);
+  }
+
+  const { concepts } = await readOkfBundle(request.bundlePath);
+  const cappedConcepts = concepts.slice(0, request.limit);
+  const memories = buildOkfImportMemories({
+    concepts: cappedConcepts,
+    repository: request.repository,
+    confidence: request.confidence,
+    sourceSessionId: invocation.sessionId,
+  });
+
+  let importedCount = 0;
+  let skippedCount = 0;
+  for (const memory of memories) {
+    const retained = retainMemory({ db: runtime.db, kind: "semantic", memory });
+    if (retained.id) {
+      importedCount += 1;
+    } else {
+      skippedCount += 1;
+    }
+  }
+
+  return formatOkfImportResult({
+    bundleDir: path.relative(repoRootFromBuildersModule(), request.bundlePath).replaceAll(path.sep, "/"),
+    repository: request.repository,
+    importedCount,
+    skippedCount,
+    totalConceptCount: concepts.length,
+  });
+}
+
+function repoRootFromBuildersModule() {
+  // This module lives at <repo>/lib/memory-tools-builders.mjs, so one level
+  // up from its directory is the actual repository root (mirrors
+  // repoRootFromModule() in memory-tools-portable-bundle.mjs /
+  // memory-tools-okf-bundle.mjs).
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 }
 
 function buildMaintenanceScheduleRunTool(getRuntime) {

--- a/lib/memory-tools-helpers.mjs
+++ b/lib/memory-tools-helpers.mjs
@@ -26,6 +26,11 @@ export {
   formatOkfBundleResult,
   writeOkfBundle,
 } from "./memory-tools-okf-bundle.mjs";
+export { readOkfBundle } from "./okf-bundle-reader.mjs";
+export {
+  buildOkfImportMemories,
+  formatOkfImportResult,
+} from "./okf-bundle-import.mjs";
 export {
   normalizeCapabilityInventoryAction,
   renderCapabilityInventoryAction,

--- a/lib/memory-tools-portable-bundle.mjs
+++ b/lib/memory-tools-portable-bundle.mjs
@@ -9,6 +9,8 @@ import {
 import { ensureLimit } from "./memory-tools-validation-utils.mjs";
 
 const PORTABLE_BUNDLE_EXPORT_ACTION = "export";
+const PORTABLE_BUNDLE_IMPORT_ACTION = "import";
+const PORTABLE_BUNDLE_ACTIONS = [PORTABLE_BUNDLE_EXPORT_ACTION, PORTABLE_BUNDLE_IMPORT_ACTION];
 const PORTABLE_BUNDLE_VERSION = 1;
 const PORTABLE_BUNDLE_TYPE = "lore-portable-improvement";
 const PORTABLE_BUNDLE_FORMATS = ["json", "okf"];
@@ -30,18 +32,27 @@ function normalizePortableBundleFormat(value) {
 
 export function buildPortableBundleRequest(args, runtime) {
   const action = normalizePortableBundleAction(args.action);
-  if (action !== PORTABLE_BUNDLE_EXPORT_ACTION) {
-    throw new Error("memory_portable_bundle currently supports action=export only");
+  if (!PORTABLE_BUNDLE_ACTIONS.includes(action)) {
+    throw new Error(`memory_portable_bundle action must be one of: ${PORTABLE_BUNDLE_ACTIONS.join(", ")}`);
   }
   const bundlePath = resolveBundlePath(args.bundlePath);
   if (args.bundlePath && !bundlePath) {
     throw new Error("bundlePath must be a non-empty path");
   }
+  if (action === PORTABLE_BUNDLE_IMPORT_ACTION && !bundlePath) {
+    throw new Error("memory_portable_bundle action=import requires bundlePath (the bundle to read from)");
+  }
+  const format = normalizePortableBundleFormat(args.format);
+  if (action === PORTABLE_BUNDLE_IMPORT_ACTION && format !== "okf") {
+    throw new Error("memory_portable_bundle action=import currently supports format=okf only");
+  }
   return {
+    action,
     repository: resolveRepositoryArg(args.repository, runtime.repository),
     limit: ensureLimit(args.limit, 20, 50),
     bundlePath,
-    format: normalizePortableBundleFormat(args.format),
+    format,
+    confidence: typeof args.confidence === "number" ? args.confidence : undefined,
   };
 }
 

--- a/lib/okf-bundle-import.mjs
+++ b/lib/okf-bundle-import.mjs
@@ -1,0 +1,76 @@
+const OKF_IMPORT_TYPE = "okf_concept";
+const OKF_IMPORT_SOURCE = "memory_okf_import";
+const DEFAULT_OKF_IMPORT_CONFIDENCE = 0.7;
+
+/**
+ * Pure: maps OKF concepts (as produced by readOkfBundle()) into
+ * semantic-memory-shaped objects ready for retainMemory({kind: "semantic"}).
+ * No I/O and no db access -- callers own persistence and counting.
+ *
+ * Imported concepts are tagged/typed distinctly from self-authored memory
+ * (memory_save) and default to a lower confidence, since this is externally
+ * sourced content the assistant did not verify itself. type=okf_concept
+ * carries a stable canonical key (repository::conceptId) so re-importing an
+ * unchanged or edited bundle upserts/reinforces existing rows instead of
+ * duplicating them (see memory-scope.mjs buildSemanticCanonicalKey).
+ */
+export function buildOkfImportMemories({ concepts, repository, confidence, sourceSessionId } = {}) {
+  const list = Array.isArray(concepts) ? concepts : [];
+  const resolvedConfidence = typeof confidence === "number" ? confidence : DEFAULT_OKF_IMPORT_CONFIDENCE;
+  return list.map((concept) => buildOkfImportMemory({
+    concept,
+    repository,
+    confidence: resolvedConfidence,
+    sourceSessionId,
+  }));
+}
+
+function buildOkfImportMemory({ concept, repository, confidence, sourceSessionId }) {
+  const okfConceptKey = `${repository ?? "global"}::${concept.id}`;
+  const content = [concept.title, concept.description, concept.body]
+    .map((part) => (typeof part === "string" ? part.trim() : ""))
+    .filter(Boolean)
+    .join("\n\n");
+  const tags = [...new Set([concept.type, "okf_import", ...(Array.isArray(concept.tags) ? concept.tags : [])].filter(Boolean))];
+
+  return {
+    type: OKF_IMPORT_TYPE,
+    content,
+    confidence,
+    repository: repository ?? null,
+    tags,
+    sourceSessionId,
+    metadata: {
+      source: OKF_IMPORT_SOURCE,
+      okfConceptKey,
+      okfId: concept.id,
+      resource: concept.resource ?? null,
+      timestamp: concept.timestamp ?? null,
+    },
+  };
+}
+
+/** Formats the memory_portable_bundle action=import result string. */
+export function formatOkfImportResult({
+  bundleDir,
+  repository,
+  importedCount = 0,
+  skippedCount = 0,
+  totalConceptCount = 0,
+}) {
+  return [
+    "action: import",
+    "format: okf",
+    `bundlePath: ${bundleDir ?? "unknown"}`,
+    `repository: ${repository ?? "global"}`,
+    `conceptsFound: ${totalConceptCount}`,
+    `importedCount: ${importedCount}`,
+    `skippedCount: ${skippedCount}`,
+    "",
+    "Notes:",
+    "- imported concepts are stored as type=okf_concept, tagged okf_import, at a lower default confidence (0.7) than self-authored memory",
+    "- re-importing the same bundle reinforces existing rows (confidence/tags/reinforcement) instead of duplicating them, but stored content is not overwritten by a later import -- the first import's content wins",
+    "- retrieve imported concepts via memory_search(type=\"okf_concept\")",
+    "- to revert a bad import: memory_search(type=\"okf_concept\") to list rows, then memory_forget(id=..., supersededBy=\"reverted okf import\") per row",
+  ].filter(Boolean).join("\n");
+}

--- a/tests/unit/memory-tools-portable-bundle.test.mjs
+++ b/tests/unit/memory-tools-portable-bundle.test.mjs
@@ -24,7 +24,7 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, test } from "node:test";
@@ -198,5 +198,184 @@ describe("resolveBundlePath (via buildPortableBundleRequest)", () => {
     const absolute = path.join(os.tmpdir(), "somewhere", "bundle.json");
     const request = buildPortableBundleRequest({ bundlePath: absolute }, { repository: null });
     assert.equal(request.bundlePath, absolute);
+  });
+});
+
+describe("memory_portable_bundle action=import", () => {
+  test("imports OKF concepts into semantic memory, retrievable via memory_search", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      seedApprovedArtifact(db);
+      const exportTool = findTool(tools, "memory_portable_bundle");
+      const bundleDir = path.join(tmpDir, "okf-bundle");
+      await exportTool.handler({ bundlePath: bundleDir, format: "okf" }, { sessionId: "portable-okf-export" });
+
+      const importTool = findTool(tools, "memory_portable_bundle");
+      const importOutput = await importTool.handler(
+        { action: "import", bundlePath: bundleDir, format: "okf", repository: "fixture-repo" },
+        { sessionId: "portable-okf-import" },
+      );
+
+      assert.match(importOutput, /action: import/);
+      assert.match(importOutput, /importedCount: 1/);
+      assert.match(importOutput, /skippedCount: 0/);
+
+      const rows = db.db.prepare("SELECT type, confidence, tags FROM semantic_memory WHERE type = ?").all("okf_concept");
+      assert.equal(rows.length, 1);
+      assert.equal(rows[0].confidence, 0.7);
+      assert.match(rows[0].tags, /okf_import/);
+
+      const search = findTool(tools, "memory_search");
+      const searchOutput = await search.handler(
+        { query: "retry backoff", type: "okf_concept", limit: 10 },
+        { sessionId: "portable-okf-search" },
+      );
+      assert.match(searchOutput, /Tighten retry backoff/);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  test("re-importing the same bundle reinforces the existing row instead of duplicating it (content is not overwritten by later imports)", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      seedApprovedArtifact(db);
+      const exportTool = findTool(tools, "memory_portable_bundle");
+      const bundleDir = path.join(tmpDir, "okf-bundle");
+      await exportTool.handler({ bundlePath: bundleDir, format: "okf" }, { sessionId: "portable-okf-export" });
+
+      const importTool = findTool(tools, "memory_portable_bundle");
+      await importTool.handler(
+        { action: "import", bundlePath: bundleDir, format: "okf", repository: "fixture-repo" },
+        { sessionId: "portable-okf-import-1" },
+      );
+      const [firstRow] = db.db.prepare("SELECT id, content, reinforcement_count FROM semantic_memory WHERE type = ?").all("okf_concept");
+
+      // Edit the exported concept file in place, simulating an updated
+      // upstream bundle, then re-import. The upsert path this reuses
+      // (shared with assistant_goal/user_identity/recurring_mistake) only
+      // bumps confidence/reinforcement_count/tags/metadata on a canonical-key
+      // match -- it does not overwrite stored content on later imports. So
+      // re-importing an edited concept still lands on the *same* row id
+      // (no duplicate) with a higher reinforcement_count, but the original
+      // first-imported content is what's retained.
+      const conceptFiles = readdirSync(path.join(bundleDir, "artifacts"));
+      const conceptPath = path.join(bundleDir, "artifacts", conceptFiles[0]);
+      const original = readFileSync(conceptPath, "utf8");
+      writeFileSync(conceptPath, original.replaceAll("Reduce retry storms during transient network errors.", "Reduce retry storms -- now with jitter."));
+
+      await importTool.handler(
+        { action: "import", bundlePath: bundleDir, format: "okf", repository: "fixture-repo" },
+        { sessionId: "portable-okf-import-2" },
+      );
+
+      const rows = db.db.prepare("SELECT id, content, reinforcement_count FROM semantic_memory WHERE type = ?").all("okf_concept");
+      assert.equal(rows.length, 1, "re-import of an edited concept should reinforce the existing row, not duplicate it");
+      assert.equal(rows[0].id, firstRow.id);
+      assert.equal(rows[0].content, firstRow.content, "content is not overwritten by later imports (matches existing canonical-key upsert semantics)");
+      assert.ok(rows[0].reinforcement_count > firstRow.reinforcement_count);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  test("throws when bundlePath is missing", { skip: SKIP_NO_FTS5 }, async () => {
+    const { tools, cleanup } = await setupFixtureTools({ enabled: true });
+    try {
+      const importTool = findTool(tools, "memory_portable_bundle");
+      await assert.rejects(
+        importTool.handler({ action: "import", format: "okf" }, { sessionId: "portable-okf-missing-path" }),
+        /bundlePath/,
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("throws when bundlePath is a file, not a directory", { skip: SKIP_NO_FTS5 }, async () => {
+    const { tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      const filePath = path.join(tmpDir, "not-a-dir.md");
+      writeFileSync(filePath, "not a bundle directory");
+      const importTool = findTool(tools, "memory_portable_bundle");
+      await assert.rejects(
+        importTool.handler({ action: "import", bundlePath: filePath, format: "okf" }, { sessionId: "portable-okf-file-path" }),
+        /is not a directory/,
+      );
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  test("succeeds as a no-op for an empty bundle directory", { skip: SKIP_NO_FTS5 }, async () => {
+    const { tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      const emptyBundleDir = path.join(tmpDir, "empty-bundle");
+      mkdirSync(emptyBundleDir, { recursive: true });
+      const importTool = findTool(tools, "memory_portable_bundle");
+      const output = await importTool.handler(
+        { action: "import", bundlePath: emptyBundleDir, format: "okf" },
+        { sessionId: "portable-okf-empty" },
+      );
+      assert.match(output, /conceptsFound: 0/);
+      assert.match(output, /importedCount: 0/);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  test("throws when format=json is combined with action=import", { skip: SKIP_NO_FTS5 }, async () => {
+    const { tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      const importTool = findTool(tools, "memory_portable_bundle");
+      await assert.rejects(
+        importTool.handler(
+          { action: "import", bundlePath: tmpDir, format: "json" },
+          { sessionId: "portable-json-import-unsupported" },
+        ),
+        /format=okf only/,
+      );
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  test("caps imported concepts at the requested limit", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      const bundleDir = path.join(tmpDir, "many-concepts-bundle");
+      mkdirSync(path.join(bundleDir, "artifacts"), { recursive: true });
+      for (let i = 0; i < 5; i += 1) {
+        writeFileSync(
+          path.join(bundleDir, "artifacts", `concept-${i}.md`),
+          `---\ntype: "Concept"\ntitle: "Concept ${i}"\n---\n\nBody for concept ${i}.\n`,
+        );
+      }
+
+      const importTool = findTool(tools, "memory_portable_bundle");
+      const output = await importTool.handler(
+        { action: "import", bundlePath: bundleDir, format: "okf", limit: 2 },
+        { sessionId: "portable-okf-limit" },
+      );
+
+      assert.match(output, /conceptsFound: 5/);
+      assert.match(output, /importedCount: 2/);
+      const rows = db.db.prepare("SELECT id FROM semantic_memory WHERE type = ?").all("okf_concept");
+      assert.equal(rows.length, 2);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
   });
 });

--- a/tests/unit/okf-bundle-import.test.mjs
+++ b/tests/unit/okf-bundle-import.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * tests/unit/okf-bundle-import.test.mjs
+ *
+ * Unit tests for lib/okf-bundle-import.mjs (pure OKF concept -> semantic
+ * memory mapping) and the okf_concept canonical key added to
+ * lib/memory-scope.mjs's buildSemanticCanonicalKey().
+ *
+ * Covers:
+ *   - buildOkfImportMemories: maps concept fields (title/description/body,
+ *     type/tags) into a semantic-memory-shaped object, defaults confidence
+ *     to 0.7, is overridable, and always tags/types imported rows distinctly
+ *     from self-authored memory (memory_save).
+ *   - okfConceptKey canonical key: same repository+conceptId produces a
+ *     stable canonical key across two calls even when the concept's body
+ *     text differs -- this is what lets action=import upsert/reinforce an
+ *     edited concept instead of duplicating it on re-import.
+ *   - formatOkfImportResult: output shape/notes.
+ *
+ * Run:
+ *   node --test tests/unit/okf-bundle-import.test.mjs
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import { buildOkfImportMemories, formatOkfImportResult } from "../../lib/okf-bundle-import.mjs";
+import { buildSemanticCanonicalKey } from "../../lib/memory-scope.mjs";
+
+function makeConcept(overrides = {}) {
+  return {
+    id: "artifacts/retry-backoff",
+    relativePath: "artifacts/retry-backoff.md",
+    type: "Improvement Artifact",
+    title: "Tighten retry backoff",
+    description: "Reduce retry storms during transient network errors.",
+    resource: "docs/proposals/retry.md",
+    tags: ["session_review", "approved"],
+    timestamp: "2026-01-02T00:00:00.000Z",
+    frontmatter: {},
+    body: "# Tighten retry backoff\n\nReduce retry storms during transient network errors.",
+    ...overrides,
+  };
+}
+
+describe("buildOkfImportMemories", () => {
+  test("maps a concept into a semantic-memory-shaped object with defaults", () => {
+    const [memory] = buildOkfImportMemories({ concepts: [makeConcept()], repository: "fixture-repo" });
+
+    assert.equal(memory.type, "okf_concept");
+    assert.equal(memory.repository, "fixture-repo");
+    assert.equal(memory.confidence, 0.7);
+    assert.match(memory.content, /Tighten retry backoff/);
+    assert.match(memory.content, /Reduce retry storms/);
+    assert.deepEqual(memory.tags, ["Improvement Artifact", "okf_import", "session_review", "approved"]);
+    assert.equal(memory.metadata.source, "memory_okf_import");
+    assert.equal(memory.metadata.okfId, "artifacts/retry-backoff");
+    assert.equal(memory.metadata.okfConceptKey, "fixture-repo::artifacts/retry-backoff");
+    assert.equal(memory.metadata.resource, "docs/proposals/retry.md");
+    assert.equal(memory.metadata.timestamp, "2026-01-02T00:00:00.000Z");
+  });
+
+  test("uses 'global' in the canonical key when no repository is given", () => {
+    const [memory] = buildOkfImportMemories({ concepts: [makeConcept()] });
+    assert.equal(memory.repository, null);
+    assert.equal(memory.metadata.okfConceptKey, "global::artifacts/retry-backoff");
+  });
+
+  test("confidence is overridable", () => {
+    const [memory] = buildOkfImportMemories({ concepts: [makeConcept()], confidence: 0.4 });
+    assert.equal(memory.confidence, 0.4);
+  });
+
+  test("deduplicates tags and tolerates a concept with no tags", () => {
+    const [memory] = buildOkfImportMemories({
+      concepts: [makeConcept({ type: "Concept", tags: ["Concept", "okf_import"] })],
+    });
+    assert.deepEqual(memory.tags, ["Concept", "okf_import"]);
+  });
+
+  test("returns an empty array for an empty concept list", () => {
+    assert.deepEqual(buildOkfImportMemories({ concepts: [] }), []);
+    assert.deepEqual(buildOkfImportMemories({}), []);
+  });
+});
+
+describe("okf_concept canonical key (memory-scope.mjs)", () => {
+  test("is stable for the same repository+conceptId even when content differs", () => {
+    const keyA = buildSemanticCanonicalKey({
+      type: "okf_concept",
+      content: "original body text",
+      metadata: { okfConceptKey: "fixture-repo::artifacts/retry-backoff" },
+    });
+    const keyB = buildSemanticCanonicalKey({
+      type: "okf_concept",
+      content: "edited body text, totally different",
+      metadata: { okfConceptKey: "fixture-repo::artifacts/retry-backoff" },
+    });
+    assert.equal(keyA, keyB);
+    assert.equal(keyA, "okf_concept:fixture-repo artifacts retry-backoff");
+  });
+
+  test("differs across distinct concept ids", () => {
+    const keyA = buildSemanticCanonicalKey({
+      type: "okf_concept",
+      content: "x",
+      metadata: { okfConceptKey: "fixture-repo::artifacts/a" },
+    });
+    const keyB = buildSemanticCanonicalKey({
+      type: "okf_concept",
+      content: "x",
+      metadata: { okfConceptKey: "fixture-repo::artifacts/b" },
+    });
+    assert.notEqual(keyA, keyB);
+  });
+
+  test("returns null when okfConceptKey metadata is missing", () => {
+    assert.equal(buildSemanticCanonicalKey({ type: "okf_concept", content: "x", metadata: {} }), null);
+  });
+});
+
+describe("formatOkfImportResult", () => {
+  test("reports action, format, counts, and rollback guidance", () => {
+    const output = formatOkfImportResult({
+      bundleDir: "tmp/okf-bundle",
+      repository: "fixture-repo",
+      importedCount: 2,
+      skippedCount: 1,
+      totalConceptCount: 3,
+    });
+    assert.match(output, /action: import/);
+    assert.match(output, /format: okf/);
+    assert.match(output, /bundlePath: tmp\/okf-bundle/);
+    assert.match(output, /repository: fixture-repo/);
+    assert.match(output, /conceptsFound: 3/);
+    assert.match(output, /importedCount: 2/);
+    assert.match(output, /skippedCount: 1/);
+    assert.match(output, /memory_search\(type="okf_concept"\)/);
+    assert.match(output, /memory_forget/);
+  });
+
+  test("defaults repository to 'global' when omitted", () => {
+    const output = formatOkfImportResult({ bundleDir: "tmp/x" });
+    assert.match(output, /repository: global/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the missing **import** side to `memory_portable_bundle`, closing the gap PR #52 (export + visualizer) left behind: OKF bundles could be exported and viewed, but never fed back into Lore's own retrieval surface. `action: "import"` (format=okf only, for this phase) now reads an OKF v0.1 bundle directory from disk and retains each concept as a `type=okf_concept` semantic memory row, retrievable via `memory_search(type="okf_concept")`.

## What changed

- **`lib/okf-bundle-import.mjs`** (new) — maps each OKF concept into a semantic-memory-shaped object: `content` = title+description+body, `tags` = `[concept.type, "okf_import", ...concept.tags]`, `confidence` defaults to `0.7` (lower than `memory_save`'s 0.9, since this is externally-sourced content), `metadata` carries `okfConceptKey`/`okfId`/`resource`/`timestamp`.
- **`lib/memory-scope.mjs`** — new `okf_concept` canonical-key case, keyed on `metadata.okfConceptKey` (`${repository ?? "global"}::${conceptId}`). Re-importing the same bundle reinforces the existing row (via the same upsert path `memory_save`/`assistant_goal`/etc. already use) instead of duplicating it.
- **`lib/memory-tools-builders.mjs`, `lib/memory-tools-portable-bundle.mjs`, `lib/memory-tools-helpers.mjs`** — wire `action: "import"` into the tool: validates `bundlePath` is a directory, requires `format: "okf"` for import (json import stays out of scope), caps imported concepts via the existing `limit` arg (default 20 / max 50), and reports imported/skipped counts.
- **`lib/capability-manifest.mjs`, `docs/support-matrix.md`, `docs/compatibility.md`, `README.md`** — document the new capability and its constraints.

## Provenance / trust boundary

- Import is **manual-invocation only** — never wired into a hook, schedule, or automatic trigger, since this promotes externally-sourced content into memory the assistant will later retrieve and reason over.
- Imported rows stay identifiable: `type: "okf_concept"` + `okf_import` tag + lower default confidence (0.7 vs 0.9 self-authored) distinguish them in `memory_search` output from verified/self-authored memory.
- **Known limitation (by design, not a bug):** re-importing a bundle after its concept's body text changed upstream reinforces the existing row (confidence/tags/reinforcement_count bump) but does **not** overwrite stored `content` — this matches the existing upsert semantics already used by `assistant_goal`/`user_identity`/`recurring_mistake`/`workstream_overlay`, so it was deliberately preserved rather than widening the blast radius of shared upsert code. Documented in code comments, tool output, README, support-matrix, and the `lore-memory-operations` skill.
- **Rollback:** `memory_search(type="okf_concept")` to list affected rows, then `memory_forget(id=..., supersededBy="reverted okf import")` per row.

## Out of scope

- `format: "json"` import (json is a signed re-export of Lore's own artifacts; importing it back would be circular).
- Any UI/visualizer changes.
- Bulk-delete/rollback tooling beyond the existing per-id `memory_forget` loop.

## Validation

- 17 new tests: `tests/unit/okf-bundle-import.test.mjs` (10) + `tests/unit/memory-tools-portable-bundle.test.mjs` import-flow additions (7).
- `npm test` → **471/471 passing**.
- `npm run lint` → 0 warnings/errors.
- `npm run validate-schema` → clean.

## Plan review

Scoped via `/plan-review-loop` (Jason + Freddy personas); round 1 both requested revisions (validation commands, rollback path, edge cases, provenance/trust-boundary section, volume guard), round 2 unanimous `[PLAN-APPROVED]`.
