### PR TITLE
feat: improve Lore hook reliability and observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Use `memory_status` for recorder health and recent samples. `includeRecentTraces
 
 `maintenanceScheduler` is the opt-in maintenance loop for deferred extraction processing, validation and replay corpus runs, backlog review, and index upkeep. On session start, Lore evaluates the maintenance plan and auto-runs the startup-safe deferred-extraction pass when it is enabled and due. The same scheduler also powers manual or scripted sweeps through `maintenance_schedule_run` and `node scripts/run-maintenance.mjs`.
 
+> **Session hooks do not guarantee wall-clock cadence.** For reliable periodic upkeep independent of session frequency, wire `scripts/run-maintenance.mjs` into cron or launchd. See [`docs/maintenance-scheduling.md`](docs/maintenance-scheduling.md) for the full guide including cron and launchd examples, failure detection, and the isolated-database rule.
+
 ```json
 {
   "maintenanceScheduler": {

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -67,6 +67,12 @@ Lore reads this file to backfill memories and extract session context. It never 
 
 When `maintenanceScheduler.sessionStartBackfill` is enabled, Lore may also perform a session-start archive import from this same raw store. That import is still read-only against `session-store.db`, and progress is surfaced to the user via CLI log messages plus the existing backfill status surfaces.
 
+### External maintenance — isolated database rule
+
+`scripts/run-maintenance.mjs` and the `maintenance_schedule_run` tool operate only on the configured Lore database. The `--derived-store-path` and `--raw-store-path` flags exist for legitimate path overrides (e.g., non-standard install locations), not for pointing an external scheduler at test fixtures or other users' databases.
+
+Failed migrations and tasks use **forward recovery**: if a migration or maintenance job fails, the database is left intact, the failure is recorded, and the next run retries the forward path. Destructive downgrade of the schema is never applied silently. If you need to recover from a migration failure, see [Scenario 3 in the releasing guide](releasing.md#scenario-3----db-schema-migration-causes-data-issues).
+
 ### Optional local inference server
 
 | Requirement | Value |

--- a/docs/copilot-sdk-hooks.md
+++ b/docs/copilot-sdk-hooks.md
@@ -1,16 +1,16 @@
 # Copilot CLI extension triggers from the bundled runtime
 
-This report answers the question using the **installed Copilot CLI / bundled SDK source on this machine**, not the `~/.copilot` repo's past extension usage. The key local source is the bundled package under `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/` plus its docs and generated event schema.[^extensions-doc]
+This document is a local verification snapshot: it inspects the Copilot CLI / bundled SDK installation visible on this machine rather than asserting a universal install location. The primary local source examined here was the package found under `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/` (paths will vary by OS and package manager); consult `npm root -g` or your project's `node_modules` for the equivalent package location in your environment.[^extensions-doc]
 
 ## Executive Summary
 
 In the bundled Copilot CLI SDK, extensions have **two upstream trigger surfaces**: **named hooks** and the **generic session event stream**.[^join-config][^event-subscribe]
 
-The **named hook contract is exactly six hooks** in this install: `onPreToolUse`, `onPostToolUse`, `onUserPromptSubmitted`, `onSessionStart`, `onSessionEnd`, and `onErrorOccurred`.[^hooks-type][^dispatch][^examples-hooks]
+The **named hook contract in this installed runtime is seven hooks**: `onPreToolUse`, `onPreMcpToolCall`, `onPostToolUse`, `onUserPromptSubmitted`, `onSessionStart`, `onSessionEnd`, and `onErrorOccurred`.[^hooks-type][^dispatch][^examples-hooks]
 
 There is **no bundled named hook called `onSubagentStart`**. Instead, sub-agent activity is exposed through the generic event stream as events like `subagent.started`, `subagent.completed`, `subagent.failed`, `subagent.selected`, and `subagent.deselected`.[^dispatch][^subagent-events]
 
-So the practical answer is: **if you want every supported extension trigger in this runtime, it is six named hooks plus event-driven triggers via `onEvent`/`session.on(...)`.** If a local extension defines `onSubagentStart`, that name is not part of the installed bundled hook dispatcher shown below.[^join-config][^dispatch]
+So the practical answer is: **if you want every supported extension trigger in this runtime, it is seven named hooks plus event-driven triggers via `onEvent`/`session.on(...)`.** If a local extension defines `onSubagentStart`, that name is not part of the installed bundled hook dispatcher shown below.[^join-config][^dispatch]
 
 ## Architecture / System Overview
 
@@ -30,7 +30,7 @@ The bundled extension docs describe extensions as separate Node.js processes tha
 
 ## Named hook triggers
 
-The installed `types.d.ts` defines the `SessionHooks` interface with exactly six fields:[^hooks-type]
+The installed `types.d.ts` defines the `SessionHooks` interface with seven fields:[^hooks-type]
 
 | Hook | Fires when | Notes |
 |---|---|---|
@@ -41,7 +41,7 @@ The installed `types.d.ts` defines the `SessionHooks` interface with exactly six
 | `onSessionEnd` | when a session ends | cleanup/logging path[^hooks-type][^examples-hooks] |
 | `onErrorOccurred` | when an error occurs | can choose retry/skip/abort behavior[^hooks-type][^examples-hooks] |
 
-The bundled runtime dispatch table in `copilot-sdk/index.js` confirms that only these six hook names are looked up by the SDK at hook invocation time.[^dispatch]
+The bundled runtime dispatch table in `copilot-sdk/index.js` confirms that these seven hook names are looked up by the SDK at hook invocation time.[^dispatch]
 
 ## Event-driven triggers
 
@@ -65,26 +65,33 @@ That means the installed runtime does **not** advertise `onSubagentStart` as a s
 
 ## Bottom line
 
-For the Copilot CLI source installed here, an extension can trigger off:
+For the Copilot CLI installation inspected here, the authoritative named-hook contract in the bundled SDK contains seven hooks: `onPreToolUse`, `onPreMcpToolCall`, `onPostToolUse`, `onUserPromptSubmitted`, `onSessionStart`, `onSessionEnd`, and `onErrorOccurred`. In addition, the runtime exposes a wide event taxonomy that extensions may subscribe to via `onEvent` or `session.on(...)` (for example: `subagent.started`, `subagent.completed`, etc.).
 
-1. **Six named hooks**: `onPreToolUse`, `onPostToolUse`, `onUserPromptSubmitted`, `onSessionStart`, `onSessionEnd`, `onErrorOccurred`.[^hooks-type][^dispatch]
-2. **Generic session events** via `onEvent` or `session.on(...)`, including sub-agent events and the wider event taxonomy.[^join-config][^event-subscribe][^subagent-events]
+Important: the filesystem paths referenced in this document are a local verification snapshot and will vary across machines, OSes, and package managers. To reproduce this verification in your environment, follow these steps:
 
-If the question behind this is "why do some extension behaviors never fire?", the most important upstream finding is that **`onSubagentStart` is not part of the bundled named hook dispatcher in this CLI install**.[^dispatch]
+1. Locate your node modules root (global or project-local):
+   - `npm root -g` for global installs, or inspect `./node_modules` for local installs.
+2. Inspect the Copilot SDK package at `<npm-root>/@github/copilot/copilot-sdk` (or the project-local equivalent): open `types.d.ts` to review the `SessionHooks` interface and open `index.js` to inspect the runtime dispatch table.
+3. Confirm what the running SDK registers by resolving the package from Node (example):
+   - `node -e "console.log(require.resolve('@github/copilot/copilot-sdk'))"`
+
+These steps reproduce the same evidence used for this snapshot without assuming `/opt/homebrew` or any single install path.
+
+If a local extension defines `onSubagentStart`, note that sub-agent lifecycle events are also available via the session event stream; they are present in the generated event schema but not advertised as an additional named hook in the bundled `SessionHooks` surface.[^dispatch]
 
 ## Confidence Assessment
 
-- **High confidence** on the six named hooks, because the installed type definitions, docs, and runtime dispatch table all agree.[^hooks-type][^dispatch][^examples-hooks]
+- **High confidence** on the seven named hooks, because the installed type definitions, docs, and runtime dispatch table all agree.[^hooks-type][^dispatch][^examples-hooks]
 - **High confidence** that sub-agent lifecycle is available as events, because the installed generated event schema enumerates those event names explicitly.[^subagent-events]
 - **High confidence** that `onEvent` is part of the join/resume configuration surface for extensions, because `JoinSessionConfig` is derived from `ResumeSessionConfig`, which includes `onEvent`.[^join-config]
 - **Medium confidence** on any undocumented hook names beyond these, because this report intentionally treats the bundled type surface and bundled dispatcher as the source of truth rather than inferring support from ad hoc local extension code.[^dispatch]
 
 ## Footnotes
 
-[^extensions-doc]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/docs/extensions.md:1-23`; `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/docs/extensions.md:39-60`
-[^join-config]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/extension.d.ts:1-19`; `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/types.d.ts:706-757`; `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/types.d.ts:762-766`
-[^hooks-type]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/types.d.ts:504-535`
-[^dispatch]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/index.js:3851-3863`
-[^examples-hooks]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/docs/examples.md:146-159`; `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/docs/examples.md:301-315`
-[^event-subscribe]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/session.d.ts:135-159`; `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/session.d.ts:224-232`
-[^subagent-events]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/generated/session-events.d.ts:2091-2242`
+[^extensions-doc]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/docs/extensions.md`
+[^join-config]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/extension.d.ts`, `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/types.d.ts`
+[^hooks-type]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/types.d.ts`
+[^dispatch]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/index.js`
+[^examples-hooks]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/docs/examples.md`
+[^event-subscribe]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/session.d.ts`
+[^subagent-events]: `/opt/homebrew/lib/node_modules/@github/copilot/copilot-sdk/generated/session-events.d.ts`

--- a/docs/copilot-sdk-hooks.md
+++ b/docs/copilot-sdk-hooks.md
@@ -131,11 +131,87 @@ DB work is always enqueued via `spawnTrackedDeferredTask` (never synchronous in 
 
 Both flags default to `false` and have no parent-flag dependencies.
 
+## Phase 3: sub-agent scoping and pre-tool guardrail
+
+Lore Phase 3 adds **sub-agent scope tracking** via the generic session event stream and a **narrow, default-off pre-tool guardrail**. Both are strictly opt-in.
+
+### Sub-agent scope tracking
+
+**Verified SDK event surface (SDK ≥ 1.0.75, `generated/session-events.d.ts`):**
+
+| Event type | Fires when | Payload fields used |
+|---|---|---|
+| `subagent.selected` | custom agent selected by user | `data.agentName`, `data.agentDisplayName` |
+| `subagent.deselected` | custom agent deselected | _(empty data)_ |
+| `subagent.started` | sub-agent execution started | `data.agentName`, `data.agentDisplayName` |
+| `subagent.completed` | sub-agent execution completed successfully | _(triggers reset)_ |
+| `subagent.failed` | sub-agent execution failed | _(triggers reset; `data.error` is never read)_ |
+
+Lore subscribes via `session.on("subagent.selected", ...)` etc. (not named hooks). Subscriptions are registered unconditionally after `joinSession`; the rollout flag is checked inside each handler at event time.
+
+| Property | Value |
+|---|---|
+| Rollout flag | `rollout.subagentScopeTracking` |
+| Default | `false` |
+| State storage | **In-memory only; never persisted** |
+| Reset events | `deselected`, `completed`, `failed`, `onSessionStart`, `onSessionEnd` |
+| Scope metadata | Additive: `{ activeSubagent: { name, displayName } }` — advisory, never blocks |
+
+**Scope attachment:** When enabled and an agent is active, the active sub-agent name is included as additive context in `onPostToolUse` trajectory artifacts and as `additionalContext` in `onPreToolUse` guardrail output. It does not alter recall results, retention logic, or any core behavior.
+
+**No-op guarantees:**
+- Unknown event shapes or malformed payloads → safe no-op.
+- `subagent.failed` `data.error` field is never read or retained.
+- The tracker holds only `agentName` (max 128 chars) and `agentDisplayName` (max 256 chars).
+
+### `onPreToolUse` guardrail
+
+| Property | Value |
+|---|---|
+| Rollout flag | `rollout.preToolUseGuardrail` |
+| Default | `false` |
+| Phase 3 behavior | Observe-only; no `permissionDecision` returned |
+| Allowlist | `lore_retain`, `lore_reflect`, `memory_save` |
+| Timeout | 50 ms (hard internal timeout; fails open) |
+
+Only tools in the explicit allowlist are observed. All others are unconditional no-ops.
+
+When the guardrail is enabled and an allowlisted tool is called while a sub-agent is active (scope tracking also enabled), it returns `{ additionalContext: "[lore scope] active sub-agent: <name>" }`. In all other cases it returns `void`.
+
+**Fail-open semantics:**
+- Timeout (>50 ms) → returns `void`.
+- Any thrown error → returns `void`.
+- Malformed/absent payload → returns `void`.
+- Disabled flag → returns `void`.
+- `permissionDecision: "deny"` is **never** returned in Phase 3.
+- Raw `toolArgs` are **never** read, logged, or persisted.
+
+### `onPreMcpToolCall` — intentionally not registered
+
+**Capability status:** Verified present in SDK ≥ 1.0.75 (`types.d.ts`). `PreMcpToolCallHookInput` has `{ serverName, toolName, arguments, _meta?, sessionId, timestamp, workingDirectory }`. Output can set `metaToUse: Record<string, unknown> | null` to inject or suppress request `_meta`.
+
+**Phase 3 decision:** No concrete Lore MCP metadata use case is verified at this time. Lore exposes its tools via the SDK tool surface, not via MCP. Injecting Lore-specific `_meta` into outgoing MCP calls has no confirmed downstream consumer. This hook is **intentionally not registered** in Phase 3. A future phase may register it if a verified use case emerges.
+
+### Enabling Phase 3 features
+
+```json
+{
+  "enabled": true,
+  "rollout": {
+    "subagentScopeTracking": true,
+    "preToolUseGuardrail": true
+  }
+}
+```
+
+Both flags default to `false`, are independent of other rollout flags, and have no effect when disabled.
+
 ## Confidence Assessment
 
 - **High confidence** on the seven named hooks, because the installed type definitions, docs, and runtime dispatch table all agree.[^hooks-type][^dispatch][^examples-hooks]
 - **High confidence** that sub-agent lifecycle is available as events, because the installed generated event schema enumerates those event names explicitly.[^subagent-events]
 - **High confidence** that `onEvent` is part of the join/resume configuration surface for extensions, because `JoinSessionConfig` is derived from `ResumeSessionConfig`, which includes `onEvent`.[^join-config]
+- **High confidence** on `onPreMcpToolCall` capability (SDK ≥ 1.0.75 types verify the interface and output shape), but **deferred** in Phase 3 due to no verified Lore-specific MCP metadata use case.
 - **Medium confidence** on any undocumented hook names beyond these, because this report intentionally treats the bundled type surface and bundled dispatcher as the source of truth rather than inferring support from ad hoc local extension code.[^dispatch]
 
 ## Footnotes

--- a/docs/copilot-sdk-hooks.md
+++ b/docs/copilot-sdk-hooks.md
@@ -79,6 +79,58 @@ These steps reproduce the same evidence used for this snapshot without assuming 
 
 If a local extension defines `onSubagentStart`, note that sub-agent lifecycle events are also available via the session event stream; they are present in the generated event schema but not advertised as an additional named hook in the bundled `SessionHooks` surface.[^dispatch]
 
+## Phase 2 passive hooks in Lore
+
+Lore Phase 2 adds two **passive, privacy-preserving** hooks. Both are **default-off** and must be explicitly opted-in via rollout flags.
+
+### `onErrorOccurred` — error telemetry
+
+| Property | Value |
+|---|---|
+| Rollout flag | `rollout.errorTelemetry` |
+| Default | `false` |
+| Phase 2 behavior | Passive observation only; **no** `errorHandling` override returned |
+| Persisted table | `error_telemetry` |
+
+**What is persisted:** `session_id`, `context_category` (e.g. `tool_use`, `network`, `permission`, `timeout`, `parse`, `unknown`), `recoverability` (`recoverable`, `unrecoverable`, `unknown`), `fingerprint` (non-reversible 16-char SHA-256 prefix), `created_at`.
+
+**What is never persisted:** `error.message`, `error.stack`, tool arguments, tool results, file contents, command output, raw payload blobs.
+
+The category and recoverability are derived from structural payload fields only (`error.name`, `error.code`, the categorical `context` descriptor, and `retryable`). The fingerprint is a SHA-256 hash of the derived categorical fields — it does not encode any free-text from the error.
+
+Retention: the table is pruned by age (`maxAgeMs = 30 days`) and by global row count (`maxRowsGlobal = 500`) every 20 writes.
+
+### `onPostToolUse` — post-tool-use observations
+
+| Property | Value |
+|---|---|
+| Rollout flag | `rollout.postToolUse` |
+| Default | `false` |
+| Phase 2 behavior | Passive observation only; no tool result modification |
+| Persisted table | `trajectory_artifact` (kind = `passive_hook_observation`) |
+
+**What is derived:** `toolCategory` (one of `bash`, `file`, `search`, `network`, `memory`, `other`) — from the tool name only. `success` — from structural payload fields (`success`, `outcome`, `status`). `argsShape` — structural metadata (is the args value parseable? is it an object? is it empty?) from JSON-string-normalised `toolArgs`.
+
+**What is never persisted:** raw `toolArgs` contents, `toolResult` contents, file contents, command output.
+
+JSON-string `toolArgs` are parsed defensively but only to extract structural shape metadata. The raw args value is never written to the DB.
+
+DB work is always enqueued via `spawnTrackedDeferredTask` (never synchronous in the hook body). Hook failures fail open and log only safe categorical metadata.
+
+### Enabling passive hooks
+
+```json
+{
+  "enabled": true,
+  "rollout": {
+    "errorTelemetry": true,
+    "postToolUse": true
+  }
+}
+```
+
+Both flags default to `false` and have no parent-flag dependencies.
+
 ## Confidence Assessment
 
 - **High confidence** on the seven named hooks, because the installed type definitions, docs, and runtime dispatch table all agree.[^hooks-type][^dispatch][^examples-hooks]

--- a/docs/maintenance-scheduling.md
+++ b/docs/maintenance-scheduling.md
@@ -113,7 +113,7 @@ For a non-standard install location, set `LORE_COPILOT_HOME`:
 
 - `cron` starts jobs with a minimal `PATH`. Use the full path to `node` (find it with `which node` or `$(command -v node)` from an interactive shell).
 - Volta or nvm-managed Node installs may not be on the `PATH` in cron's environment. Either use the full absolute path (e.g., `/Users/you/.volta/bin/node`) or set `PATH` in the crontab header.
-- The script exits 0 on success and 1 on error. Check the log for non-zero exits or `Unknown task names:` messages, which indicate a typo in `--tasks`.
+- The script exits 0 on success and 1 on error. Check the log for non-zero exits or `Unknown task names:` messages, which indicate an unrecognised name in `--tasks`. Any unknown name — even mixed with valid names — causes an immediate exit 1 before running anything.
 
 ---
 
@@ -191,7 +191,7 @@ launchctl unload ~/Library/LaunchAgents/com.lore.maintenance.plist
 
 The script exits **0** on success and **1** on any of:
 
-- Unknown task names in `--tasks` (typo protection; all-unknown exits immediately without touching the DB)
+- Any unknown task name in `--tasks` — including a mix of valid and unknown names (fail-closed: the script exits immediately before opening the DB, so no partial task set runs)
 - DB initialization or migration failure
 - Unhandled exception during sweep execution
 

--- a/docs/maintenance-scheduling.md
+++ b/docs/maintenance-scheduling.md
@@ -1,0 +1,269 @@
+# External maintenance scheduling
+
+← [README](../README.md) · [Support matrix](support-matrix.md) · [Compatibility](compatibility.md) · [CONTRIBUTING](../CONTRIBUTING.md)
+
+This document covers how to run Lore maintenance tasks reliably outside of Copilot CLI sessions using `scripts/run-maintenance.mjs` as the supported external entry point.
+
+---
+
+## Maintenance modes
+
+Lore maintenance runs in three modes. Understanding which tasks belong to each mode is essential for scheduling.
+
+| Mode | Trigger | Tasks |
+|---|---|---|
+| **Automatic** | `onSessionStart` hook | `deferredExtraction` only |
+| **Manual / in-session** | `maintenance_schedule_run` tool; `--status`; `--dry-run` | Any enabled task |
+| **External / scheduled** | `scripts/run-maintenance.mjs` via cron or launchd | Any enabled task |
+
+### Automatic maintenance (session start)
+
+When `maintenanceScheduler.enabled: true` and `maintenanceScheduler.autoRunOnSessionStart: true`, Lore evaluates the maintenance plan on `onSessionStart` and **only** runs the `deferredExtraction` task when it is enabled and due. All other tasks are intentionally excluded from the session-start path to keep that hook cheap and bounded.
+
+### Manual / in-session maintenance
+
+Within an active session, use the `maintenance_schedule_run` tool to trigger a sweep or inspect the plan:
+
+```
+maintenance_schedule_run({ dryRun: true })   # plan without mutation
+maintenance_schedule_run({ tasks: ["validationCorpus"] })
+```
+
+You can also run `--status` or `--dry-run` from a terminal at any time — these do not require an active CLI session:
+
+```sh
+node scripts/run-maintenance.mjs --status
+node scripts/run-maintenance.mjs --dry-run
+```
+
+### External / scheduled maintenance
+
+Use `scripts/run-maintenance.mjs` with cron, launchd, or another OS scheduler for wall-clock-driven upkeep. See the [cron](#cron) and [launchd](#launchd-macos) sections below.
+
+---
+
+## Hook cadence disclaimer
+
+**Session hooks do not guarantee wall-clock cadence.**
+
+`onSessionStart` fires when a Copilot CLI session begins. If you rarely start sessions — or go on holiday — the automatic `deferredExtraction` pass and any other session-start work may not run for hours or days. This is by design: Lore does not run background timers or daemons inside the extension process.
+
+For tasks that require reliable periodic execution regardless of session frequency, wire them into an external scheduler.
+
+---
+
+## Supported tasks
+
+| Task | Default enabled | Suggested cadence | Notes |
+|---|---|---|---|
+| `deferredExtraction` | `true` | Automatic at session start | Also runnable externally. Requires `deferredExtraction.enabled: true` and `deferredExtraction.autoProcessOnSessionStart: true` for session-start auto-run. |
+| `validationCorpus` | `true` | Every 12 h | Runs the validation case corpus against current retrieval behavior. |
+| `replayCorpus` | `true` | Every 24 h | Runs the replay corpus and reports ranking hits/misses. |
+| `backlogReview` | `true` | Every 6 h | Processes accumulated improvement backlog items. |
+| `traceCompaction` | `false` | Every 1 h | Compacts trace recorder samples. Requires `rollout.traceRecorder: true`. |
+| `indexUpkeep` | `false` | Every 12 h | Refreshes the memory index. |
+| `doctorSnapshot` | `false` | Every 24 h | Captures a doctor health snapshot. Requires `rollout.loreDoctor: true` and `maintenanceScheduler.tasks.doctorSnapshot: true`. |
+
+---
+
+## Configuration
+
+Scheduled maintenance reads the same `lore.json` that the extension uses at session start. All paths, rollout flags, and task enablement apply.
+
+### Path resolution order
+
+The script resolves the config path in this order:
+
+1. `--config <path>` flag
+2. `LORE_CONFIG` environment variable (exact path)
+3. `LORE_COPILOT_HOME` environment variable joined with `lore.json`
+4. `lore.json` relative to the current working directory
+
+For cron and launchd, always set `LORE_COPILOT_HOME` or `LORE_CONFIG` explicitly so the script does not depend on the working directory.
+
+### Database isolation rule
+
+Scheduled maintenance operates **only on the configured Lore database** (`~/.copilot/lore.db` or the path in your config). It must never be pointed at test fixtures, shared databases, or databases owned by other users.
+
+The `--derived-store-path` and `--raw-store-path` flags exist for legitimate path overrides (e.g., non-standard install locations), not for pointing the scheduler at fixture databases.
+
+**Failed migrations and jobs use forward recovery, not destructive downgrade.** If a schema migration or task fails, Lore records the failure and leaves the database intact. Re-running the sweep or restarting the CLI will retry the failed path forward. Do not attempt to roll back schema changes manually — see the [rollback guidance](releasing.md#scenario-3----db-schema-migration-causes-data-issues) in `docs/releasing.md` if you need to recover from a migration issue.
+
+---
+
+## cron
+
+Add entries to your crontab with `crontab -e`. Always redirect stderr alongside stdout so failures are not silently discarded.
+
+```cron
+# Lore maintenance — default ~/.copilot install
+# Redirect both stdout and stderr so failures appear in the log
+0 */6 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks validationCorpus,backlogReview >> ~/.copilot/lore-maintenance.log 2>&1
+15 2 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks replayCorpus,indexUpkeep,traceCompaction >> ~/.copilot/lore-maintenance.log 2>&1
+30 3 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks doctorSnapshot >> ~/.copilot/lore-maintenance.log 2>&1
+```
+
+For a non-standard install location, set `LORE_COPILOT_HOME`:
+
+```cron
+0 */6 * * * LORE_COPILOT_HOME=/path/to/copilot-home node /path/to/lore/scripts/run-maintenance.mjs --tasks validationCorpus,backlogReview >> /path/to/lore-maintenance.log 2>&1
+```
+
+**cron environment notes:**
+
+- `cron` starts jobs with a minimal `PATH`. Use the full path to `node` (find it with `which node` or `$(command -v node)` from an interactive shell).
+- Volta or nvm-managed Node installs may not be on the `PATH` in cron's environment. Either use the full absolute path (e.g., `/Users/you/.volta/bin/node`) or set `PATH` in the crontab header.
+- The script exits 0 on success and 1 on error. Check the log for non-zero exits or `Unknown task names:` messages, which indicate a typo in `--tasks`.
+
+---
+
+## launchd (macOS)
+
+launchd is the recommended scheduler on macOS. Create a property list at `~/Library/LaunchAgents/com.lore.maintenance.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.lore.maintenance</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <!-- Use the full path to node; find it with: which node -->
+    <string>/usr/local/bin/node</string>
+    <string>/Users/YOU/.copilot/extensions/lore/scripts/run-maintenance.mjs</string>
+    <string>--tasks</string>
+    <string>validationCorpus,backlogReview,traceCompaction</string>
+  </array>
+
+  <!-- Run every 6 hours (21600 seconds) -->
+  <key>StartInterval</key>
+  <integer>21600</integer>
+
+  <!-- Capture both stdout and stderr -->
+  <key>StandardOutPath</key>
+  <string>/Users/YOU/.copilot/lore-maintenance.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/YOU/.copilot/lore-maintenance.log</string>
+
+  <!-- Explicit home path so the script does not depend on cwd -->
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>LORE_COPILOT_HOME</key>
+    <string>/Users/YOU/.copilot</string>
+  </dict>
+</dict>
+</plist>
+```
+
+Replace `YOU` with your username. Then load and verify:
+
+```sh
+launchctl load ~/Library/LaunchAgents/com.lore.maintenance.plist
+launchctl list | grep com.lore.maintenance   # should show PID when running
+```
+
+To trigger a manual run immediately:
+
+```sh
+launchctl start com.lore.maintenance
+```
+
+To unload (stop scheduling):
+
+```sh
+launchctl unload ~/Library/LaunchAgents/com.lore.maintenance.plist
+```
+
+**launchd notes:**
+
+- `StandardOutPath` and `StandardErrorPath` pointing at the same file is the simplest way to capture interleaved output.
+- If your `node` binary is managed by Volta, use `/Users/YOU/.volta/bin/node` as the `ProgramArguments` first entry.
+- launchd jobs run as your user and inherit your keychain and file permissions. No special privilege is required.
+- Use `StartCalendarInterval` instead of `StartInterval` if you need specific clock times (e.g., run at 02:15 daily).
+
+---
+
+## Failure detection and reporting
+
+The script exits **0** on success and **1** on any of:
+
+- Unknown task names in `--tasks` (typo protection; all-unknown exits immediately without touching the DB)
+- DB initialization or migration failure
+- Unhandled exception during sweep execution
+
+**Minimum viable failure detection for cron/launchd:**
+
+1. **Log both stdout and stderr** — append both streams to a log file with `>> logfile 2>&1`.
+2. **Scan the log for non-zero exits** — if you have a monitoring system, alert on lines containing `Unknown task names:` or process exit codes ≠ 0.
+3. **Use `--dry-run` to probe** — a dry-run does not mutate state and will surface DB or config errors the same as a live run.
+
+To check whether the last run was successful without a monitoring system:
+
+```sh
+# tail the last ~20 lines of the log
+tail -20 ~/.copilot/lore-maintenance.log
+
+# or run a status check on-demand
+node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --status
+```
+
+---
+
+## Inspecting status
+
+At any time, run status or dry-run to see the current maintenance state:
+
+```sh
+# Current task states and cadence tracking (no DB write):
+node scripts/run-maintenance.mjs --status
+
+# Full plan with due/not-due and last-run ages (no DB write):
+node scripts/run-maintenance.mjs --dry-run
+
+# Scope to a specific repository:
+node scripts/run-maintenance.mjs --status --repository my-repo
+
+# Override paths for a non-standard install:
+node scripts/run-maintenance.mjs --status \
+  --derived-store-path /path/to/lore.db \
+  --raw-store-path /path/to/session-store.db
+```
+
+Output fields:
+
+| Field | Meaning |
+|---|---|
+| `status` | `ok`, `dry_run`, or error status |
+| `taskCount` | Total tasks in the plan |
+| `completedCount` | Tasks that ran and completed in this sweep |
+| `skippedCount` | Tasks skipped (not due, not enabled, or not selected) |
+| `failedCount` | Tasks that completed with errors |
+| For each task: `due`, `dueReason`, `lastRunMinutesAgo`, `nextRunMinutes` | Cadence tracking |
+
+---
+
+## Quick reference
+
+```sh
+# Show help
+node scripts/run-maintenance.mjs --help
+
+# Show recommended schedule with cron/launchd examples
+node scripts/run-maintenance.mjs --recommended-schedule
+
+# Dry-run (plan only, no state change)
+node scripts/run-maintenance.mjs --dry-run
+
+# Live sweep of specific tasks
+node scripts/run-maintenance.mjs --tasks validationCorpus,backlogReview
+
+# Force tasks regardless of cadence
+node scripts/run-maintenance.mjs --tasks indexUpkeep --force
+
+# Status check (reads DB, no writes)
+node scripts/run-maintenance.mjs --status
+```

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -132,7 +132,7 @@ This document defines which surfaces are **supported**, **experimental**, or **u
 | Script | Status | Notes |
 |---|---|---|
 | `scripts/validate-config-schema.mjs` | 🟢 Supported | Validates `lore.json` against the schema. Safe to run at any time. |
-| `scripts/run-maintenance.mjs` | 🟡 Experimental | Runs maintenance sweeps outside of session context. Use `maintenance_schedule_run` tool for in-session triggering. |
+| `scripts/run-maintenance.mjs` | 🟡 Experimental | The supported out-of-session entry point for maintenance tasks (`validationCorpus`, `replayCorpus`, `backlogReview`, `traceCompaction`, `indexUpkeep`, `doctorSnapshot`). Designed for cron, launchd, or any external scheduler. Exits 0 on success, 1 on unknown task names or DB error. Operates only on the configured Lore database — never on test fixtures or other users' databases. See [`docs/maintenance-scheduling.md`](maintenance-scheduling.md) for the full guide. Use `maintenance_schedule_run` tool for in-session triggering. |
 | `scripts/run-browser.mjs` | 🟡 Experimental | Starts the local browser dashboard. Loopback hosts only (`127.0.0.1`, `localhost`, or `::1`). |
 
 ---
@@ -192,6 +192,24 @@ These are persisted rows, so new values should be treated as contract changes an
 
 Lore's maintenance loop is intentionally bounded. It is about **runtime/data health and improvement artifacts**, not static source-code repair.
 
+### Hook cadence
+
+**Session hooks do not guarantee wall-clock cadence.** `onSessionStart` fires only when a Copilot CLI session starts. If sessions are infrequent, maintenance that depends on session start may not run for hours or days. Use `scripts/run-maintenance.mjs` with an external scheduler (cron, launchd) for wall-clock-driven upkeep.
+
+### Maintenance modes
+
+| Mode | Trigger | Tasks |
+|---|---|---|
+| Automatic | `onSessionStart` hook | `deferredExtraction` only |
+| Manual / in-session | `maintenance_schedule_run` tool; `--dry-run`; `--status` | Any enabled task |
+| External / scheduled | `scripts/run-maintenance.mjs` | Any enabled task |
+
+### Isolated database rule
+
+Scheduled maintenance operates only on the configured Lore database (default `~/.copilot/lore.db`). It must never be pointed at test fixtures, shared databases, or other users' databases. Failed migrations and jobs use forward recovery — if a task fails, the database is left intact and the failure is recorded for the next run to retry.
+
+### Auto-run conditions
+
 It auto-runs on session start only when all of these are true:
 
 - `maintenanceScheduler.enabled: true`
@@ -207,6 +225,6 @@ Additional task gates:
 - `doctorSnapshot` requires `rollout.loreDoctor: true`.
 - Proposal/integrity/review surfaces stay bounded by the `evolutionLedger`, `proposalGeneration`, `generatedArtifactIntegrity`, `reviewGate`, and `approvalSubstrate` rollout flags.
 
-You can always inspect or force the loop manually with `maintenance_schedule_run` or `node scripts/run-maintenance.mjs`.
+You can always inspect or force the loop manually with `maintenance_schedule_run` or `node scripts/run-maintenance.mjs`. See [`docs/maintenance-scheduling.md`](maintenance-scheduling.md) for the full external scheduling guide.
 
 What it **does not** currently do: statically inspect Lore's own source tree for logic mistakes like duplicated migration calls. Those still need tests, review, or future invariant checks.

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -27,6 +27,8 @@ This document defines which surfaces are **supported**, **experimental**, or **u
 | `onSessionStart` | 🟢 Supported | Initialises DB, loads config, runs cheap pre-warm. Bounded latency target: < 300 ms. |
 | `onUserPromptSubmitted` | 🟢 Supported | Injects memory capsule into prompt context when relevant. Bounded latency target: < 200 ms. Temporal prompts use date normalisation plus `day_summary` / episode lookup first, then bounded raw session-store verification only when primary temporal evidence is missing. |
 | `onSessionEnd` | 🟢 Supported | Persists session extraction to the derived store. Non-blocking best-effort. |
+| `onErrorOccurred` | 🟡 Experimental | Passive error telemetry. Requires `rollout.errorTelemetry: true` (default-off). Persists only categorical metadata to `error_telemetry` table. Never persists error messages, stack traces, or raw payloads. No `errorHandling` override in Phase 2. |
+| `onPostToolUse` | 🟡 Experimental | Passive post-tool-use observations. Requires `rollout.postToolUse: true` (default-off). Derives categorical tool kind and success/failure only. Never persists raw args or results. Enqueues observations via deferred background path. |
 
 ---
 
@@ -155,6 +157,8 @@ Experimental surfaces are controlled by rollout flags in the `rollout` section o
 | `loreDoctor` | 🟢 Supported | `true` (requires `evolutionLedger`) | `memory_doctor_report` |
 | `reviewGate` | 🟢 Supported | `true` (requires `evolutionLedger`) | `memory_review_gate` |
 | `approvalSubstrate` | 🟢 Supported | `true` (requires `evolutionLedger`) | Approval-workflow substrate for ledger-backed proposal review state |
+| `errorTelemetry` | 🟡 Experimental | `false` | Passive `onErrorOccurred` hook. Persists only categorical metadata (category, recoverability, fingerprint) to `error_telemetry`. Never persists raw messages or stack traces. No `errorHandling` overrides. |
+| `postToolUse` | 🟡 Experimental | `false` | Passive `onPostToolUse` hook. Derives categorical tool kind and success/failure. Enqueues observations via deferred background path. Never persists raw args or results. |
 
 Temporal recall notes:
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -28,7 +28,9 @@ This document defines which surfaces are **supported**, **experimental**, or **u
 | `onUserPromptSubmitted` | 🟢 Supported | Injects memory capsule into prompt context when relevant. Bounded latency target: < 200 ms. Temporal prompts use date normalisation plus `day_summary` / episode lookup first, then bounded raw session-store verification only when primary temporal evidence is missing. |
 | `onSessionEnd` | 🟢 Supported | Persists session extraction to the derived store. Non-blocking best-effort. |
 | `onErrorOccurred` | 🟡 Experimental | Passive error telemetry. Requires `rollout.errorTelemetry: true` (default-off). Persists only categorical metadata to `error_telemetry` table. Never persists error messages, stack traces, or raw payloads. No `errorHandling` override in Phase 2. |
-| `onPostToolUse` | 🟡 Experimental | Passive post-tool-use observations. Requires `rollout.postToolUse: true` (default-off). Derives categorical tool kind and success/failure only. Never persists raw args or results. Enqueues observations via deferred background path. |
+| `onPostToolUse` | 🟡 Experimental | Passive post-tool-use observations. Requires `rollout.postToolUse: true` (default-off). Derives categorical tool kind and success/failure only. Never persists raw args or results. Enqueues observations via deferred background path. When `subagentScopeTracking` is also enabled, annotates observations with the active sub-agent name. |
+| `onPreToolUse` | 🟡 Experimental | Narrow default-off guardrail (Phase 3). Requires `rollout.preToolUseGuardrail: true`. Only observes tools in the explicit allowlist (`lore_retain`, `lore_reflect`, `memory_save`). Never blocks; never persists raw args. Returns advisory `additionalContext` with active sub-agent scope when both flags are on. Fails open on timeout (50 ms), error, or malformed payload. |
+| `onPreMcpToolCall` | ⏸ Deferred | SDK capability verified (≥ 1.0.75). Intentionally not registered in Phase 3 — no concrete Lore MCP metadata use case verified. See `docs/copilot-sdk-hooks.md`. |
 
 ---
 
@@ -159,6 +161,8 @@ Experimental surfaces are controlled by rollout flags in the `rollout` section o
 | `approvalSubstrate` | 🟢 Supported | `true` (requires `evolutionLedger`) | Approval-workflow substrate for ledger-backed proposal review state |
 | `errorTelemetry` | 🟡 Experimental | `false` | Passive `onErrorOccurred` hook. Persists only categorical metadata (category, recoverability, fingerprint) to `error_telemetry`. Never persists raw messages or stack traces. No `errorHandling` overrides. |
 | `postToolUse` | 🟡 Experimental | `false` | Passive `onPostToolUse` hook. Derives categorical tool kind and success/failure. Enqueues observations via deferred background path. Never persists raw args or results. |
+| `subagentScopeTracking` | 🟡 Experimental | `false` | Phase 3. Tracks active custom agent identity via `subagent.*` session events. In-memory only; never persisted. Resets on deselection, completion, failure, and session end. Attaches additive scope metadata to `onPostToolUse` and `onPreToolUse` outputs when active. |
+| `preToolUseGuardrail` | 🟡 Experimental | `false` | Phase 3. Wires `onPreToolUse` for tools in the explicit Lore allowlist (`lore_retain`, `lore_reflect`, `memory_save`). Observe-only; never blocks; fails open on timeout (50 ms), error, or malformed payload. No raw args persisted. |
 
 Temporal recall notes:
 

--- a/extension.mjs
+++ b/extension.mjs
@@ -32,11 +32,14 @@ import {
   readOverlayAutoHydrationEnabled,
   readErrorTelemetryEnabled,
   readPostToolUseEnabled,
+  readSubagentScopeTrackingEnabled,
 } from "./lib/rollout-flags.mjs";
 import {
   buildErrorTelemetryRecord,
   buildPostToolUseObservation,
 } from "./lib/passive-hooks.mjs";
+import { createSubagentScopeTracker } from "./lib/subagent-scope-tracker.mjs";
+import { runPreToolUseGuardrail } from "./lib/pre-tool-use-guardrail.mjs";
 import { setTimeout as delay } from "node:timers/promises";
 
 let lastKnownCwd = process.cwd();
@@ -46,6 +49,7 @@ const metrics = {
   userPromptSubmittedMs: [],
   errorTelemetryMs: [],
   postToolUseMs: [],
+  preToolUseMs: [],
 };
 
 const capsuleCache = new Map();
@@ -1429,11 +1433,15 @@ function maybeCompactErrorTelemetry(activeRuntime) {
 
 import { buildLoreHooks } from "./lib/hook-registration.mjs";
 
+// Session-local sub-agent scope tracker. Reset on session end.
+const subagentScopeTracker = createSubagentScopeTracker();
+
 const session = await joinSession({
   onPermissionRequest: approveAll,
   hooks: buildLoreHooks({
     onSessionStart: async (input, invocation) => {
       lastKnownCwd = input.cwd || lastKnownCwd;
+      subagentScopeTracker.reset(); // clear any stale state from previous session
       return handleSessionStartHook({ session, invocation, input, metrics });
     },
 
@@ -1500,6 +1508,7 @@ const session = await joinSession({
 
     onSessionEnd: async (input, invocation) => {
       lastKnownCwd = input.cwd || lastKnownCwd;
+      subagentScopeTracker.reset(); // ensure no scope state leaks past session end
       return handleSessionEndHook({ session, invocation, input });
     },
 
@@ -1541,7 +1550,7 @@ const session = await joinSession({
       // Phase 2: no errorHandling override returned
     },
 
-    onPostToolUse: async (input, invocation) => {
+    onPostToolUse: async (input, _invocation) => {
       const startedAt = Date.now();
       try {
         const activeRuntime = runtime;
@@ -1555,6 +1564,9 @@ const session = await joinSession({
         if (!observation) {
           return;
         }
+        const scopeMeta = readSubagentScopeTrackingEnabled(activeRuntime.config)
+          ? subagentScopeTracker.getActiveScopeMetadata()
+          : null;
         spawnTrackedDeferredTask(async () => {
           try {
             activeRuntime.db.insertTrajectoryArtifact({
@@ -1568,6 +1580,7 @@ const session = await joinSession({
                 toolCategory: observation.toolCategory,
                 success: observation.success,
                 argsShape: observation.argsShape,
+                ...(scopeMeta ? { activeSubagent: scopeMeta.activeSubagent.name } : {}),
               },
             });
           } catch (error) {
@@ -1588,6 +1601,33 @@ const session = await joinSession({
         );
       }
     },
+
+    // onPreToolUse — narrow default-off guardrail (Phase 3).
+    // Only active when rollout.preToolUseGuardrail is true.
+    // Observes only the explicit Lore-relevant tool allowlist.
+    // Never blocks; fails open on any error, timeout, or malformed payload.
+    // onPreMcpToolCall is intentionally not registered: the SDK capability is
+    // verified (PreMcpToolCallHookInput + metaToUse output, SDK ≥ 1.0.75) but
+    // no concrete Lore MCP metadata use case is verified at this time.
+    // See docs/copilot-sdk-hooks.md for rationale.
+    onPreToolUse: async (input, _invocation) => {
+      const startedAt = Date.now();
+      try {
+        return await runPreToolUseGuardrail(input, {
+          config: runtime.config,
+          scopeTracker: subagentScopeTracker,
+        });
+      } catch {
+        // fail open — pre-tool hook must never throw to the SDK
+        return undefined;
+      } finally {
+        recordMetric(
+          metrics.preToolUseMs,
+          Date.now() - startedAt,
+          runtime.config?.limits?.metricWindowSize ?? 200,
+        );
+      }
+    },
   }),
   tools: createMemoryTools({
     getRuntime: async (sessionId) => {
@@ -1600,6 +1640,65 @@ const session = await joinSession({
       };
     },
   }),
+});
+
+// Subscribe to verified sub-agent events for scope tracking (Phase 3).
+// Handlers check runtime.config at event time so the config is always loaded.
+// These event subscriptions are safe to wire unconditionally; the guard inside
+// each handler enforces the rollout flag before touching any state.
+session.on("subagent.selected", (event) => {
+  try {
+    if (!runtime.config || !readSubagentScopeTrackingEnabled(runtime.config)) {
+      return;
+    }
+    subagentScopeTracker.handleSelected(event);
+  } catch {
+    // safe no-op — event handler must never throw
+  }
+});
+
+session.on("subagent.deselected", (event) => {
+  try {
+    if (!runtime.config || !readSubagentScopeTrackingEnabled(runtime.config)) {
+      return;
+    }
+    subagentScopeTracker.handleDeselected(event);
+  } catch {
+    // safe no-op
+  }
+});
+
+session.on("subagent.started", (event) => {
+  try {
+    if (!runtime.config || !readSubagentScopeTrackingEnabled(runtime.config)) {
+      return;
+    }
+    subagentScopeTracker.handleStarted(event);
+  } catch {
+    // safe no-op
+  }
+});
+
+session.on("subagent.completed", (event) => {
+  try {
+    if (!runtime.config || !readSubagentScopeTrackingEnabled(runtime.config)) {
+      return;
+    }
+    subagentScopeTracker.handleCompleted(event);
+  } catch {
+    // safe no-op
+  }
+});
+
+session.on("subagent.failed", (event) => {
+  try {
+    if (!runtime.config || !readSubagentScopeTrackingEnabled(runtime.config)) {
+      return;
+    }
+    subagentScopeTracker.handleFailed(event);
+  } catch {
+    // safe no-op
+  }
 });
 
 await ensureRuntime(session);

--- a/extension.mjs
+++ b/extension.mjs
@@ -28,7 +28,15 @@ import {
 import { assembleMemoryCapsule, detectPromptContextNeed } from "./lib/capsule-assembler.mjs";
 import { hydrateWorkstreamOverlay } from "./lib/overlay-hydrator.mjs";
 import { seedOnboardingMemories } from "./lib/onboarding.mjs";
-import { readOverlayAutoHydrationEnabled } from "./lib/rollout-flags.mjs";
+import {
+  readOverlayAutoHydrationEnabled,
+  readErrorTelemetryEnabled,
+  readPostToolUseEnabled,
+} from "./lib/rollout-flags.mjs";
+import {
+  buildErrorTelemetryRecord,
+  buildPostToolUseObservation,
+} from "./lib/passive-hooks.mjs";
 import { setTimeout as delay } from "node:timers/promises";
 
 let lastKnownCwd = process.cwd();
@@ -36,6 +44,8 @@ let lastKnownCwd = process.cwd();
 const metrics = {
   sessionStartMs: [],
   userPromptSubmittedMs: [],
+  errorTelemetryMs: [],
+  postToolUseMs: [],
 };
 
 const capsuleCache = new Map();
@@ -55,6 +65,7 @@ const runtime = {
   processingMaintenance: false,
   processingBackfill: false,
   tracePersistenceWrites: 0,
+  errorTelemetryWrites: 0,
   pendingWork: new Set(),
   shuttingDown: false,
 };
@@ -270,6 +281,17 @@ function buildLatencyMetric(values, minSamples, targetMs) {
   };
 }
 
+function buildSimpleLatencyMetric(values) {
+  const samples = values.length;
+  return {
+    samples,
+    averageMs: Math.round(average(values)),
+    p95Ms: Math.round(percentile(values, 0.95)),
+    maxMs: Math.round(samples > 0 ? Math.max(...values) : 0),
+    latestMs: Math.round(values.at(-1) ?? 0),
+  };
+}
+
 function buildLatencyMetrics(config) {
   const minSamples = {
     sessionStart: Math.max(1, Number(config?.latencyReadinessMinSamples?.sessionStart ?? 20)),
@@ -302,6 +324,10 @@ function buildLatencyMetrics(config) {
     sampleSize: {
       sessionStart: sessionStartWithTarget.samples,
       userPromptSubmitted: userPromptSubmitted.samples,
+    },
+    passiveHooks: {
+      errorTelemetry: buildSimpleLatencyMetric(metrics.errorTelemetryMs),
+      postToolUse: buildSimpleLatencyMetric(metrics.postToolUseMs),
     },
   };
 }
@@ -1390,6 +1416,17 @@ async function recordUserPromptBypassObservation({
   });
 }
 
+function maybeCompactErrorTelemetry(activeRuntime) {
+  activeRuntime.errorTelemetryWrites = (activeRuntime.errorTelemetryWrites ?? 0) + 1;
+  if (activeRuntime.errorTelemetryWrites % 20 !== 0) {
+    return;
+  }
+  activeRuntime.db.pruneErrorTelemetry({
+    maxRowsGlobal: 500,
+    maxAgeMs: 30 * 24 * 60 * 60 * 1000,
+  });
+}
+
 import { buildLoreHooks } from "./lib/hook-registration.mjs";
 
 const session = await joinSession({
@@ -1464,6 +1501,92 @@ const session = await joinSession({
     onSessionEnd: async (input, invocation) => {
       lastKnownCwd = input.cwd || lastKnownCwd;
       return handleSessionEndHook({ session, invocation, input });
+    },
+
+    onErrorOccurred: async (input, invocation) => {
+      const startedAt = Date.now();
+      try {
+        const activeRuntime = runtime;
+        if (!readErrorTelemetryEnabled(activeRuntime.config)) {
+          return;
+        }
+        if (!activeRuntime.initialized || !activeRuntime.db || !hooksEnabled(activeRuntime.config)) {
+          return;
+        }
+        const record = buildErrorTelemetryRecord(input, invocation?.sessionId);
+        if (!record) {
+          return;
+        }
+        spawnTrackedDeferredTask(async () => {
+          try {
+            activeRuntime.db.insertErrorTelemetry(record);
+            maybeCompactErrorTelemetry(activeRuntime);
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            await session.log(`lore error telemetry persistence warning: ${message}`, {
+              ephemeral: true,
+              level: "warning",
+            });
+          }
+        });
+      } catch {
+        // fail open — passive hook must never throw to the SDK
+      } finally {
+        recordMetric(
+          metrics.errorTelemetryMs,
+          Date.now() - startedAt,
+          runtime.config?.limits?.metricWindowSize ?? 200,
+        );
+      }
+      // Phase 2: no errorHandling override returned
+    },
+
+    onPostToolUse: async (input, invocation) => {
+      const startedAt = Date.now();
+      try {
+        const activeRuntime = runtime;
+        if (!readPostToolUseEnabled(activeRuntime.config)) {
+          return;
+        }
+        if (!activeRuntime.initialized || !activeRuntime.db || !hooksEnabled(activeRuntime.config)) {
+          return;
+        }
+        const observation = buildPostToolUseObservation(input);
+        if (!observation) {
+          return;
+        }
+        spawnTrackedDeferredTask(async () => {
+          try {
+            activeRuntime.db.insertTrajectoryArtifact({
+              kind: "passive_hook_observation",
+              repository: null,
+              summary: `${observation.toolCategory}/${observation.success ? "success" : "failure"}`,
+              severity: observation.success ? "info" : "warning",
+              outcome: "captured",
+              context: {
+                hookKind: "onPostToolUse",
+                toolCategory: observation.toolCategory,
+                success: observation.success,
+                argsShape: observation.argsShape,
+              },
+            });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            await session.log(`lore post-tool observation warning: ${message}`, {
+              ephemeral: true,
+              level: "warning",
+            });
+          }
+        });
+      } catch {
+        // fail open — passive hook must never throw to the SDK
+      } finally {
+        recordMetric(
+          metrics.postToolUseMs,
+          Date.now() - startedAt,
+          runtime.config?.limits?.metricWindowSize ?? 200,
+        );
+      }
     },
   }),
   tools: createMemoryTools({

--- a/extension.mjs
+++ b/extension.mjs
@@ -55,7 +55,94 @@ const runtime = {
   processingMaintenance: false,
   processingBackfill: false,
   tracePersistenceWrites: 0,
+  pendingWork: new Set(),
+  shuttingDown: false,
 };
+
+/**
+ * Register a background promise in the runtime tracking set.
+ * The promise is removed automatically when it settles so the set only
+ * contains in-flight work.
+ *
+ * @param {Promise<unknown>} promise
+ */
+function trackBackgroundWork(promise) {
+  runtime.pendingWork.add(promise);
+  promise.finally(() => {
+    runtime.pendingWork.delete(promise);
+  });
+}
+
+/**
+ * Spawn a tracked microtask.  The async function is called via
+ * Promise.resolve() so it runs in the next microtask checkpoint, equivalent
+ * to queueMicrotask, but the resulting promise is registered in
+ * runtime.pendingWork so shutdownRuntime can drain it.
+ *
+ * Returns without spawning if shutdown has already been requested.
+ *
+ * @param {() => Promise<unknown>} fn
+ */
+function spawnTrackedMicrotask(fn) {
+  if (runtime.shuttingDown) {
+    return;
+  }
+  trackBackgroundWork(Promise.resolve().then(fn));
+}
+
+/**
+ * Spawn a tracked deferred task via setTimeout(0).  Equivalent to the
+ * existing setTimeout(async () => {...}, 0) pattern, but the resulting
+ * promise is registered in runtime.pendingWork so shutdownRuntime can drain
+ * it.
+ *
+ * Returns without spawning if shutdown has already been requested.
+ *
+ * @param {() => Promise<unknown>} fn
+ */
+function spawnTrackedDeferredTask(fn) {
+  if (runtime.shuttingDown) {
+    return;
+  }
+  const p = new Promise((resolve, reject) => {
+    setTimeout(() => {
+      Promise.resolve().then(fn).then(resolve, reject);
+    }, 0);
+  });
+  trackBackgroundWork(p);
+}
+
+/**
+ * Initiate a bounded shutdown of the extension runtime.
+ *
+ * Marks the runtime as shutting down (so no new background work is spawned),
+ * waits up to gracePeriodMs for any in-flight background jobs to settle, then
+ * closes the database exactly once.  Safe to call multiple times — the flag
+ * ensures only the first invocation does real work.
+ *
+ * @param {object} session - Copilot session (used for graceful drain logs)
+ * @param {number} [gracePeriodMs=4000]
+ */
+async function shutdownRuntime(session, gracePeriodMs = 4000) {
+  if (runtime.shuttingDown) {
+    return;
+  }
+  runtime.shuttingDown = true;
+
+  if (runtime.pendingWork.size > 0) {
+    await Promise.race([
+      Promise.allSettled([...runtime.pendingWork]),
+      delay(gracePeriodMs),
+    ]);
+  }
+
+  try {
+    runtime.db?.close();
+  } catch {
+    // best-effort close; never rethrow from shutdown path
+  }
+  runtime.db = null;
+}
 
 function recordMetric(values, value, windowSize) {
   values.push(value);
@@ -762,7 +849,7 @@ function resolveTraceSuccessRecord(traceResult) {
   };
 }
 
-function persistTraceSuccess({ activeRuntime, repository, traceResult, durationMs, hook }) {
+function persistTraceSuccess({ activeRuntime, repository, traceResult, durationMs, hook, session }) {
   if (!activeRuntime?.db || !traceResult || typeof traceResult !== "object") {
     return;
   }
@@ -771,7 +858,7 @@ function persistTraceSuccess({ activeRuntime, repository, traceResult, durationM
     return;
   }
 
-  queueMicrotask(() => {
+  spawnTrackedMicrotask(async () => {
     try {
       const { recordedAt, traceUpdates, contextInjectionUpdates } = buildTraceSuccessUpdates({
         traceRecord,
@@ -798,8 +885,13 @@ function persistTraceSuccess({ activeRuntime, repository, traceResult, durationM
         hook,
         recordedAt,
       });
-    } catch {
-      // best-effort visibility persistence; never block hook path
+    } catch (error) {
+      // best-effort visibility persistence; warn but never block hook path
+      const message = error instanceof Error ? error.message : String(error);
+      await session.log(`lore trace persistence warning: ${message}`, {
+        ephemeral: true,
+        level: "warning",
+      });
     }
   });
 }
@@ -923,6 +1015,8 @@ async function handleSessionEndHook({
       level: "warning",
     });
   }
+
+  await shutdownRuntime(session);
 }
 
 async function maybeProcessDeferredExtractions(session, activeRuntime, repository) {
@@ -935,7 +1029,7 @@ async function maybeProcessDeferredExtractions(session, activeRuntime, repositor
   }
 
   activeRuntime.processingDeferred = true;
-  queueMicrotask(async () => {
+  spawnTrackedMicrotask(async () => {
     try {
       const result = await processDeferredExtractions({
         db: activeRuntime.db,
@@ -982,7 +1076,7 @@ async function maybeRunMaintenanceScheduler(session, activeRuntime, repository) 
   }
 
   activeRuntime.processingMaintenance = true;
-  queueMicrotask(async () => {
+  spawnTrackedMicrotask(async () => {
     try {
       const result = await runMaintenanceSweep({
         runtime: {
@@ -1045,7 +1139,7 @@ async function maybeRunSessionStartBackfill(session, activeRuntime, repository) 
   }
 
   activeRuntime.processingBackfill = true;
-  setTimeout(async () => {
+  spawnTrackedDeferredTask(async () => {
     try {
       await runSessionStartBackfillWork({
         session,
@@ -1063,7 +1157,7 @@ async function maybeRunSessionStartBackfill(session, activeRuntime, repository) 
     } finally {
       activeRuntime.processingBackfill = false;
     }
-  }, 0);
+  });
 }
 
 function maybeHydrateOverlay(session, activeRuntime, workspacePath, repository, sessionId) {
@@ -1073,7 +1167,7 @@ function maybeHydrateOverlay(session, activeRuntime, workspacePath, repository, 
   if (!activeRuntime.db || !workspacePath) {
     return;
   }
-  queueMicrotask(async () => {
+  spawnTrackedMicrotask(async () => {
     try {
       await hydrateWorkstreamOverlay({
         db: activeRuntime.db,
@@ -1161,6 +1255,7 @@ function recordHookTraceAndMetric({
   durationMs,
   hook,
   metricWindow,
+  session,
 }) {
   persistTraceSuccess({
     activeRuntime,
@@ -1168,6 +1263,7 @@ function recordHookTraceAndMetric({
     traceResult,
     durationMs,
     hook,
+    session,
   });
   recordMetric(
     metricWindow,
@@ -1226,6 +1322,7 @@ async function finalizeHookObservation({
     durationMs,
     hook,
     metricWindow,
+    session,
   });
   if (!includeLatencyWarning) {
     return;

--- a/extension.mjs
+++ b/extension.mjs
@@ -989,34 +989,32 @@ async function handleSessionEndHook({
 
   try {
     const extraction = readSessionEndExtraction(activeRuntime, invocation.sessionId);
-    if (!extraction) {
-      return;
+    if (extraction) {
+      applySessionExtraction({
+        db: activeRuntime.db,
+        sessionId: invocation.sessionId,
+        repository,
+        sessionArtifacts: extraction,
+        workspace,
+      });
+      maybeEnqueueDeferredSessionExtraction(activeRuntime, invocation.sessionId, repository);
     }
 
-    applySessionExtraction({
-      db: activeRuntime.db,
-      sessionId: invocation.sessionId,
-      repository,
-      sessionArtifacts: extraction,
-      workspace,
-    });
-    maybeEnqueueDeferredSessionExtraction(activeRuntime, invocation.sessionId, repository);
+    if (input.reason === "error") {
+      await session.log("lore observed session end with error", {
+        ephemeral: true,
+        level: "warning",
+      });
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     await session.log(`lore session-end extraction skipped: ${message}`, {
       ephemeral: true,
       level: "warning",
     });
+  } finally {
+    await shutdownRuntime(session);
   }
-
-  if (input.reason === "error") {
-    await session.log("lore observed session end with error", {
-      ephemeral: true,
-      level: "warning",
-    });
-  }
-
-  await shutdownRuntime(session);
 }
 
 async function maybeProcessDeferredExtractions(session, activeRuntime, repository) {

--- a/extension.mjs
+++ b/extension.mjs
@@ -1297,82 +1297,80 @@ async function recordUserPromptBypassObservation({
 
 import { buildLoreHooks } from "./lib/hook-registration.mjs";
 
-const handlers = {
-  onSessionStart: async (input, invocation) => {
-    lastKnownCwd = input.cwd || lastKnownCwd;
-    return handleSessionStartHook({ session, invocation, input, metrics });
-  },
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+  hooks: buildLoreHooks({
+    onSessionStart: async (input, invocation) => {
+      lastKnownCwd = input.cwd || lastKnownCwd;
+      return handleSessionStartHook({ session, invocation, input, metrics });
+    },
 
-  onUserPromptSubmitted: async (input, invocation) => {
-    const startedAt = Date.now();
-    lastKnownCwd = input.cwd || lastKnownCwd;
+    onUserPromptSubmitted: async (input, invocation) => {
+      const startedAt = Date.now();
+      lastKnownCwd = input.cwd || lastKnownCwd;
 
-    const context = await getContext(session, invocation.sessionId, input.cwd);
-    const { runtime: activeRuntime, repository } = context;
+      const context = await getContext(session, invocation.sessionId, input.cwd);
+      const { runtime: activeRuntime, repository } = context;
 
-    if (isHookRuntimeUnavailable(activeRuntime) || !hooksEnabled(activeRuntime.config)) {
-      return;
-    }
+      if (isHookRuntimeUnavailable(activeRuntime) || !hooksEnabled(activeRuntime.config)) {
+        return;
+      }
 
-    const need = detectPromptContextNeed(input.prompt);
-    const hasAmbientInteractionStyle = readAmbientInteractionStylePresence(activeRuntime);
-    if (!need.requiresLookup && !hasAmbientInteractionStyle) {
-      await recordUserPromptBypassObservation({
+      const need = detectPromptContextNeed(input.prompt);
+      const hasAmbientInteractionStyle = readAmbientInteractionStylePresence(activeRuntime);
+      if (!need.requiresLookup && !hasAmbientInteractionStyle) {
+        await recordUserPromptBypassObservation({
+          session,
+          activeRuntime,
+          repository,
+          inputPrompt: input.prompt,
+          need,
+          durationMs: Date.now() - startedAt,
+        });
+        return;
+      }
+
+      const recall = recallMemory({
+        db: activeRuntime.db,
+        prompt: input.prompt,
+        repository,
+        includeOtherRepositories: need.allowCrossRepoFallback === true,
+        limit: activeRuntime.config.limits.promptContextLimit,
+        sessionStore: activeRuntime.sessionStore,
+        promptNeed: need,
+      });
+      const additionalContext = recall.text;
+
+      await finalizeHookObservation({
         session,
         activeRuntime,
         repository,
-        inputPrompt: input.prompt,
-        need,
+        hook: "onUserPromptSubmitted",
+        prompt: input.prompt,
+        promptNeed: need,
+        trace: recall.trace,
+        contextText: additionalContext,
         durationMs: Date.now() - startedAt,
+        metricWindow: metrics.userPromptSubmittedMs,
+        latencyMetric: "userPromptSubmitted",
+        hookLabel: "lore onUserPromptSubmitted",
+        targetMs: activeRuntime.config.latencyTargetsMs.userPromptSubmittedP95,
       });
-      return;
-    }
 
-    const recall = recallMemory({
-      db: activeRuntime.db,
-      prompt: input.prompt,
-      repository,
-      includeOtherRepositories: need.allowCrossRepoFallback === true,
-      limit: activeRuntime.config.limits.promptContextLimit,
-      sessionStore: activeRuntime.sessionStore,
-      promptNeed: need,
-    });
-    const additionalContext = recall.text;
+      if (!additionalContext) {
+        return;
+      }
 
-    await finalizeHookObservation({
-      session,
-      activeRuntime,
-      repository,
-      hook: "onUserPromptSubmitted",
-      prompt: input.prompt,
-      promptNeed: need,
-      trace: recall.trace,
-      contextText: additionalContext,
-      durationMs: Date.now() - startedAt,
-      metricWindow: metrics.userPromptSubmittedMs,
-      latencyMetric: "userPromptSubmitted",
-      hookLabel: "lore onUserPromptSubmitted",
-      targetMs: activeRuntime.config.latencyTargetsMs.userPromptSubmittedP95,
-    });
+      return {
+        additionalContext,
+      };
+    },
 
-    if (!additionalContext) {
-      return;
-    }
-
-    return {
-      additionalContext,
-    };
-  },
-
-  onSessionEnd: async (input, invocation) => {
-    lastKnownCwd = input.cwd || lastKnownCwd;
-    return handleSessionEndHook({ session, invocation, input });
-  },
-};
-
-const session = await joinSession({
-  onPermissionRequest: approveAll,
-  hooks: buildLoreHooks(handlers),
+    onSessionEnd: async (input, invocation) => {
+      lastKnownCwd = input.cwd || lastKnownCwd;
+      return handleSessionEndHook({ session, invocation, input });
+    },
+  }),
   tools: createMemoryTools({
     getRuntime: async (sessionId) => {
       const context = await getContext(session, sessionId, lastKnownCwd);

--- a/extension.mjs
+++ b/extension.mjs
@@ -1295,80 +1295,84 @@ async function recordUserPromptBypassObservation({
   });
 }
 
-const session = await joinSession({
-  onPermissionRequest: approveAll,
-  hooks: {
-    onSessionStart: async (input, invocation) => {
-      lastKnownCwd = input.cwd || lastKnownCwd;
-      return handleSessionStartHook({ session, invocation, input, metrics });
-    },
+import { buildLoreHooks } from "./lib/hook-registration.mjs";
 
-    onUserPromptSubmitted: async (input, invocation) => {
-      const startedAt = Date.now();
-      lastKnownCwd = input.cwd || lastKnownCwd;
+const handlers = {
+  onSessionStart: async (input, invocation) => {
+    lastKnownCwd = input.cwd || lastKnownCwd;
+    return handleSessionStartHook({ session, invocation, input, metrics });
+  },
 
-      const context = await getContext(session, invocation.sessionId, input.cwd);
-      const { runtime: activeRuntime, repository } = context;
+  onUserPromptSubmitted: async (input, invocation) => {
+    const startedAt = Date.now();
+    lastKnownCwd = input.cwd || lastKnownCwd;
 
-      if (isHookRuntimeUnavailable(activeRuntime) || !hooksEnabled(activeRuntime.config)) {
-        return;
-      }
+    const context = await getContext(session, invocation.sessionId, input.cwd);
+    const { runtime: activeRuntime, repository } = context;
 
-      const need = detectPromptContextNeed(input.prompt);
-      const hasAmbientInteractionStyle = readAmbientInteractionStylePresence(activeRuntime);
-      if (!need.requiresLookup && !hasAmbientInteractionStyle) {
-        await recordUserPromptBypassObservation({
-          session,
-          activeRuntime,
-          repository,
-          inputPrompt: input.prompt,
-          need,
-          durationMs: Date.now() - startedAt,
-        });
-        return;
-      }
+    if (isHookRuntimeUnavailable(activeRuntime) || !hooksEnabled(activeRuntime.config)) {
+      return;
+    }
 
-      const recall = recallMemory({
-        db: activeRuntime.db,
-        prompt: input.prompt,
-        repository,
-        includeOtherRepositories: need.allowCrossRepoFallback === true,
-        limit: activeRuntime.config.limits.promptContextLimit,
-        sessionStore: activeRuntime.sessionStore,
-        promptNeed: need,
-      });
-      const additionalContext = recall.text;
-
-      await finalizeHookObservation({
+    const need = detectPromptContextNeed(input.prompt);
+    const hasAmbientInteractionStyle = readAmbientInteractionStylePresence(activeRuntime);
+    if (!need.requiresLookup && !hasAmbientInteractionStyle) {
+      await recordUserPromptBypassObservation({
         session,
         activeRuntime,
         repository,
-        hook: "onUserPromptSubmitted",
-        prompt: input.prompt,
-        promptNeed: need,
-        trace: recall.trace,
-        contextText: additionalContext,
+        inputPrompt: input.prompt,
+        need,
         durationMs: Date.now() - startedAt,
-        metricWindow: metrics.userPromptSubmittedMs,
-        latencyMetric: "userPromptSubmitted",
-        hookLabel: "lore onUserPromptSubmitted",
-        targetMs: activeRuntime.config.latencyTargetsMs.userPromptSubmittedP95,
       });
+      return;
+    }
 
-      if (!additionalContext) {
-        return;
-      }
+    const recall = recallMemory({
+      db: activeRuntime.db,
+      prompt: input.prompt,
+      repository,
+      includeOtherRepositories: need.allowCrossRepoFallback === true,
+      limit: activeRuntime.config.limits.promptContextLimit,
+      sessionStore: activeRuntime.sessionStore,
+      promptNeed: need,
+    });
+    const additionalContext = recall.text;
 
-      return {
-        additionalContext,
-      };
-    },
+    await finalizeHookObservation({
+      session,
+      activeRuntime,
+      repository,
+      hook: "onUserPromptSubmitted",
+      prompt: input.prompt,
+      promptNeed: need,
+      trace: recall.trace,
+      contextText: additionalContext,
+      durationMs: Date.now() - startedAt,
+      metricWindow: metrics.userPromptSubmittedMs,
+      latencyMetric: "userPromptSubmitted",
+      hookLabel: "lore onUserPromptSubmitted",
+      targetMs: activeRuntime.config.latencyTargetsMs.userPromptSubmittedP95,
+    });
 
-    onSessionEnd: async (input, invocation) => {
-      lastKnownCwd = input.cwd || lastKnownCwd;
-      return handleSessionEndHook({ session, invocation, input });
-    },
+    if (!additionalContext) {
+      return;
+    }
+
+    return {
+      additionalContext,
+    };
   },
+
+  onSessionEnd: async (input, invocation) => {
+    lastKnownCwd = input.cwd || lastKnownCwd;
+    return handleSessionEndHook({ session, invocation, input });
+  },
+};
+
+const session = await joinSession({
+  onPermissionRequest: approveAll,
+  hooks: buildLoreHooks(handlers),
   tools: createMemoryTools({
     getRuntime: async (sessionId) => {
       const context = await getContext(session, sessionId, lastKnownCwd);

--- a/lib/backfill.mjs
+++ b/lib/backfill.mjs
@@ -4,6 +4,17 @@ import { extractSessionMemories } from "./rule-extractor.mjs";
 import { enhanceSessionExtractionWithLocalInference } from "./local-inference-extraction.mjs";
 import { setTimeout as delay } from "node:timers/promises";
 
+/**
+ * Generate a lightweight unique token for deferred extraction lease ownership.
+ * Uses process PID + timestamp + random suffix — no crypto dependency needed
+ * for this local, in-process lock mechanism.
+ *
+ * @returns {string}
+ */
+function generateOwnerToken() {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
 function shouldTrackSessionImprovement(memory) {
   return memory?.type === "assistant_goal" || memory?.type === "recurring_mistake";
 }
@@ -274,6 +285,7 @@ async function processDeferredExtractionJob({
   repository,
   job,
   fetchImpl,
+  ownerToken,
 }) {
   const artifacts = sessionStore.getSessionArtifacts(job.session_id);
   if (!artifacts) {
@@ -288,6 +300,10 @@ async function processDeferredExtractionJob({
     workspace,
     fetchImpl,
   });
+  // applySessionExtraction writes are idempotent: upsertEpisodeDigest uses
+  // ON CONFLICT(session_id) DO UPDATE and insertSemanticMemory uses a
+  // find-before-upsert pattern — so a reclaimed worker processing the same
+  // session will produce the same result without creating duplicates.
   applySessionExtraction({
     db,
     sessionId: job.session_id,
@@ -296,8 +312,47 @@ async function processDeferredExtractionJob({
     workspace,
     extraction: prepared.extraction,
   });
-  db.completeDeferredExtraction(job.session_id);
+  db.completeDeferredExtraction(job.session_id, ownerToken);
   return prepared;
+}
+
+/**
+ * Wrap processDeferredExtractionJob with a heartbeat interval so the lease
+ * stays alive during long-running extraction work.  Clears the interval on
+ * completion or error, ensuring no dangling timers.
+ *
+ * @param {object} params
+ * @param {number} [params.heartbeatIntervalMs=120000] - How often to renew (default 2 min)
+ * @param {number} [params.leaseDurationMs=600000] - Each renewal extends lease by this (default 10 min)
+ */
+async function processDeferredExtractionJobWithHeartbeat({
+  db,
+  sessionStore,
+  repository,
+  job,
+  fetchImpl,
+  ownerToken,
+  heartbeatIntervalMs = 2 * 60 * 1000,
+  leaseDurationMs = 10 * 60 * 1000,
+}) {
+  let heartbeatInterval = null;
+  try {
+    heartbeatInterval = setInterval(() => {
+      db.heartbeatDeferredExtraction(job.session_id, ownerToken, leaseDurationMs);
+    }, heartbeatIntervalMs);
+    return await processDeferredExtractionJob({
+      db,
+      sessionStore,
+      repository,
+      job,
+      fetchImpl,
+      ownerToken,
+    });
+  } finally {
+    if (heartbeatInterval !== null) {
+      clearInterval(heartbeatInterval);
+    }
+  }
 }
 
 export async function processDeferredExtractions({
@@ -308,11 +363,16 @@ export async function processDeferredExtractions({
   retryDelayMinutes = 15,
   fetchImpl = globalThis.fetch,
 }) {
+  // Reap any running jobs whose leases have expired before claiming new ones
+  // so that stale in-flight attempts from dead workers become retryable.
+  db.reclaimStaleDeferredExtractions?.();
+
   const jobs = db.listDeferredExtractions({
     repository,
     limit,
   });
 
+  const ownerToken = generateOwnerToken();
   let processed = 0;
   let failed = 0;
   let inferenceUsed = 0;
@@ -320,14 +380,19 @@ export async function processDeferredExtractions({
   const inferenceErrors = [];
 
   for (const job of jobs) {
-    db.markDeferredExtractionRunning(job.session_id);
+    const claimed = db.claimDeferredExtraction(job.session_id, ownerToken);
+    if (!claimed) {
+      // Another worker claimed this job between listDeferredExtractions and now.
+      continue;
+    }
     try {
-      const result = await processDeferredExtractionJob({
+      const result = await processDeferredExtractionJobWithHeartbeat({
         db,
         sessionStore,
         repository,
         job,
         fetchImpl,
+        ownerToken,
       });
       if (result.inferenceUsed) {
         inferenceUsed += 1;
@@ -345,6 +410,7 @@ export async function processDeferredExtractions({
       db.failDeferredExtraction(job.session_id, {
         errorMessage: message,
         retryDelayMinutes,
+        ownerToken,
       });
       failed += 1;
     }

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -179,6 +179,8 @@ export const USER_CONFIG_DEFAULTS = Object.freeze({
     approvalSubstrate: true,
     hybridRetrieval: true,
     ambientWorkingProfile: true,
+    errorTelemetry: false,
+    postToolUse: false,
   },
 });
 
@@ -363,6 +365,14 @@ export function normalizeRolloutConfig(rollout = {}) {
     ambientWorkingProfile: normalizeBoolean(
       rollout.ambientWorkingProfile,
       USER_CONFIG_DEFAULTS.rollout.ambientWorkingProfile,
+    ),
+    errorTelemetry: normalizeBoolean(
+      rollout.errorTelemetry,
+      USER_CONFIG_DEFAULTS.rollout.errorTelemetry,
+    ),
+    postToolUse: normalizeBoolean(
+      rollout.postToolUse,
+      USER_CONFIG_DEFAULTS.rollout.postToolUse,
     ),
   };
 }

--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -181,6 +181,8 @@ export const USER_CONFIG_DEFAULTS = Object.freeze({
     ambientWorkingProfile: true,
     errorTelemetry: false,
     postToolUse: false,
+    subagentScopeTracking: false,
+    preToolUseGuardrail: false,
   },
 });
 
@@ -373,6 +375,14 @@ export function normalizeRolloutConfig(rollout = {}) {
     postToolUse: normalizeBoolean(
       rollout.postToolUse,
       USER_CONFIG_DEFAULTS.rollout.postToolUse,
+    ),
+    subagentScopeTracking: normalizeBoolean(
+      rollout.subagentScopeTracking,
+      USER_CONFIG_DEFAULTS.rollout.subagentScopeTracking,
+    ),
+    preToolUseGuardrail: normalizeBoolean(
+      rollout.preToolUseGuardrail,
+      USER_CONFIG_DEFAULTS.rollout.preToolUseGuardrail,
     ),
   };
 }

--- a/lib/db-migration-runner.mjs
+++ b/lib/db-migration-runner.mjs
@@ -179,6 +179,11 @@ export class MigrationRunner {
         shouldRun: (currentVersion) => currentVersion > 0 && currentVersion < 12,
         run: () => api.applyIntentJournalMigration(),
       },
+      {
+        label: "deferred-extraction-lease",
+        shouldRun: (currentVersion) => currentVersion > 0 && currentVersion < 16,
+        run: () => api.applyDeferredExtractionLeaseMigration(),
+      },
     ];
   }
 
@@ -833,5 +838,26 @@ export class MigrationRunner {
           ON semantic_memory(domain_key);
       `);
     }
+  }
+
+  /**
+   * Adds durable owner token, lease expiry, and heartbeat columns to
+   * deferred_extraction for existing databases upgrading from schema v15.
+   * Fresh installs get these via the CREATE TABLE statement in schema.mjs.
+   * Very old databases (pre-deferred_extraction) are skipped; the table will
+   * be created with the new columns when the schema statements run.
+   *
+   * @param {MigrationApi} [api=this]
+   * @returns {void}
+   */
+  applyDeferredExtractionLeaseMigration(api = this) {
+    if (!api.tableExists("deferred_extraction")) {
+      // deferred_extraction didn't exist in very old schemas; the CREATE TABLE
+      // IF NOT EXISTS in schema statements will create it with all columns.
+      return;
+    }
+    api.ensureColumn("deferred_extraction", "owner_token", "TEXT");
+    api.ensureColumn("deferred_extraction", "lease_expires_at", "TEXT");
+    api.ensureColumn("deferred_extraction", "heartbeat_at", "TEXT");
   }
 }

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -1427,6 +1427,10 @@ export class LoreDb {
     return this.migrations.applyMemoryDomainObservationMigration(this);
   }
 
+  applyDeferredExtractionLeaseMigration() {
+    return this.migrations.applyDeferredExtractionLeaseMigration(this);
+  }
+
   ensureOpen() {
     if (!this.db) {
       throw new Error("lore database is not initialized");
@@ -3525,7 +3529,96 @@ export class LoreDb {
     `).run(nowIso(), sessionId);
   }
 
-  completeDeferredExtraction(sessionId) {
+  /**
+   * Atomically claim a pending/failed deferred extraction job for exclusive
+   * processing.  Returns true when the job was successfully claimed by this
+   * caller, false when another worker already holds it or the job is not
+   * available (e.g. not yet due).
+   *
+   * The claim sets a 10-minute lease (configurable via leaseDurationMs) that
+   * must be renewed every ≤2 minutes via heartbeatDeferredExtraction.  If the
+   * lease expires, reclaimStaleDeferredExtractions will reset the job to
+   * "failed" so another worker can pick it up.
+   *
+   * @param {string} sessionId
+   * @param {string} ownerToken - Opaque token identifying the claiming worker
+   * @param {number} [leaseDurationMs=600000] - Lease TTL in milliseconds (default 10 min)
+   * @returns {boolean} true when claimed, false when already held or unavailable
+   */
+  claimDeferredExtraction(sessionId, ownerToken, leaseDurationMs = 10 * 60 * 1000) {
+    this.ensureOpen();
+    const now = nowIso();
+    const leaseExpiresAt = new Date(Date.now() + leaseDurationMs).toISOString();
+    const result = this.db.prepare(`
+      UPDATE deferred_extraction
+      SET status = 'running',
+          attempts = attempts + 1,
+          started_at = ?,
+          owner_token = ?,
+          lease_expires_at = ?,
+          heartbeat_at = ?,
+          last_error = NULL
+      WHERE session_id = ?
+        AND status IN ('pending', 'failed')
+        AND available_at <= ?
+    `).run(now, ownerToken, leaseExpiresAt, now, sessionId, now);
+    return result.changes > 0;
+  }
+
+  /**
+   * Renew the lease for an active deferred extraction job.  Only succeeds when
+   * the caller still owns the job (owner_token matches) and the job is still
+   * in "running" state.
+   *
+   * Must be called at least once per 10-minute lease window; a 2-minute
+   * heartbeat interval keeps the lease well within its expiry.
+   *
+   * @param {string} sessionId
+   * @param {string} ownerToken
+   * @param {number} [leaseDurationMs=600000] - Renewed lease TTL (default 10 min)
+   * @returns {boolean} true when renewed, false when the lease is already lost
+   */
+  heartbeatDeferredExtraction(sessionId, ownerToken, leaseDurationMs = 10 * 60 * 1000) {
+    this.ensureOpen();
+    const now = nowIso();
+    const leaseExpiresAt = new Date(Date.now() + leaseDurationMs).toISOString();
+    const result = this.db.prepare(`
+      UPDATE deferred_extraction
+      SET heartbeat_at = ?,
+          lease_expires_at = ?
+      WHERE session_id = ?
+        AND owner_token = ?
+        AND status = 'running'
+    `).run(now, leaseExpiresAt, sessionId, ownerToken);
+    return result.changes > 0;
+  }
+
+  /**
+   * Reclaim all running deferred extraction jobs whose leases have expired.
+   * Resets each to "failed" so the next processing cycle can retry them.
+   * Only touches jobs that have an explicit lease_expires_at in the past;
+   * legacy rows without a lease are left untouched.
+   *
+   * @returns {number} Number of jobs reclaimed
+   */
+  reclaimStaleDeferredExtractions() {
+    this.ensureOpen();
+    const now = nowIso();
+    const result = this.db.prepare(`
+      UPDATE deferred_extraction
+      SET status = 'failed',
+          last_error = 'lease expired',
+          available_at = ?,
+          owner_token = NULL,
+          lease_expires_at = NULL
+      WHERE status = 'running'
+        AND lease_expires_at IS NOT NULL
+        AND lease_expires_at < ?
+    `).run(now, now);
+    return result.changes;
+  }
+
+  completeDeferredExtraction(sessionId, ownerToken = null) {
     this.ensureOpen();
     const completedAt = nowIso();
     const row = this.db.prepare(`
@@ -3534,39 +3627,71 @@ export class LoreDb {
       WHERE session_id = ?
       LIMIT 1
     `).get(sessionId);
-    this.db.prepare(`
-      UPDATE deferred_extraction
-      SET status = 'completed',
-          completed_at = ?,
-          last_error = NULL
-      WHERE session_id = ?
-    `).run(completedAt, sessionId);
-    this.upsertActivitySuccess({
-      repository: row?.repository ?? null,
-      updates: {
-        lastExtractionCompletionAt: completedAt,
-        lastExtractionRepository: row?.repository ?? null,
-      },
-    });
-    this.upsertActivitySuccess({
-      repository: null,
-      updates: {
-        lastExtractionCompletionAt: completedAt,
-        lastExtractionRepository: row?.repository ?? null,
-      },
-    });
+    // When an ownerToken is provided, guard against stale workers completing
+    // a job that has already been reclaimed by another caller.  Without a
+    // token (legacy callers), behave as before.
+    const result = ownerToken
+      ? this.db.prepare(`
+          UPDATE deferred_extraction
+          SET status = 'completed',
+              completed_at = ?,
+              last_error = NULL
+          WHERE session_id = ?
+            AND owner_token = ?
+            AND status = 'running'
+        `).run(completedAt, sessionId, ownerToken)
+      : this.db.prepare(`
+          UPDATE deferred_extraction
+          SET status = 'completed',
+              completed_at = ?,
+              last_error = NULL
+          WHERE session_id = ?
+        `).run(completedAt, sessionId);
+    // Only update activity state when the completion actually landed.
+    if (!ownerToken || result.changes > 0) {
+      this.upsertActivitySuccess({
+        repository: row?.repository ?? null,
+        updates: {
+          lastExtractionCompletionAt: completedAt,
+          lastExtractionRepository: row?.repository ?? null,
+        },
+      });
+      this.upsertActivitySuccess({
+        repository: null,
+        updates: {
+          lastExtractionCompletionAt: completedAt,
+          lastExtractionRepository: row?.repository ?? null,
+        },
+      });
+    }
   }
 
-  failDeferredExtraction(sessionId, { errorMessage, retryDelayMinutes = 15 }) {
+  failDeferredExtraction(sessionId, { errorMessage, retryDelayMinutes = 15, ownerToken = null }) {
     this.ensureOpen();
     const availableAt = new Date(Date.now() + (retryDelayMinutes * 60 * 1000)).toISOString();
-    this.db.prepare(`
-      UPDATE deferred_extraction
-      SET status = 'failed',
-          available_at = ?,
-          last_error = ?
-      WHERE session_id = ?
-    `).run(availableAt, errorMessage, sessionId);
+    // Guard by ownerToken when provided so a stale worker cannot clobber the
+    // state of a job that has already been reclaimed by a new worker.
+    if (ownerToken) {
+      this.db.prepare(`
+        UPDATE deferred_extraction
+        SET status = 'failed',
+            available_at = ?,
+            last_error = ?,
+            owner_token = NULL,
+            lease_expires_at = NULL
+        WHERE session_id = ?
+          AND owner_token = ?
+          AND status = 'running'
+      `).run(availableAt, errorMessage, sessionId, ownerToken);
+    } else {
+      this.db.prepare(`
+        UPDATE deferred_extraction
+        SET status = 'failed',
+            available_at = ?,
+            last_error = ?
+        WHERE session_id = ?
+      `).run(availableAt, errorMessage, sessionId);
+    }
   }
 
   forgetMemory({ id, supersededBy }) {

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -2116,6 +2116,70 @@ export class LoreDb {
     });
   }
 
+  listRetrievalTraceSamples({
+    repository,
+    includeGlobal = true,
+    limit = 10,
+  } = {}) {
+    this.ensureOpen();
+    return listRetrievalTraceSamplesImpl(this.db, {
+      repository,
+      includeGlobal,
+      limit,
+    });
+  }
+
+  /**
+   * Persist a privacy-minimised error telemetry record.
+   * Accepts only categorical fields — never raw messages or stacks.
+   *
+   * @param {{ sessionId: string | null, contextCategory: string, recoverability: string, fingerprint: string }} record
+   * @returns {string} Generated record ID.
+   */
+  insertErrorTelemetry({ sessionId, contextCategory, recoverability, fingerprint }) {
+    this.ensureOpen();
+    const id = crypto.randomUUID();
+    this.db.prepare(`
+      INSERT INTO error_telemetry (id, session_id, context_category, recoverability, fingerprint, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(
+      id,
+      sessionId ?? null,
+      String(contextCategory || "unknown"),
+      String(recoverability || "unknown"),
+      String(fingerprint || ""),
+      nowIso(),
+    );
+    return id;
+  }
+
+  /**
+   * Prune old error telemetry rows for retention compliance.
+   * Deletes rows older than maxAgeMs and trims to maxRowsGlobal.
+   *
+   * @param {{ maxRowsGlobal?: number, maxAgeMs?: number }} options
+   * @returns {{ deletedByAge: number, deletedByLimit: number }}
+   */
+  pruneErrorTelemetry({
+    maxRowsGlobal = 500,
+    maxAgeMs = 30 * 24 * 60 * 60 * 1000,
+  } = {}) {
+    this.ensureOpen();
+    const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
+    const byAge = this.db.prepare(
+      `DELETE FROM error_telemetry WHERE created_at < ?`,
+    ).run(cutoff);
+    const byLimit = this.db.prepare(`
+      DELETE FROM error_telemetry WHERE id NOT IN (
+        SELECT id FROM error_telemetry ORDER BY created_at DESC LIMIT ?
+      )
+    `).run(maxRowsGlobal);
+    return {
+      deletedByAge: byAge.changes ?? 0,
+      deletedByLimit: byLimit.changes ?? 0,
+    };
+  }
+
   getSemanticMemoryByIds(ids) {
     this.ensureOpen();
     if (!Array.isArray(ids) || ids.length === 0) {

--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -2116,19 +2116,6 @@ export class LoreDb {
     });
   }
 
-  listRetrievalTraceSamples({
-    repository,
-    includeGlobal = true,
-    limit = 10,
-  } = {}) {
-    this.ensureOpen();
-    return listRetrievalTraceSamplesImpl(this.db, {
-      repository,
-      includeGlobal,
-      limit,
-    });
-  }
-
   /**
    * Persist a privacy-minimised error telemetry record.
    * Accepts only categorical fields — never raw messages or stacks.

--- a/lib/hook-registration.mjs
+++ b/lib/hook-registration.mjs
@@ -1,0 +1,22 @@
+export function buildLoreHooks(handlers = {}) {
+  // Known/allowed hook names - keep conservative list of likely SDK hooks.
+  const allowed = [
+    "onPreToolUse",
+    "onPostToolUse",
+    "onUserPromptSubmitted",
+    "onSessionStart",
+    "onSessionEnd",
+    "onErrorOccurred",
+    "onEvent",
+  ];
+
+  const result = {};
+  for (const name of allowed) {
+    const v = handlers[name];
+    if (typeof v === "function") {
+      // Preserve original function identity; do not wrap.
+      result[name] = v;
+    }
+  }
+  return result;
+}

--- a/lib/hook-registration.mjs
+++ b/lib/hook-registration.mjs
@@ -1,22 +1,20 @@
-export function buildLoreHooks(handlers = {}) {
-  // Known/allowed hook names - keep conservative list of likely SDK hooks.
-  const allowed = [
-    "onPreToolUse",
-    "onPostToolUse",
-    "onUserPromptSubmitted",
-    "onSessionStart",
-    "onSessionEnd",
-    "onErrorOccurred",
-    "onEvent",
-  ];
+export const LORE_HOOK_NAMES = Object.freeze([
+  "onPreToolUse",
+  "onPreMcpToolCall",
+  "onPostToolUse",
+  "onUserPromptSubmitted",
+  "onSessionStart",
+  "onSessionEnd",
+  "onErrorOccurred",
+]);
 
-  const result = {};
-  for (const name of allowed) {
-    const v = handlers[name];
-    if (typeof v === "function") {
-      // Preserve original function identity; do not wrap.
-      result[name] = v;
+export function buildLoreHooks(handlers = {}) {
+  const out = {};
+  for (const name of LORE_HOOK_NAMES) {
+    const h = handlers[name];
+    if (typeof h === "function") {
+      out[name] = h;
     }
   }
-  return result;
+  return out;
 }

--- a/lib/maintenance-scheduler.mjs
+++ b/lib/maintenance-scheduler.mjs
@@ -12,7 +12,7 @@ import {
 } from "./proposal-generator.mjs";
 import { runDoctorObservation } from "./lore-doctor.mjs";
 
-const TASK_ORDER = Object.freeze([
+export const TASK_ORDER = Object.freeze([
   "deferredExtraction",
   "validationCorpus",
   "replayCorpus",

--- a/lib/passive-hooks.mjs
+++ b/lib/passive-hooks.mjs
@@ -1,0 +1,306 @@
+/**
+ * lib/passive-hooks.mjs
+ *
+ * Privacy-preserving payload normalisation and categorical derivation for
+ * the Phase 2 passive hooks: onErrorOccurred and onPostToolUse.
+ *
+ * Constraints enforced here:
+ *   - Never reads error.message, error.stack, toolArgs content, toolResult
+ *     content, file contents, or command output.
+ *   - Derives only categorical fields: context category, recoverability,
+ *     tool kind/category, success/failure.
+ *   - Produces a non-reversible fingerprint from categorical fields only.
+ *   - Safe no-op on absent or malformed payloads.
+ */
+
+import crypto from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// Categorical constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Categorical error context types derived from structural payload fields only.
+ * Never derived from raw error.message or error.stack.
+ */
+export const ERROR_CONTEXT_CATEGORY = Object.freeze({
+  TOOL_USE: "tool_use",
+  NETWORK: "network",
+  PERMISSION: "permission",
+  TIMEOUT: "timeout",
+  PARSE: "parse",
+  UNKNOWN: "unknown",
+});
+
+export const RECOVERABILITY = Object.freeze({
+  RECOVERABLE: "recoverable",
+  UNRECOVERABLE: "unrecoverable",
+  UNKNOWN: "unknown",
+});
+
+/**
+ * Tool categories derived from tool name only.
+ */
+export const TOOL_CATEGORY = Object.freeze({
+  BASH: "bash",
+  FILE: "file",
+  SEARCH: "search",
+  NETWORK: "network",
+  MEMORY: "memory",
+  OTHER: "other",
+});
+
+// ---------------------------------------------------------------------------
+// Error telemetry derivation
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive error context category from non-message structural fields only.
+ * Inspects error.name, error.code, and the categorical context descriptor.
+ * Never reads error.message or error.stack.
+ *
+ * @param {unknown} payload
+ * @returns {string} One of ERROR_CONTEXT_CATEGORY values.
+ */
+function deriveErrorContextCategory(payload) {
+  if (!payload || typeof payload !== "object") {
+    return ERROR_CONTEXT_CATEGORY.UNKNOWN;
+  }
+
+  // context is a categorical descriptor provided by the SDK (e.g. hook name),
+  // not a free-text message — safe to inspect for tool/network/etc keywords.
+  const contextHint = String(payload.context ?? "").toLowerCase();
+  const errorName = String(payload.error?.name ?? payload.errorName ?? "").toLowerCase();
+  const errorCode = String(payload.error?.code ?? payload.errorCode ?? "").toLowerCase();
+
+  if (errorCode === "etimedout" || errorCode === "etimeout" || contextHint.includes("timeout")) {
+    return ERROR_CONTEXT_CATEGORY.TIMEOUT;
+  }
+  if (
+    errorCode === "eacces" || errorCode === "eperm"
+    || errorName.includes("permission")
+    || contextHint.includes("permission") || contextHint.includes("auth")
+  ) {
+    return ERROR_CONTEXT_CATEGORY.PERMISSION;
+  }
+  if (
+    errorCode === "econnrefused" || errorCode === "econnreset" || errorCode === "enetunreach"
+    || errorName.includes("network") || errorName.includes("fetch")
+    || contextHint.includes("network") || contextHint.includes("fetch")
+  ) {
+    return ERROR_CONTEXT_CATEGORY.NETWORK;
+  }
+  if (contextHint.includes("tool") || contextHint.includes("mcp")) {
+    return ERROR_CONTEXT_CATEGORY.TOOL_USE;
+  }
+  if (errorName.includes("syntax") || errorName.includes("parse")) {
+    return ERROR_CONTEXT_CATEGORY.PARSE;
+  }
+  return ERROR_CONTEXT_CATEGORY.UNKNOWN;
+}
+
+/**
+ * Derive recoverability from structural fields (retry hints, error codes).
+ * Never reads error.message or error.stack.
+ *
+ * @param {unknown} payload
+ * @returns {string} One of RECOVERABILITY values.
+ */
+function deriveRecoverability(payload) {
+  if (!payload || typeof payload !== "object") {
+    return RECOVERABILITY.UNKNOWN;
+  }
+  if (payload.retryable === true || payload.retry === true) {
+    return RECOVERABILITY.RECOVERABLE;
+  }
+  if (payload.retryable === false || payload.retry === false) {
+    return RECOVERABILITY.UNRECOVERABLE;
+  }
+  const errorCode = String(payload.error?.code ?? payload.errorCode ?? "").toLowerCase();
+  if (errorCode === "eacces" || errorCode === "eperm") {
+    return RECOVERABILITY.UNRECOVERABLE;
+  }
+  if (errorCode === "etimedout" || errorCode === "econnrefused") {
+    return RECOVERABILITY.RECOVERABLE;
+  }
+  return RECOVERABILITY.UNKNOWN;
+}
+
+/**
+ * Build a non-reversible type fingerprint from categorical fields only.
+ * The fingerprint does NOT encode any free-text from the error.
+ *
+ * error.name is the JS class name (e.g. "TypeError") — a structural
+ * identifier, not a message. It is included in the hash after stripping
+ * to ASCII word-characters only.
+ *
+ * @param {string} contextCategory
+ * @param {string} recoverability
+ * @param {string} [errorName=""] - error.name (class identifier, not message)
+ * @returns {string} 16-character hex prefix of SHA-256 hash.
+ */
+export function buildErrorFingerprint(contextCategory, recoverability, errorName = "") {
+  const safeErrorName = String(errorName)
+    .replace(/[^a-zA-Z0-9_]/g, "")
+    .toLowerCase()
+    .slice(0, 32);
+  return crypto
+    .createHash("sha256")
+    .update(`${contextCategory}:${recoverability}:${safeErrorName}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/**
+ * Build a privacy-minimised error telemetry record from an onErrorOccurred payload.
+ * Returns null when the payload is absent or structurally malformed.
+ *
+ * Fields persisted: session_id (session ID), context_category, recoverability,
+ * fingerprint (non-reversible hash), created_at (added by the DB layer).
+ *
+ * Fields never persisted: error.message, error.stack, tool arguments, tool
+ * results, file contents, command output, raw payload blobs.
+ *
+ * @param {unknown} payload - Raw onErrorOccurred input payload.
+ * @param {string | null} [sessionId] - Current session ID.
+ * @returns {{ sessionId: string | null, contextCategory: string, recoverability: string, fingerprint: string } | null}
+ */
+export function buildErrorTelemetryRecord(payload, sessionId = null) {
+  if (payload === null || payload === undefined) {
+    return null;
+  }
+  if (typeof payload !== "object") {
+    return null;
+  }
+
+  const contextCategory = deriveErrorContextCategory(payload);
+  const recoverability = deriveRecoverability(payload);
+  const errorName = String(payload.error?.name ?? payload.errorName ?? "");
+  const fingerprint = buildErrorFingerprint(contextCategory, recoverability, errorName);
+
+  return {
+    sessionId: typeof sessionId === "string" && sessionId.length > 0 ? sessionId : null,
+    contextCategory,
+    recoverability,
+    fingerprint,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Post-tool-use observation derivation
+// ---------------------------------------------------------------------------
+
+const BASH_TOOLS = new Set([
+  "bash", "run_command", "shell", "execute_command", "run_shell_command",
+]);
+const FILE_TOOLS = new Set([
+  "read_file", "write_file", "view", "create", "edit", "delete_file",
+  "list_dir", "list_files", "view_file", "create_file", "edit_file",
+]);
+const SEARCH_TOOLS = new Set([
+  "grep", "glob", "search", "rg", "search_files", "find_files", "ripgrep",
+]);
+const NETWORK_TOOLS = new Set([
+  "web_fetch", "fetch", "http_get", "http_post", "web_search",
+  "browser_navigate", "browser_navigate_back",
+]);
+const MEMORY_TOOL_PREFIXES = ["lore_", "memory_"];
+
+/**
+ * Derive a categorical tool kind from the tool name only.
+ * Never inspects tool arguments or results.
+ *
+ * @param {unknown} toolName
+ * @returns {string} One of TOOL_CATEGORY values.
+ */
+export function deriveToolCategory(toolName) {
+  const name = String(toolName ?? "").toLowerCase().replace(/[-\s]/g, "_");
+  if (BASH_TOOLS.has(name)) {
+    return TOOL_CATEGORY.BASH;
+  }
+  if (FILE_TOOLS.has(name)) {
+    return TOOL_CATEGORY.FILE;
+  }
+  if (SEARCH_TOOLS.has(name)) {
+    return TOOL_CATEGORY.SEARCH;
+  }
+  if (NETWORK_TOOLS.has(name)) {
+    return TOOL_CATEGORY.NETWORK;
+  }
+  if (MEMORY_TOOL_PREFIXES.some((prefix) => name.startsWith(prefix))) {
+    return TOOL_CATEGORY.MEMORY;
+  }
+  return TOOL_CATEGORY.OTHER;
+}
+
+/**
+ * Safely inspect the structural shape of toolArgs if they arrive as a JSON
+ * string. Returns only structural metadata (is it parseable? is it an object?
+ * is it empty?). Never returns the raw args value itself for persistence.
+ *
+ * @param {unknown} toolArgs
+ * @returns {{ parsed: boolean, isObject: boolean, isEmpty: boolean }}
+ */
+export function normalizeToolArgsShape(toolArgs) {
+  if (toolArgs === null || toolArgs === undefined) {
+    return { parsed: true, isObject: false, isEmpty: true };
+  }
+  if (typeof toolArgs === "object") {
+    return {
+      parsed: true,
+      isObject: true,
+      isEmpty: Object.keys(toolArgs).length === 0,
+    };
+  }
+  if (typeof toolArgs === "string") {
+    try {
+      const parsed = JSON.parse(toolArgs);
+      const isObject = typeof parsed === "object" && parsed !== null && !Array.isArray(parsed);
+      return {
+        parsed: true,
+        isObject,
+        isEmpty: isObject ? Object.keys(parsed).length === 0 : false,
+      };
+    } catch {
+      return { parsed: false, isObject: false, isEmpty: false };
+    }
+  }
+  return { parsed: true, isObject: false, isEmpty: false };
+}
+
+/**
+ * Build a privacy-preserving post-tool-use observation from an onPostToolUse payload.
+ * Returns null when the payload is absent, malformed, or has no tool name.
+ *
+ * Derives only categorical tool kind/category and success/failure.
+ * Never persists raw args, results, file contents, or command output.
+ *
+ * @param {unknown} payload - Raw onPostToolUse input payload.
+ * @returns {{ toolName: string, toolCategory: string, success: boolean, argsShape: object } | null}
+ */
+export function buildPostToolUseObservation(payload) {
+  if (payload === null || payload === undefined) {
+    return null;
+  }
+  if (typeof payload !== "object") {
+    return null;
+  }
+
+  const toolName = String(payload.toolName ?? payload.name ?? "").slice(0, 64);
+  if (!toolName) {
+    return null;
+  }
+
+  const toolCategory = deriveToolCategory(toolName);
+  const success = payload.success === true
+    || payload.outcome === "success"
+    || payload.status === "success";
+  const argsShape = normalizeToolArgsShape(payload.toolArgs ?? payload.args);
+
+  return {
+    toolName,
+    toolCategory,
+    success,
+    argsShape,
+  };
+}

--- a/lib/pre-tool-use-guardrail.mjs
+++ b/lib/pre-tool-use-guardrail.mjs
@@ -107,14 +107,18 @@ export async function runPreToolUseGuardrail(input, { config, scopeTracker } = {
       };
     });
 
+    // Hoist the handle so it can be cleared once the race settles,
+    // regardless of which side wins or whether the check throws.
+    let timerId;
     const timeoutPromise = new Promise((resolve) => {
-      const id = setTimeout(() => {
-        clearTimeout(id);
-        resolve(undefined); // fail open on timeout
-      }, GUARDRAIL_TIMEOUT_MS);
+      timerId = setTimeout(() => resolve(undefined), GUARDRAIL_TIMEOUT_MS);
     });
 
-    return await Promise.race([checkPromise, timeoutPromise]);
+    try {
+      return await Promise.race([checkPromise, timeoutPromise]);
+    } finally {
+      clearTimeout(timerId);
+    }
   } catch {
     // Fail open on any error, SDK mismatch, or unexpected condition
     return undefined;

--- a/lib/pre-tool-use-guardrail.mjs
+++ b/lib/pre-tool-use-guardrail.mjs
@@ -1,0 +1,122 @@
+/**
+ * lib/pre-tool-use-guardrail.mjs
+ *
+ * Narrow, default-off pre-tool-use guardrail for the onPreToolUse hook.
+ *
+ * Design constraints (Phase 3):
+ *   - Default-off: only active when rollout.preToolUseGuardrail is true.
+ *   - Explicit allowlist: only processes tools in PRE_TOOL_USE_ALLOWLIST.
+ *   - Never reads, logs, or persists raw toolArgs content.
+ *   - Enforces a 50 ms internal timeout; fails open on timeout, error,
+ *     SDK mismatch, or malformed payload.
+ *   - Returns void (no-op) by default; never returns a "deny" decision.
+ *   - Observe-only in Phase 3: may return { additionalContext } with advisory
+ *     sub-agent scope metadata when scope tracking is active.
+ *
+ * Verified SDK capability (types.d.ts, SDK ≥ 1.0.75):
+ *   PreToolUseHookInput  — { toolName, toolArgs, sessionId, timestamp, workingDirectory }
+ *   PreToolUseHookOutput — { permissionDecision?, permissionDecisionReason?,
+ *                            modifiedArgs?, additionalContext?, suppressOutput? }
+ *
+ * Privacy guarantees:
+ *   - toolArgs are structurally present in the input but never accessed here.
+ *   - No raw argument content appears in any returned output, trace, or log.
+ */
+
+import { createRolloutBooleanReader } from "./rollout-flag-utils.mjs";
+
+/**
+ * Lore-relevant tools that benefit from a pre-use scope context check.
+ * Only tools in this set are observed by the guardrail; all others are no-ops.
+ *
+ * @type {ReadonlySet<string>}
+ */
+export const PRE_TOOL_USE_ALLOWLIST = Object.freeze(
+  new Set(["lore_retain", "lore_reflect", "memory_save"]),
+);
+
+/** Maximum time (ms) the guardrail check may run before failing open. */
+export const GUARDRAIL_TIMEOUT_MS = 50;
+
+const readPreToolUseGuardrailEnabledInternal = createRolloutBooleanReader(
+  "preToolUseGuardrail",
+  false,
+);
+
+/**
+ * Returns true if the tool name is in the explicit allowlist.
+ *
+ * @param {unknown} toolName
+ * @returns {boolean}
+ */
+export function isToolInAllowlist(toolName) {
+  if (typeof toolName !== "string" || !toolName) {
+    return false;
+  }
+  return PRE_TOOL_USE_ALLOWLIST.has(toolName.trim().slice(0, 64));
+}
+
+/**
+ * Run the pre-tool-use guardrail.
+ *
+ * Returns undefined in all base cases. When the tool is in the allowlist and
+ * sub-agent scope tracking is active, returns { additionalContext } with
+ * advisory scope text. Fails open (returns undefined) on any error, timeout,
+ * or ambiguous input.
+ *
+ * Must complete within GUARDRAIL_TIMEOUT_MS or it fails open automatically.
+ *
+ * @param {unknown} input - PreToolUseHookInput from the SDK
+ * @param {{
+ *   config: unknown,
+ *   scopeTracker?: { getActiveScopeMetadata(): object | null },
+ * }} opts
+ * @returns {Promise<{ additionalContext: string } | undefined>}
+ */
+export async function runPreToolUseGuardrail(input, { config, scopeTracker } = {}) {
+  try {
+    if (!readPreToolUseGuardrailEnabledInternal(config)) {
+      return undefined;
+    }
+
+    // Malformed or absent payload → no-op
+    if (!input || typeof input !== "object") {
+      return undefined;
+    }
+
+    const toolName = typeof input.toolName === "string" ? input.toolName : "";
+
+    // toolArgs are intentionally never read or inspected here
+
+    if (!isToolInAllowlist(toolName)) {
+      return undefined;
+    }
+
+    // Cheap precomputed check wrapped in a hard timeout.
+    const checkPromise = Promise.resolve().then(() => {
+      const scopeMeta = scopeTracker?.getActiveScopeMetadata?.() ?? null;
+      if (!scopeMeta) {
+        return undefined;
+      }
+      const agentName = String(scopeMeta.activeSubagent?.name ?? "").slice(0, 64);
+      if (!agentName) {
+        return undefined;
+      }
+      return {
+        additionalContext: `[lore scope] active sub-agent: ${agentName}`,
+      };
+    });
+
+    const timeoutPromise = new Promise((resolve) => {
+      const id = setTimeout(() => {
+        clearTimeout(id);
+        resolve(undefined); // fail open on timeout
+      }, GUARDRAIL_TIMEOUT_MS);
+    });
+
+    return await Promise.race([checkPromise, timeoutPromise]);
+  } catch {
+    // Fail open on any error, SDK mismatch, or unexpected condition
+    return undefined;
+  }
+}

--- a/lib/rollout-flag-utils.mjs
+++ b/lib/rollout-flag-utils.mjs
@@ -3,3 +3,8 @@ import { normalizeBoolean } from "./config.mjs";
 export function readRolloutBoolean(config, key, fallback) {
   return normalizeBoolean(config?.rollout?.[key], fallback);
 }
+
+export function createRolloutBooleanReader(key, fallback, parentReader = null) {
+  return (config) => (parentReader?.(config) ?? true)
+    && readRolloutBoolean(config, key, fallback);
+}

--- a/lib/rollout-flags.mjs
+++ b/lib/rollout-flags.mjs
@@ -24,3 +24,8 @@ export {
   readErrorTelemetryEnabled,
   readPostToolUseEnabled,
 } from "./rollout-passive-hooks-flags.mjs";
+
+export {
+  readSubagentScopeTrackingEnabled,
+  readPreToolUseGuardrailEnabled,
+} from "./rollout-phase3-flags.mjs";

--- a/lib/rollout-flags.mjs
+++ b/lib/rollout-flags.mjs
@@ -19,3 +19,8 @@ export {
   readReviewGateEnabled,
   readApprovalSubstrateEnabled,
 } from "./rollout-evolution-flags.mjs";
+
+export {
+  readErrorTelemetryEnabled,
+  readPostToolUseEnabled,
+} from "./rollout-passive-hooks-flags.mjs";

--- a/lib/rollout-passive-hooks-flags.mjs
+++ b/lib/rollout-passive-hooks-flags.mjs
@@ -1,0 +1,7 @@
+import { createRolloutBooleanReader } from "./rollout-flag-utils.mjs";
+
+// Both passive hooks default to false so they are strictly opt-in.
+const readErrorTelemetryEnabled = createRolloutBooleanReader("errorTelemetry", false);
+const readPostToolUseEnabled = createRolloutBooleanReader("postToolUse", false);
+
+export { readErrorTelemetryEnabled, readPostToolUseEnabled };

--- a/lib/rollout-phase3-flags.mjs
+++ b/lib/rollout-phase3-flags.mjs
@@ -1,0 +1,7 @@
+import { createRolloutBooleanReader } from "./rollout-flag-utils.mjs";
+
+// Both Phase 3 flags default to false — strictly opt-in.
+const readSubagentScopeTrackingEnabled = createRolloutBooleanReader("subagentScopeTracking", false);
+const readPreToolUseGuardrailEnabled = createRolloutBooleanReader("preToolUseGuardrail", false);
+
+export { readSubagentScopeTrackingEnabled, readPreToolUseGuardrailEnabled };

--- a/lib/schema.mjs
+++ b/lib/schema.mjs
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 16;
+export const SCHEMA_VERSION = 17;
 
 export const SCHEMA_STATEMENTS = [
   `
@@ -514,6 +514,24 @@ export const SCHEMA_STATEMENTS = [
       last_summary_json TEXT NOT NULL DEFAULT '{}',
       updated_at TEXT NOT NULL
     );
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS error_telemetry (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      context_category TEXT NOT NULL DEFAULT 'unknown',
+      recoverability TEXT NOT NULL DEFAULT 'unknown',
+      fingerprint TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_error_telemetry_session
+      ON error_telemetry(session_id, created_at DESC);
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_error_telemetry_category_created
+      ON error_telemetry(context_category, created_at DESC);
   `,
   `
     CREATE TABLE IF NOT EXISTS lore_schema_version (

--- a/lib/schema.mjs
+++ b/lib/schema.mjs
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 15;
+export const SCHEMA_VERSION = 16;
 
 export const SCHEMA_STATEMENTS = [
   `
@@ -240,6 +240,9 @@ export const SCHEMA_STATEMENTS = [
       completed_at TEXT,
       attempts INTEGER NOT NULL DEFAULT 0,
       last_error TEXT,
+      owner_token TEXT,
+      lease_expires_at TEXT,
+      heartbeat_at TEXT,
       metadata_json TEXT NOT NULL DEFAULT '{}'
     );
   `,

--- a/lib/subagent-scope-tracker.mjs
+++ b/lib/subagent-scope-tracker.mjs
@@ -1,0 +1,178 @@
+/**
+ * lib/subagent-scope-tracker.mjs
+ *
+ * Session-local sub-agent identity tracking via the Copilot CLI event stream.
+ *
+ * Listens to verified subagent.* events (selected, deselected, started,
+ * completed, failed) subscribed via session.on() and maintains lightweight
+ * session-local state: the active sub-agent name and display name.
+ *
+ * Verified sub-agent events (SDK ≥ 1.0.75 session-events.d.ts):
+ *   subagent.selected   — custom agent selected (has agentName, agentDisplayName, tools)
+ *   subagent.deselected — custom agent deselected (empty payload)
+ *   subagent.started    — sub-agent execution started (has agentName, agentDisplayName, agentDescription, toolCallId)
+ *   subagent.completed  — sub-agent execution completed (has agentName, toolCallId)
+ *   subagent.failed     — sub-agent execution failed (has agentName, error, toolCallId)
+ *
+ * Design constraints:
+ *   - State is purely in-memory and never persisted.
+ *   - State must not leak across sessions or active agents. reset() clears all.
+ *   - Unknown event shapes or malformed payloads are safe no-ops.
+ *   - Scope metadata is additive and advisory; it never alters core behavior.
+ *   - Private fields (error messages etc.) are never read or retained.
+ */
+
+/**
+ * Create a new sub-agent scope tracker bound to a single session lifetime.
+ * Call reset() at session end to ensure state cannot leak.
+ *
+ * @returns {{
+ *   handleSelected(event: unknown): void,
+ *   handleDeselected(event: unknown): void,
+ *   handleStarted(event: unknown): void,
+ *   handleCompleted(event: unknown): void,
+ *   handleFailed(event: unknown): void,
+ *   reset(): void,
+ *   getActiveScopeMetadata(): { activeSubagent: { name: string, displayName: string | null } } | null,
+ *   isActive(): boolean,
+ * }}
+ */
+export function createSubagentScopeTracker() {
+  /** @type {string | null} */
+  let activeAgentName = null;
+  /** @type {string | null} */
+  let activeAgentDisplayName = null;
+
+  function clearState() {
+    activeAgentName = null;
+    activeAgentDisplayName = null;
+  }
+
+  return {
+    /**
+     * Handle subagent.selected event.
+     * Sets the active agent identity. Safe no-op on absent/malformed event.
+     *
+     * @param {unknown} event
+     */
+    handleSelected(event) {
+      try {
+        const name =
+          typeof event?.data?.agentName === "string"
+            ? event.data.agentName.slice(0, 128)
+            : null;
+        if (!name) {
+          return;
+        }
+        const displayName =
+          typeof event?.data?.agentDisplayName === "string"
+            ? event.data.agentDisplayName.slice(0, 256)
+            : null;
+        activeAgentName = name;
+        activeAgentDisplayName = displayName;
+      } catch {
+        // safe no-op on any access error
+      }
+    },
+
+    /**
+     * Handle subagent.deselected event.
+     * Clears the active agent identity. Always safe to call.
+     *
+     * @param {unknown} _event
+     */
+    handleDeselected(_event) {
+      clearState();
+    },
+
+    /**
+     * Handle subagent.started event.
+     * Reinforces the active agent identity from the started payload.
+     * Safe no-op on absent/malformed event.
+     *
+     * @param {unknown} event
+     */
+    handleStarted(event) {
+      try {
+        const name =
+          typeof event?.data?.agentName === "string"
+            ? event.data.agentName.slice(0, 128)
+            : null;
+        if (!name) {
+          return;
+        }
+        const displayName =
+          typeof event?.data?.agentDisplayName === "string"
+            ? event.data.agentDisplayName.slice(0, 256)
+            : null;
+        // Only update if no agent is currently tracked or the name matches.
+        if (!activeAgentName || activeAgentName === name) {
+          activeAgentName = name;
+          if (displayName !== null) {
+            activeAgentDisplayName = displayName;
+          }
+        }
+      } catch {
+        // safe no-op
+      }
+    },
+
+    /**
+     * Handle subagent.completed event.
+     * Clears the active agent identity on successful completion.
+     *
+     * @param {unknown} _event
+     */
+    handleCompleted(_event) {
+      clearState();
+    },
+
+    /**
+     * Handle subagent.failed event.
+     * Clears the active agent identity on failure.
+     * Never reads the error message from the payload.
+     *
+     * @param {unknown} _event
+     */
+    handleFailed(_event) {
+      clearState();
+    },
+
+    /**
+     * Reset all session-local state. Must be called at session end.
+     * Safe to call multiple times — subsequent calls are no-ops.
+     */
+    reset() {
+      clearState();
+    },
+
+    /**
+     * Returns additive scope metadata when a sub-agent is active, or null
+     * when no sub-agent is currently tracked.
+     *
+     * The metadata is advisory and never alters core recall/retain behavior.
+     *
+     * @returns {{ activeSubagent: { name: string, displayName: string | null } } | null}
+     */
+    getActiveScopeMetadata() {
+      if (!activeAgentName) {
+        return null;
+      }
+      return {
+        activeSubagent: {
+          name: activeAgentName,
+          displayName: activeAgentDisplayName,
+        },
+      };
+    },
+
+    /**
+     * Returns true when a sub-agent is currently active.
+     *
+     * @returns {boolean}
+     */
+    isActive() {
+      return activeAgentName !== null;
+    },
+  };
+}

--- a/schemas/lore.schema.json
+++ b/schemas/lore.schema.json
@@ -656,6 +656,16 @@
         "ambientWorkingProfile": {
           "type": "boolean",
           "default": true
+        },
+        "errorTelemetry": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable passive error telemetry hook (onErrorOccurred). Persists only privacy-minimised categorical metadata — no raw messages or stacks. Default-off."
+        },
+        "postToolUse": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable passive post-tool-use observation hook (onPostToolUse). Records only categorical tool kind and success/failure — no raw args or results. Default-off."
         }
       }
     }

--- a/schemas/lore.schema.json
+++ b/schemas/lore.schema.json
@@ -666,6 +666,16 @@
           "type": "boolean",
           "default": false,
           "description": "Enable passive post-tool-use observation hook (onPostToolUse). Records only categorical tool kind and success/failure — no raw args or results. Default-off."
+        },
+        "subagentScopeTracking": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable sub-agent scope tracking via session events (subagent.selected/deselected/started/completed/failed). Tracks the active custom agent name as session-local in-memory state and attaches additive scope metadata to Lore operations where supported. State is never persisted and resets at session end. Default-off."
+        },
+        "preToolUseGuardrail": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the narrow onPreToolUse guardrail. Only observes tools in the explicit Lore-relevant allowlist (lore_retain, lore_reflect, memory_save). Adds advisory sub-agent scope context when active. Never blocks, never persists raw args. Fails open on timeout, error, or ambiguous payload. Default-off."
         }
       }
     }

--- a/scripts/run-maintenance.mjs
+++ b/scripts/run-maintenance.mjs
@@ -79,7 +79,7 @@ function renderHelp() {
     "",
     "Exit codes:",
     "  0  Sweep completed (or dry-run/status planned) successfully.",
-    "  1  Error: unknown task names, DB failure, or unhandled exception.",
+    "  1  Error: any unknown task name in --tasks (fail-closed, DB never opened), DB failure, or unhandled exception.",
     "",
     "Environment variables:",
     "  LORE_COPILOT_HOME     Override ~/.copilot home directory (all path defaults derived from it).",
@@ -280,15 +280,12 @@ async function main() {
   }
 
   // Validate task names before touching the DB so cron typos fail loudly.
+  // Fail closed: any unknown name — even mixed with valid names — exits 1 without running tasks.
   if (args.tasks.length > 0) {
     const unknownTasks = validateTaskNames(args.tasks);
     if (unknownTasks !== null) {
-      const valid = args.tasks.filter((t) => TASK_ORDER.includes(t));
-      if (valid.length === 0) {
-        console.error(`Unknown task names: ${unknownTasks.join(", ")}. Valid tasks: ${TASK_ORDER.join(", ")}`);
-        process.exit(1);
-      }
-      console.error(`Warning: ignoring unknown task names: ${unknownTasks.join(", ")}. Valid tasks: ${TASK_ORDER.join(", ")}`);
+      console.error(`Unknown task names: ${unknownTasks.join(", ")}. Valid tasks: ${TASK_ORDER.join(", ")}`);
+      process.exit(1);
     }
   }
 

--- a/scripts/run-maintenance.mjs
+++ b/scripts/run-maintenance.mjs
@@ -1,15 +1,14 @@
 #!/usr/bin/env node
-
-import { existsSync } from "node:fs";
 import path from "node:path";
+import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { USER_CONFIG_DEFAULTS, isPlainObject, mergeDeep, loadFileConfigSync } from "../lib/config.mjs";
-import { LoreDb } from "../lib/db.mjs";
-import { runMaintenanceSweep } from "../lib/maintenance-scheduler.mjs";
-import { SessionStoreReader } from "../lib/session-store-reader.mjs";
-import { createTraceRecorder } from "../lib/trace-recorder.mjs";
 import { COMMON_PATH_ARG_HANDLERS, consumeValueArg, parseArgsWith, resolveDefaultLoreConfigPath, finalizeScriptConfig } from "./shared-args.mjs";
+import { LoreDb } from "../lib/db.mjs";
+import { SessionStoreReader } from "../lib/session-store-reader.mjs";
+import { USER_CONFIG_DEFAULTS, isPlainObject, mergeDeep, loadFileConfigSync } from "../lib/config.mjs";
+import { createTraceRecorder } from "../lib/trace-recorder.mjs";
+import { runMaintenanceSweep, TASK_ORDER } from "../lib/maintenance-scheduler.mjs";
 
 function parseTaskList(value) {
   return String(value ?? "")
@@ -61,11 +60,15 @@ function renderHelp() {
     "Usage:",
     "  node scripts/run-maintenance.mjs [options]",
     "",
+    "The supported out-of-session entry point for Lore maintenance tasks.",
+    "Designed for use with cron, launchd, or any external scheduler.",
+    "Operates only on the configured Lore database; never touches test fixtures.",
+    "",
     "Options:",
     "  --status                   Show current scheduler/task status (dry-run).",
     "  --dry-run                  Plan a maintenance sweep without state mutation.",
     "  --force                    Ignore cadence and force selected tasks due.",
-    "  --tasks <csv>              Task subset: deferredExtraction,validationCorpus,replayCorpus,backlogReview,traceCompaction,indexUpkeep,doctorSnapshot.",
+    `  --tasks <csv>              Task subset: ${TASK_ORDER.join(",")}.`,
     "  --repository <name>        Optional repository scope override.",
     "  --config <path>            Optional lore.json path.",
     "  --derived-store-path <p>   Override derived lore DB path.",
@@ -73,6 +76,10 @@ function renderHelp() {
     "  --backup-dir <path>        Override backup directory.",
     "  --recommended-schedule     Show recommended external schedule guidance.",
     "  --help, -h                 Show this help text.",
+    "",
+    "Exit codes:",
+    "  0  Sweep completed (or dry-run/status planned) successfully.",
+    "  1  Error: unknown task names, DB failure, or unhandled exception.",
     "",
     "Environment variables:",
     "  LORE_COPILOT_HOME     Override ~/.copilot home directory (all path defaults derived from it).",
@@ -88,27 +95,83 @@ function renderRecommendedSchedule(config) {
   };
   return [
     "Recommended maintenance schedule (external runner):",
-    "- Keep session-start cheap/bounded: only deferredExtraction auto-runs at session start.",
-    "- Use this script for periodic upkeep from cron/launchd/system scheduler.",
+    "",
+    "Cadence model:",
+    "- Session hooks (onSessionStart, onSessionEnd) do NOT guarantee wall-clock cadence.",
+    "  They fire only when Copilot CLI sessions are active, so infrequent users may go",
+    "  hours or days between hook invocations. Use an external scheduler for reliable upkeep.",
+    "- On session start, Lore only auto-selects the deferredExtraction task.",
+    "- All other tasks are for external or manual sweeps via this script.",
+    "",
+    "Maintenance modes:",
+    "  automatic       deferredExtraction runs at session start when enabled and due.",
+    "  manual          maintenance_schedule_run tool (in-session); --dry-run / --status flags.",
+    "  external        This script, driven by cron, launchd, or another scheduler.",
     "",
     "Suggested cadences:",
-    `- validationCorpus: every ${cadenceFor("validationCorpus", 12 * 60)} minutes`,
-    `- replayCorpus: every ${cadenceFor("replayCorpus", 24 * 60)} minutes`,
-    `- backlogReview: every ${cadenceFor("backlogReview", 6 * 60)} minutes`,
-    `- traceCompaction: every ${cadenceFor("traceCompaction", 60)} minutes`,
-    `- indexUpkeep: every ${cadenceFor("indexUpkeep", 12 * 60)} minutes`,
-    `- doctorSnapshot: every ${cadenceFor("doctorSnapshot", 24 * 60)} minutes (optional; requires rollout.loreDoctor=true and maintenanceScheduler.tasks.doctorSnapshot=true)`,
+    `- validationCorpus: every ${cadenceFor("validationCorpus", 12 * 60)} minutes (12 h)`,
+    `- replayCorpus: every ${cadenceFor("replayCorpus", 24 * 60)} minutes (24 h)`,
+    `- backlogReview: every ${cadenceFor("backlogReview", 6 * 60)} minutes (6 h)`,
+    `- traceCompaction: every ${cadenceFor("traceCompaction", 60)} minutes (1 h)`,
+    `- indexUpkeep: every ${cadenceFor("indexUpkeep", 12 * 60)} minutes (12 h)`,
+    `- doctorSnapshot: every ${cadenceFor("doctorSnapshot", 24 * 60)} minutes (24 h, optional; requires rollout.loreDoctor=true and maintenanceScheduler.tasks.doctorSnapshot=true)`,
     "",
-    "Example cron entries (default ~/.copilot install):",
-    "0 */6 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks validationCorpus,backlogReview",
-    "15 2 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks replayCorpus,indexUpkeep,traceCompaction",
-    "30 3 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks doctorSnapshot",
+    "── cron examples (default ~/.copilot install) ─────────────────────────────",
+    "# redirect stderr to a log file so failures are not silently discarded",
+    "0 */6 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks validationCorpus,backlogReview >> ~/.copilot/lore-maintenance.log 2>&1",
+    "15 2 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks replayCorpus,indexUpkeep,traceCompaction >> ~/.copilot/lore-maintenance.log 2>&1",
+    "30 3 * * * node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --tasks doctorSnapshot >> ~/.copilot/lore-maintenance.log 2>&1",
     "",
-    "Non-standard install (set LORE_COPILOT_HOME to override ~/.copilot):",
-    "0 */6 * * * LORE_COPILOT_HOME=/path/to/copilot-home node /path/to/lore/scripts/run-maintenance.mjs --tasks validationCorpus,backlogReview",
+    "# non-standard install (LORE_COPILOT_HOME overrides ~/.copilot)",
+    "0 */6 * * * LORE_COPILOT_HOME=/path/to/copilot-home node /path/to/lore/scripts/run-maintenance.mjs --tasks validationCorpus,backlogReview >> /path/to/lore-maintenance.log 2>&1",
+    "",
+    "── launchd example (macOS, default ~/.copilot install) ─────────────────────",
+    "# Save as ~/Library/LaunchAgents/com.lore.maintenance.plist, then:",
+    "#   launchctl load ~/Library/LaunchAgents/com.lore.maintenance.plist",
+    "#   launchctl start com.lore.maintenance",
+    "#",
+    "# <?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+    "# <!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\"",
+    "#   \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+    "# <plist version=\"1.0\">",
+    "# <dict>",
+    "#   <key>Label</key>",
+    "#   <string>com.lore.maintenance</string>",
+    "#   <key>ProgramArguments</key>",
+    "#   <array>",
+    "#     <string>/usr/local/bin/node</string>",
+    "#     <string>/Users/YOU/.copilot/extensions/lore/scripts/run-maintenance.mjs</string>",
+    "#     <string>--tasks</string>",
+    "#     <string>validationCorpus,backlogReview,traceCompaction</string>",
+    "#   </array>",
+    "#   <key>StartInterval</key>",
+    "#   <integer>21600</integer>",
+    "#   <key>StandardOutPath</key>",
+    "#   <string>/Users/YOU/.copilot/lore-maintenance.log</string>",
+    "#   <key>StandardErrorPath</key>",
+    "#   <string>/Users/YOU/.copilot/lore-maintenance.log</string>",
+    "#   <key>EnvironmentVariables</key>",
+    "#   <dict>",
+    "#     <key>LORE_COPILOT_HOME</key>",
+    "#     <string>/Users/YOU/.copilot</string>",
+    "#   </dict>",
+    "# </dict>",
+    "# </plist>",
+    "",
+    "Inspect status at any time:",
+    "  node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --status",
+    "  node ~/.copilot/extensions/lore/scripts/run-maintenance.mjs --dry-run",
+    "",
+    "See docs/maintenance-scheduling.md for the full guide.",
   ].join("\n");
 }
 
+function validateTaskNames(tasks) {
+  if (tasks.length === 0) return null;
+  const unknown = tasks.filter((t) => !TASK_ORDER.includes(t));
+  if (unknown.length === 0) return null;
+  return unknown;
+}
 function buildConfig(args) {
   // LORE_CONFIG env var provides a portable default config path that does
   // not depend on the working directory, useful for cron/CI/fixture environments.
@@ -215,6 +278,20 @@ async function main() {
     console.log(renderHelp());
     return;
   }
+
+  // Validate task names before touching the DB so cron typos fail loudly.
+  if (args.tasks.length > 0) {
+    const unknownTasks = validateTaskNames(args.tasks);
+    if (unknownTasks !== null) {
+      const valid = args.tasks.filter((t) => TASK_ORDER.includes(t));
+      if (valid.length === 0) {
+        console.error(`Unknown task names: ${unknownTasks.join(", ")}. Valid tasks: ${TASK_ORDER.join(", ")}`);
+        process.exit(1);
+      }
+      console.error(`Warning: ignoring unknown task names: ${unknownTasks.join(", ")}. Valid tasks: ${TASK_ORDER.join(", ")}`);
+    }
+  }
+
   const config = buildConfig(args);
   if (args.action === "recommended-schedule") {
     console.log(renderRecommendedSchedule(config));

--- a/tests/helpers/fixture-config.mjs
+++ b/tests/helpers/fixture-config.mjs
@@ -178,6 +178,8 @@ function buildFixtureConfig(home, overrides = {}) {
       approvalSubstrate: false,
       hybridRetrieval: false,
       ambientWorkingProfile: false,
+      errorTelemetry: false,
+      postToolUse: false,
     },
   };
 

--- a/tests/smoke/scripts.test.mjs
+++ b/tests/smoke/scripts.test.mjs
@@ -427,9 +427,8 @@ describe("run-maintenance --tasks validation", () => {
     }
   });
 
-  test("warns on stderr about unknown tasks when some tasks are unknown and some are valid", () => {
-    // When the task list contains a mix of unknown + valid names, the script warns on stderr.
-    // The warning must appear before any DB work begins.
+  test("exits 1 and prints error when task list mixes unknown and valid names", () => {
+    // Fail-closed: any unknown name — even alongside valid names — must exit 1 without running tasks.
     const tempHome = makeTempDir();
     try {
       const result = run(
@@ -437,13 +436,27 @@ describe("run-maintenance --tasks validation", () => {
         ["--tasks", "validationCorpus,typo", "--dry-run"],
         { env: { LORE_COPILOT_HOME: tempHome } },
       );
+      assert.strictEqual(
+        result.status,
+        1,
+        `Expected exit 1 for mixed valid+unknown task list.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+      );
       assert.ok(
-        result.stderr.includes("Warning: ignoring unknown task names:"),
-        `Expected warning in stderr about unknown tasks.\nActual: ${result.stderr}`,
+        result.stderr.includes("Unknown task names:"),
+        `Expected error in stderr listing unknown tasks.\nActual: ${result.stderr}`,
       );
       assert.ok(
         result.stderr.includes("typo"),
-        `Expected 'typo' named in the warning.\nActual: ${result.stderr}`,
+        `Expected 'typo' named in the error.\nActual: ${result.stderr}`,
+      );
+      assert.ok(
+        result.stderr.includes("Valid tasks:"),
+        `Expected valid-task list in error guidance.\nActual: ${result.stderr}`,
+      );
+      // No maintenance DB should be created — the script must exit before opening the DB.
+      assert.ok(
+        !existsSync(path.join(tempHome, "lore.db")),
+        `Expected no lore.db created when exiting early on invalid tasks.\nfound: ${path.join(tempHome, "lore.db")}`,
       );
     } finally {
       rmSync(tempHome, { recursive: true, force: true });

--- a/tests/smoke/scripts.test.mjs
+++ b/tests/smoke/scripts.test.mjs
@@ -286,6 +286,46 @@ describe("run-maintenance --recommended-schedule", () => {
       rmSync(tempHome, { recursive: true, force: true });
     }
   });
+
+  test("includes launchd plist example", () => {
+    const tempHome = makeTempDir();
+    try {
+      const result = run("run-maintenance.mjs", ["--recommended-schedule"], {
+        env: { LORE_COPILOT_HOME: tempHome },
+      });
+      assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+      assert.ok(
+        result.stdout.includes("launchd"),
+        `Expected 'launchd' in stdout.\nActual: ${result.stdout}`,
+      );
+      assert.ok(
+        result.stdout.includes("com.lore.maintenance"),
+        `Expected launchd label in stdout.\nActual: ${result.stdout}`,
+      );
+      assert.ok(
+        result.stdout.includes("StartInterval"),
+        `Expected StartInterval in stdout.\nActual: ${result.stdout}`,
+      );
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("includes hook cadence disclaimer", () => {
+    const tempHome = makeTempDir();
+    try {
+      const result = run("run-maintenance.mjs", ["--recommended-schedule"], {
+        env: { LORE_COPILOT_HOME: tempHome },
+      });
+      assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+      assert.ok(
+        result.stdout.includes("do NOT guarantee wall-clock cadence"),
+        `Expected cadence disclaimer in stdout.\nActual: ${result.stdout}`,
+      );
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -346,6 +386,64 @@ describe("run-maintenance --status", () => {
       assert.ok(
         result.stdout.includes("dryRun: true"),
         `Expected 'dryRun: true' in stdout.\nActual: ${result.stdout}`,
+      );
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// run-maintenance.mjs — task name validation
+// ---------------------------------------------------------------------------
+
+describe("run-maintenance --tasks validation", () => {
+  test("exits 1 and prints error when all task names are unknown", () => {
+    const result = run("run-maintenance.mjs", ["--tasks", "notATask,alsoNotATask"]);
+    assert.strictEqual(
+      result.status,
+      1,
+      `Expected exit 1.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+    );
+    assert.ok(
+      result.stderr.includes("Unknown task names:"),
+      `Expected unknown-task error in stderr.\nActual: ${result.stderr}`,
+    );
+    assert.ok(
+      result.stderr.includes("Valid tasks:"),
+      `Expected valid-task list in stderr.\nActual: ${result.stderr}`,
+    );
+  });
+
+  test("exits 1 and lists all known valid tasks in the error message", () => {
+    const result = run("run-maintenance.mjs", ["--tasks", "typo"]);
+    assert.strictEqual(result.status, 1, `stderr: ${result.stderr}`);
+    // Every valid task name should appear in the error guidance
+    for (const task of ["validationCorpus", "replayCorpus", "backlogReview", "traceCompaction", "indexUpkeep", "doctorSnapshot"]) {
+      assert.ok(
+        result.stderr.includes(task),
+        `Expected '${task}' in stderr valid-task list.\nActual: ${result.stderr}`,
+      );
+    }
+  });
+
+  test("warns on stderr about unknown tasks when some tasks are unknown and some are valid", () => {
+    // When the task list contains a mix of unknown + valid names, the script warns on stderr.
+    // The warning must appear before any DB work begins.
+    const tempHome = makeTempDir();
+    try {
+      const result = run(
+        "run-maintenance.mjs",
+        ["--tasks", "validationCorpus,typo", "--dry-run"],
+        { env: { LORE_COPILOT_HOME: tempHome } },
+      );
+      assert.ok(
+        result.stderr.includes("Warning: ignoring unknown task names:"),
+        `Expected warning in stderr about unknown tasks.\nActual: ${result.stderr}`,
+      );
+      assert.ok(
+        result.stderr.includes("typo"),
+        `Expected 'typo' named in the warning.\nActual: ${result.stderr}`,
       );
     } finally {
       rmSync(tempHome, { recursive: true, force: true });

--- a/tests/unit/config.test.mjs
+++ b/tests/unit/config.test.mjs
@@ -135,6 +135,8 @@ describe("loadConfig", () => {
         ambientWorkingProfile: true,
         errorTelemetry: false,
         postToolUse: false,
+        subagentScopeTracking: false,
+        preToolUseGuardrail: false,
       },
     );
   });

--- a/tests/unit/config.test.mjs
+++ b/tests/unit/config.test.mjs
@@ -133,6 +133,8 @@ describe("loadConfig", () => {
         approvalSubstrate: true,
         hybridRetrieval: false,
         ambientWorkingProfile: true,
+        errorTelemetry: false,
+        postToolUse: false,
       },
     );
   });

--- a/tests/unit/db-lease-recovery.test.mjs
+++ b/tests/unit/db-lease-recovery.test.mjs
@@ -1,0 +1,398 @@
+/**
+ * tests/unit/db-lease-recovery.test.mjs
+ *
+ * Validates the deferred-extraction lease mechanism:
+ *   - claimDeferredExtraction atomically claims pending/failed jobs
+ *   - heartbeatDeferredExtraction renews the lease while the job runs
+ *   - reclaimStaleDeferredExtractions returns expired running jobs to failed
+ *   - completeDeferredExtraction and failDeferredExtraction guard by ownerToken
+ *     so stale workers cannot clobber a live worker's state
+ *
+ * All tests run against isolated temp-home databases; the real
+ * ~/.copilot/lore.db is never opened.
+ */
+
+import assert from "node:assert/strict";
+import { describe, test, beforeEach, afterEach } from "node:test";
+
+import { withFixtureDb } from "../helpers/fixture-db.mjs";
+import { FTS5_AVAILABLE } from "../helpers/fixture-db.mjs";
+
+const SKIP_NO_FTS5 = !FTS5_AVAILABLE
+  ? "FTS5 not compiled into this Node.js SQLite build"
+  : false;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert a pending deferred_extraction row directly so tests can control
+ * the initial state without going through enqueueDeferredExtraction.
+ */
+function seedDeferredJob(db, { sessionId, status = "pending", leaseExpiresAt = null, ownerToken = null } = {}) {
+  const now = new Date().toISOString();
+  db.db.prepare(`
+    INSERT INTO deferred_extraction (
+      session_id, repository, status, priority, reason,
+      queued_at, available_at, attempts, owner_token, lease_expires_at, heartbeat_at,
+      metadata_json
+    ) VALUES (?, ?, ?, 0, 'test', ?, ?, 0, ?, ?, ?, '{}')
+    ON CONFLICT(session_id) DO UPDATE SET
+      status = excluded.status,
+      owner_token = excluded.owner_token,
+      lease_expires_at = excluded.lease_expires_at
+  `).run(
+    sessionId,
+    "fixture-repo",
+    status,
+    now,
+    now, // available_at = now so it's immediately due
+    ownerToken,
+    leaseExpiresAt,
+    leaseExpiresAt ? now : null, // heartbeat_at
+  );
+}
+
+function readJob(db, sessionId) {
+  return db.db.prepare(`
+    SELECT session_id, status, owner_token, lease_expires_at, heartbeat_at, attempts, last_error
+    FROM deferred_extraction WHERE session_id = ?
+  `).get(sessionId);
+}
+
+// ---------------------------------------------------------------------------
+// claimDeferredExtraction
+// ---------------------------------------------------------------------------
+
+describe("claimDeferredExtraction", { skip: SKIP_NO_FTS5 }, () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = await withFixtureDb({ seed: false });
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test("claims a pending job and sets running state with owner token and lease", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-claim-1" });
+
+    const token = "worker-token-1";
+    const claimed = db.claimDeferredExtraction("sess-claim-1", token);
+
+    assert.equal(claimed, true);
+    const row = readJob(db, "sess-claim-1");
+    assert.equal(row.status, "running");
+    assert.equal(row.owner_token, token);
+    assert.ok(row.lease_expires_at, "lease_expires_at should be set");
+    assert.ok(row.heartbeat_at, "heartbeat_at should be set");
+    assert.equal(row.attempts, 1);
+    assert.equal(row.last_error, null);
+  });
+
+  test("claims a failed job and increments attempts", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-claim-2", status: "failed" });
+
+    const claimed = db.claimDeferredExtraction("sess-claim-2", "worker-2");
+    assert.equal(claimed, true);
+
+    const row = readJob(db, "sess-claim-2");
+    assert.equal(row.status, "running");
+    assert.equal(row.attempts, 1);
+  });
+
+  test("returns false when the job is already running", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-claim-3" });
+
+    // First claim succeeds
+    assert.equal(db.claimDeferredExtraction("sess-claim-3", "worker-A"), true);
+
+    // Second claim on the same job fails
+    const secondClaim = db.claimDeferredExtraction("sess-claim-3", "worker-B");
+    assert.equal(secondClaim, false);
+
+    // Original owner is unchanged
+    const row = readJob(db, "sess-claim-3");
+    assert.equal(row.owner_token, "worker-A");
+  });
+
+  test("returns false when the job is already completed", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-claim-4", status: "completed" });
+
+    const claimed = db.claimDeferredExtraction("sess-claim-4", "late-worker");
+    assert.equal(claimed, false);
+  });
+
+  test("sets lease_expires_at approximately leaseDurationMs in the future", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-claim-5" });
+
+    const before = Date.now();
+    db.claimDeferredExtraction("sess-claim-5", "worker-5", 10 * 60 * 1000);
+    const after = Date.now();
+
+    const row = readJob(db, "sess-claim-5");
+    const expiresMs = new Date(row.lease_expires_at).getTime();
+    // lease should be ~10 min ahead with some tolerance for test timing
+    assert.ok(expiresMs >= before + 9 * 60 * 1000, "lease should be at least 9 min ahead");
+    assert.ok(expiresMs <= after + 11 * 60 * 1000, "lease should be at most 11 min ahead");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// heartbeatDeferredExtraction
+// ---------------------------------------------------------------------------
+
+describe("heartbeatDeferredExtraction", { skip: SKIP_NO_FTS5 }, () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = await withFixtureDb({ seed: false });
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test("renews lease when caller owns the job", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-hb-1" });
+    db.claimDeferredExtraction("sess-hb-1", "owner-X");
+
+    const beforeHeartbeat = readJob(db, "sess-hb-1");
+    // Advance the system clock perception by using a slightly different duration
+    const renewed = db.heartbeatDeferredExtraction("sess-hb-1", "owner-X", 10 * 60 * 1000);
+
+    assert.equal(renewed, true);
+    const afterHeartbeat = readJob(db, "sess-hb-1");
+    assert.ok(afterHeartbeat.heartbeat_at, "heartbeat_at should be set");
+    // lease_expires_at should still be a future timestamp
+    assert.ok(
+      new Date(afterHeartbeat.lease_expires_at).getTime() > Date.now() + 9 * 60 * 1000,
+      "renewed lease should be at least 9 min in the future",
+    );
+    assert.equal(beforeHeartbeat.owner_token, afterHeartbeat.owner_token);
+  });
+
+  test("returns false when called with the wrong owner token", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-hb-2" });
+    db.claimDeferredExtraction("sess-hb-2", "correct-owner");
+
+    const renewed = db.heartbeatDeferredExtraction("sess-hb-2", "wrong-owner");
+    assert.equal(renewed, false);
+  });
+
+  test("returns false when the job is not in running state", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-hb-3", status: "pending" });
+
+    const renewed = db.heartbeatDeferredExtraction("sess-hb-3", "any-token");
+    assert.equal(renewed, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reclaimStaleDeferredExtractions
+// ---------------------------------------------------------------------------
+
+describe("reclaimStaleDeferredExtractions", { skip: SKIP_NO_FTS5 }, () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = await withFixtureDb({ seed: false });
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test("resets running jobs with expired leases to failed", () => {
+    const { db } = fixture;
+    const expiredLease = new Date(Date.now() - 1000).toISOString(); // 1 sec ago = expired
+    seedDeferredJob(db, {
+      sessionId: "sess-stale-1",
+      status: "running",
+      leaseExpiresAt: expiredLease,
+      ownerToken: "dead-worker",
+    });
+
+    const reclaimed = db.reclaimStaleDeferredExtractions();
+    assert.equal(reclaimed, 1);
+
+    const row = readJob(db, "sess-stale-1");
+    assert.equal(row.status, "failed");
+    assert.equal(row.last_error, "lease expired");
+    assert.equal(row.owner_token, null);
+    assert.equal(row.lease_expires_at, null);
+  });
+
+  test("does not touch running jobs whose leases have not expired", () => {
+    const { db } = fixture;
+    const futureLease = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+    seedDeferredJob(db, {
+      sessionId: "sess-stale-2",
+      status: "running",
+      leaseExpiresAt: futureLease,
+      ownerToken: "active-worker",
+    });
+
+    const reclaimed = db.reclaimStaleDeferredExtractions();
+    assert.equal(reclaimed, 0);
+
+    const row = readJob(db, "sess-stale-2");
+    assert.equal(row.status, "running");
+    assert.equal(row.owner_token, "active-worker");
+  });
+
+  test("does not touch running jobs without a lease_expires_at (legacy rows)", () => {
+    const { db } = fixture;
+    // Legacy row: running with no lease columns
+    db.db.prepare(`
+      INSERT INTO deferred_extraction (
+        session_id, repository, status, priority, reason, queued_at, available_at, metadata_json
+      ) VALUES ('sess-legacy', 'repo', 'running', 0, 'manual', datetime('now'), datetime('now'), '{}')
+    `).run();
+
+    const reclaimed = db.reclaimStaleDeferredExtractions();
+    assert.equal(reclaimed, 0);
+
+    const row = readJob(db, "sess-legacy");
+    assert.equal(row.status, "running");
+  });
+
+  test("reclaims multiple expired jobs in one call", () => {
+    const { db } = fixture;
+    const expiredLease = new Date(Date.now() - 500).toISOString();
+    for (const id of ["a", "b", "c"]) {
+      seedDeferredJob(db, {
+        sessionId: `sess-multi-${id}`,
+        status: "running",
+        leaseExpiresAt: expiredLease,
+        ownerToken: "old-worker",
+      });
+    }
+
+    const reclaimed = db.reclaimStaleDeferredExtractions();
+    assert.equal(reclaimed, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// completeDeferredExtraction with owner token (idempotency guard)
+// ---------------------------------------------------------------------------
+
+describe("completeDeferredExtraction owner token guard", { skip: SKIP_NO_FTS5 }, () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = await withFixtureDb({ seed: false });
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test("completes the job when the owner token matches", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-comp-1" });
+    db.claimDeferredExtraction("sess-comp-1", "worker-ok");
+
+    db.completeDeferredExtraction("sess-comp-1", "worker-ok");
+
+    const row = readJob(db, "sess-comp-1");
+    assert.equal(row.status, "completed");
+  });
+
+  test("does not overwrite a reclaimed job when a stale worker tries to complete", () => {
+    const { db } = fixture;
+    const expiredLease = new Date(Date.now() - 1000).toISOString();
+    seedDeferredJob(db, {
+      sessionId: "sess-comp-2",
+      status: "running",
+      leaseExpiresAt: expiredLease,
+      ownerToken: "old-worker",
+    });
+
+    // Reaper resets it to failed
+    db.reclaimStaleDeferredExtractions();
+    assert.equal(readJob(db, "sess-comp-2").status, "failed");
+
+    // New worker claims it
+    db.claimDeferredExtraction("sess-comp-2", "new-worker");
+    assert.equal(readJob(db, "sess-comp-2").status, "running");
+
+    // Old worker tries to complete — should be a no-op
+    db.completeDeferredExtraction("sess-comp-2", "old-worker");
+    const row = readJob(db, "sess-comp-2");
+    assert.equal(row.status, "running", "stale complete must not overwrite live job");
+    assert.equal(row.owner_token, "new-worker");
+  });
+
+  test("backward-compat: completing without a token updates status unconditionally", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-comp-3", status: "running", ownerToken: "some-token" });
+
+    // Legacy call without ownerToken
+    db.completeDeferredExtraction("sess-comp-3");
+    assert.equal(readJob(db, "sess-comp-3").status, "completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// failDeferredExtraction with owner token
+// ---------------------------------------------------------------------------
+
+describe("failDeferredExtraction owner token guard", { skip: SKIP_NO_FTS5 }, () => {
+  let fixture;
+
+  beforeEach(async () => {
+    fixture = await withFixtureDb({ seed: false });
+  });
+
+  afterEach(() => {
+    fixture.cleanup();
+  });
+
+  test("fails the job and clears lease fields when owner token matches", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-fail-1" });
+    db.claimDeferredExtraction("sess-fail-1", "worker-f");
+
+    db.failDeferredExtraction("sess-fail-1", {
+      errorMessage: "something went wrong",
+      retryDelayMinutes: 15,
+      ownerToken: "worker-f",
+    });
+
+    const row = readJob(db, "sess-fail-1");
+    assert.equal(row.status, "failed");
+    assert.equal(row.last_error, "something went wrong");
+    assert.equal(row.owner_token, null);
+    assert.equal(row.lease_expires_at, null);
+  });
+
+  test("does not overwrite when a stale worker tries to fail a reclaimed job", () => {
+    const { db } = fixture;
+    seedDeferredJob(db, { sessionId: "sess-fail-2" });
+    // New worker owns the job
+    db.claimDeferredExtraction("sess-fail-2", "new-worker");
+
+    // Old worker tries to fail using its stale token
+    db.failDeferredExtraction("sess-fail-2", {
+      errorMessage: "stale error",
+      retryDelayMinutes: 1,
+      ownerToken: "old-worker",
+    });
+
+    const row = readJob(db, "sess-fail-2");
+    assert.equal(row.status, "running", "stale fail must not overwrite live job");
+    assert.equal(row.owner_token, "new-worker");
+  });
+});

--- a/tests/unit/db-legacy-schema-version.test.mjs
+++ b/tests/unit/db-legacy-schema-version.test.mjs
@@ -258,4 +258,61 @@ describe("LoreDb legacy schema version compatibility", () => {
     assert.ok(plan.includes("deferred-extraction-lease"), `plan ${JSON.stringify(plan)} should include deferred-extraction-lease`);
     assert.ok(plan.includes("schema-statements"), "plan should include schema-statements");
   });
+
+  test("v16 migration plan includes schema-statements (creates error_telemetry)", () => {
+    const loreDb = new LoreDb({
+      paths: { derivedStorePath: "ignored.db", backupDir: "ignored-backups" },
+    });
+
+    const plan = loreDb.buildMigrationPlan(16).map((step) => step.label);
+    assert.ok(plan.includes("schema-statements"), "plan for v16 must include schema-statements to create error_telemetry");
+    // No dedicated pre-schema step for error_telemetry; the table is added via schema-statements
+    assert.ok(!plan.includes("error-telemetry"), "no separate error-telemetry migration step needed");
+  });
+
+  test("upgrading a v16 DB creates error_telemetry table", { skip: SKIP_NO_FTS5 }, () => {
+    const tempHome = makeTempDir();
+    const dbPath = path.join(tempHome, "lore.db");
+    const backupDir = path.join(tempHome, "backups");
+
+    try {
+      const raw = new DatabaseSync(dbPath);
+      raw.exec(`
+        CREATE TABLE lore_schema_version (version INTEGER NOT NULL);
+        INSERT INTO lore_schema_version (version) VALUES (16);
+        CREATE TABLE deferred_extraction (
+          session_id TEXT PRIMARY KEY,
+          repository TEXT,
+          status TEXT NOT NULL DEFAULT 'pending',
+          priority INTEGER NOT NULL DEFAULT 0,
+          reason TEXT NOT NULL DEFAULT 'manual',
+          queued_at TEXT NOT NULL,
+          available_at TEXT NOT NULL,
+          started_at TEXT,
+          completed_at TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          last_error TEXT,
+          owner_token TEXT,
+          lease_expires_at TEXT,
+          heartbeat_at TEXT,
+          metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+      `);
+      raw.close();
+
+      const loreDb = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      loreDb.initialize();
+
+      assert.equal(loreDb.getCurrentVersion(), SCHEMA_VERSION);
+
+      const table = loreDb.db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='error_telemetry'`)
+        .get();
+      assert.ok(table, "error_telemetry table must exist after v16 upgrade");
+
+      loreDb.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/unit/db-legacy-schema-version.test.mjs
+++ b/tests/unit/db-legacy-schema-version.test.mjs
@@ -164,4 +164,98 @@ describe("LoreDb legacy schema version compatibility", () => {
       rmSync(tempHome, { recursive: true, force: true });
     }
   });
+
+  test("v15→v16 migration adds lease columns to deferred_extraction", { skip: SKIP_NO_FTS5 }, () => {
+    const tempHome = makeTempDir();
+    const dbPath = path.join(tempHome, "lore.db");
+    const backupDir = path.join(tempHome, "backups");
+
+    try {
+      // Create a minimal v15 database that has deferred_extraction without the
+      // new lease columns. The migration runner must add them on upgrade.
+      const rawDb = new DatabaseSync(dbPath);
+      rawDb.exec(`
+        CREATE TABLE lore_schema_version (version INTEGER NOT NULL);
+        INSERT INTO lore_schema_version (version) VALUES (15);
+        CREATE TABLE deferred_extraction (
+          session_id TEXT PRIMARY KEY,
+          repository TEXT,
+          status TEXT NOT NULL DEFAULT 'pending',
+          priority INTEGER NOT NULL DEFAULT 0,
+          reason TEXT NOT NULL DEFAULT 'manual',
+          queued_at TEXT NOT NULL,
+          available_at TEXT NOT NULL,
+          started_at TEXT,
+          completed_at TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          last_error TEXT,
+          metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+        INSERT INTO deferred_extraction (session_id, queued_at, available_at)
+          VALUES ('test-sess', datetime('now'), datetime('now'));
+      `);
+      rawDb.close();
+
+      const loreDb = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      loreDb.initialize();
+
+      assert.equal(loreDb.getCurrentVersion(), SCHEMA_VERSION);
+
+      // Verify the new columns exist and are accessible
+      const row = loreDb.db.prepare(`
+        SELECT session_id, owner_token, lease_expires_at, heartbeat_at
+        FROM deferred_extraction WHERE session_id = 'test-sess'
+      `).get();
+      assert.ok(row, "deferred_extraction row should be readable after migration");
+      assert.equal(row.owner_token, null, "owner_token should default to null");
+      assert.equal(row.lease_expires_at, null, "lease_expires_at should default to null");
+      assert.equal(row.heartbeat_at, null, "heartbeat_at should default to null");
+
+      loreDb.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("fresh install has lease columns in deferred_extraction", { skip: SKIP_NO_FTS5 }, () => {
+    const tempHome = makeTempDir();
+    const dbPath = path.join(tempHome, "lore.db");
+    const backupDir = path.join(tempHome, "backups");
+
+    try {
+      const loreDb = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      loreDb.initialize();
+
+      assert.equal(loreDb.getCurrentVersion(), SCHEMA_VERSION);
+
+      // Verify that a fresh schema has all three lease columns.
+      // We insert a row and read back the new nullable columns.
+      loreDb.db.prepare(`
+        INSERT INTO deferred_extraction (session_id, queued_at, available_at)
+        VALUES ('fresh-sess', datetime('now'), datetime('now'))
+      `).run();
+      const row = loreDb.db.prepare(`
+        SELECT session_id, owner_token, lease_expires_at, heartbeat_at
+        FROM deferred_extraction WHERE session_id = 'fresh-sess'
+      `).get();
+      assert.ok(row, "deferred_extraction row should be readable");
+      assert.equal(row.owner_token, null);
+      assert.equal(row.lease_expires_at, null);
+      assert.equal(row.heartbeat_at, null);
+
+      loreDb.close();
+    } finally {
+      rmSync(tempHome, { recursive: true, force: true });
+    }
+  });
+
+  test("v15 migration plan includes deferred-extraction-lease step", () => {
+    const loreDb = new LoreDb({
+      paths: { derivedStorePath: "ignored.db", backupDir: "ignored-backups" },
+    });
+
+    const plan = loreDb.buildMigrationPlan(15).map((step) => step.label);
+    assert.ok(plan.includes("deferred-extraction-lease"), `plan ${JSON.stringify(plan)} should include deferred-extraction-lease`);
+    assert.ok(plan.includes("schema-statements"), "plan should include schema-statements");
+  });
 });

--- a/tests/unit/extension-shutdown.test.mjs
+++ b/tests/unit/extension-shutdown.test.mjs
@@ -1,0 +1,372 @@
+/**
+ * tests/unit/extension-shutdown.test.mjs
+ *
+ * Tests for the background-work tracking and bounded shutdown helpers defined
+ * in extension.mjs.  Functions are loaded via the source-parser approach used
+ * by the other extension hook tests so they can be tested without importing
+ * the whole extension entrypoint (which depends on @github/copilot-sdk).
+ *
+ * Covers:
+ *   - trackBackgroundWork registers the promise and removes it on settlement
+ *   - spawnTrackedMicrotask registers work and short-circuits when shutting down
+ *   - spawnTrackedDeferredTask registers work and short-circuits when shutting down
+ *   - shutdownRuntime: drains pending work then calls db.close() exactly once
+ *   - shutdownRuntime: idempotent — second call is a no-op
+ *   - shutdownRuntime: respects gracePeriodMs when work is slow
+ */
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "node:test";
+
+import { makeSourceExtractor } from "../helpers/source-parser.mjs";
+
+const EXTENSION_SOURCE = readFileSync(new URL("../../extension.mjs", import.meta.url), "utf8");
+const extractFunctionSource = makeSourceExtractor(EXTENSION_SOURCE);
+
+function loadFunction(name, dependencies = {}) {
+  const functionSource = extractFunctionSource(name);
+  return Function(
+    ...Object.keys(dependencies),
+    `"use strict"; ${functionSource}; return ${name};`,
+  )(...Object.values(dependencies));
+}
+
+function loadFunctions(names, dependencies = {}) {
+  const functionSources = names.map((name) => extractFunctionSource(name)).join("\n\n");
+  return Function(
+    ...Object.keys(dependencies),
+    `"use strict"; ${functionSources}; return { ${names.join(", ")} };`,
+  )(...Object.values(dependencies));
+}
+
+// ---------------------------------------------------------------------------
+// trackBackgroundWork
+// ---------------------------------------------------------------------------
+
+describe("trackBackgroundWork", () => {
+  test("adds promise to pendingWork and removes it on resolution", async () => {
+    const pendingWork = new Set();
+    const runtime = { pendingWork };
+
+    const trackBackgroundWork = loadFunction("trackBackgroundWork", { runtime });
+
+    let resolve;
+    const p = new Promise((res) => { resolve = res; });
+
+    trackBackgroundWork(p);
+    assert.equal(pendingWork.size, 1, "promise should be in pendingWork while pending");
+
+    resolve();
+    await p;
+    // Give the finally handler a tick to run
+    await Promise.resolve();
+
+    assert.equal(pendingWork.size, 0, "promise should be removed after resolution");
+  });
+
+  test("removes promise from pendingWork on rejection", async () => {
+    const pendingWork = new Set();
+    const runtime = { pendingWork };
+
+    const trackBackgroundWork = loadFunction("trackBackgroundWork", { runtime });
+
+    const p = Promise.reject(new Error("test rejection")).catch(() => {});
+    trackBackgroundWork(p);
+
+    await p;
+    await Promise.resolve();
+
+    assert.equal(pendingWork.size, 0, "rejected promise should also be removed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spawnTrackedMicrotask
+// ---------------------------------------------------------------------------
+
+describe("spawnTrackedMicrotask", () => {
+  test("spawns and tracks a microtask promise when not shutting down", async () => {
+    const pendingWork = new Set();
+    const runtime = { pendingWork, shuttingDown: false };
+
+    const { spawnTrackedMicrotask, trackBackgroundWork } = loadFunctions(
+      ["spawnTrackedMicrotask", "trackBackgroundWork"],
+      { runtime },
+    );
+
+    let resolved = false;
+    spawnTrackedMicrotask(async () => {
+      resolved = true;
+    });
+
+    // pendingWork should have one entry immediately
+    assert.equal(pendingWork.size, 1, "microtask should be in pendingWork immediately");
+
+    // Let it run
+    await new Promise((res) => setTimeout(res, 5));
+    assert.equal(resolved, true, "fn should have run");
+    assert.equal(pendingWork.size, 0, "pendingWork should be empty after completion");
+  });
+
+  test("does not spawn work when shuttingDown is true", async () => {
+    const pendingWork = new Set();
+    const runtime = { pendingWork, shuttingDown: true };
+
+    const { spawnTrackedMicrotask, trackBackgroundWork } = loadFunctions(
+      ["spawnTrackedMicrotask", "trackBackgroundWork"],
+      { runtime },
+    );
+
+    let ran = false;
+    spawnTrackedMicrotask(async () => { ran = true; });
+
+    await new Promise((res) => setTimeout(res, 10));
+    assert.equal(ran, false, "fn must not run when shutting down");
+    assert.equal(pendingWork.size, 0, "pendingWork must remain empty");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// spawnTrackedDeferredTask
+// ---------------------------------------------------------------------------
+
+describe("spawnTrackedDeferredTask", () => {
+  test("spawns and tracks a deferred task promise when not shutting down", async () => {
+    const pendingWork = new Set();
+    const runtime = { pendingWork, shuttingDown: false };
+
+    const { spawnTrackedDeferredTask, trackBackgroundWork } = loadFunctions(
+      ["spawnTrackedDeferredTask", "trackBackgroundWork"],
+      { runtime },
+    );
+
+    let ran = false;
+    spawnTrackedDeferredTask(async () => { ran = true; });
+
+    // promise is tracked before the task runs
+    assert.equal(pendingWork.size, 1, "deferred task should be in pendingWork immediately");
+
+    await new Promise((res) => setTimeout(res, 20));
+    assert.equal(ran, true, "fn should have run after setTimeout");
+    assert.equal(pendingWork.size, 0, "pendingWork should be empty after completion");
+  });
+
+  test("does not spawn work when shuttingDown is true", async () => {
+    const pendingWork = new Set();
+    const runtime = { pendingWork, shuttingDown: true };
+
+    const { spawnTrackedDeferredTask, trackBackgroundWork } = loadFunctions(
+      ["spawnTrackedDeferredTask", "trackBackgroundWork"],
+      { runtime },
+    );
+
+    let ran = false;
+    spawnTrackedDeferredTask(async () => { ran = true; });
+
+    await new Promise((res) => setTimeout(res, 20));
+    assert.equal(ran, false, "fn must not run when shutting down");
+    assert.equal(pendingWork.size, 0, "pendingWork must remain empty");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shutdownRuntime
+// ---------------------------------------------------------------------------
+
+describe("shutdownRuntime", () => {
+  test("sets shuttingDown, drains pending work, and calls db.close() once", async () => {
+    const closeCalls = [];
+    let nulledDb = false;
+    const runtime = {
+      pendingWork: new Set(),
+      shuttingDown: false,
+      db: {
+        close() { closeCalls.push("close"); },
+      },
+    };
+
+    const delays = [];
+    const { shutdownRuntime, trackBackgroundWork } = loadFunctions(
+      ["shutdownRuntime", "trackBackgroundWork"],
+      {
+        runtime,
+        async delay(ms) { delays.push(ms); },
+        Promise,
+      },
+    );
+
+    // Add a fast-settling background job
+    const p = Promise.resolve();
+    trackBackgroundWork(p);
+    await p;
+    await Promise.resolve();
+
+    const session = { async log() {} };
+    await shutdownRuntime(session, 4000);
+
+    assert.equal(runtime.shuttingDown, true, "shuttingDown should be true after shutdown");
+    assert.equal(closeCalls.length, 1, "db.close() should be called exactly once");
+    assert.equal(runtime.db, null, "runtime.db should be nulled after shutdown");
+  });
+
+  test("does nothing on second call (idempotent)", async () => {
+    const closeCalls = [];
+    const runtime = {
+      pendingWork: new Set(),
+      shuttingDown: false,
+      db: {
+        close() { closeCalls.push("close"); },
+      },
+    };
+
+    const { shutdownRuntime, trackBackgroundWork } = loadFunctions(
+      ["shutdownRuntime", "trackBackgroundWork"],
+      {
+        runtime,
+        async delay() {},
+        Promise,
+      },
+    );
+
+    const session = { async log() {} };
+    await shutdownRuntime(session, 100);
+    await shutdownRuntime(session, 100);
+
+    assert.equal(closeCalls.length, 1, "close should only be called once even when shutdown called twice");
+  });
+
+  test("resolves within gracePeriodMs when pending work is slow", async () => {
+    const closeCalls = [];
+    const runtime = {
+      pendingWork: new Set(),
+      shuttingDown: false,
+      db: {
+        close() { closeCalls.push("close"); },
+      },
+    };
+
+    const { shutdownRuntime, trackBackgroundWork } = loadFunctions(
+      ["shutdownRuntime", "trackBackgroundWork"],
+      {
+        runtime,
+        delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+        Promise,
+      },
+    );
+
+    // Add a work item that never settles within the grace period
+    let resolveWork;
+    const slowWork = new Promise((resolve) => { resolveWork = resolve; });
+    trackBackgroundWork(slowWork);
+
+    const start = Date.now();
+    const session = { async log() {} };
+    // Very short grace period — should bail out quickly
+    await shutdownRuntime(session, 50);
+    const elapsed = Date.now() - start;
+
+    assert.ok(elapsed < 500, `shutdown should complete within 500ms, took ${elapsed}ms`);
+    assert.equal(closeCalls.length, 1, "close should still be called after grace period");
+    resolveWork(); // cleanup
+  });
+
+  test("calls db.close() even when db is null (no-op)", async () => {
+    const runtime = {
+      pendingWork: new Set(),
+      shuttingDown: false,
+      db: null,
+    };
+
+    const { shutdownRuntime } = loadFunctions(
+      ["shutdownRuntime", "trackBackgroundWork"],
+      {
+        runtime,
+        async delay() {},
+        Promise,
+      },
+    );
+
+    const session = { async log() {} };
+    // Should not throw when db is null
+    await assert.doesNotReject(() => shutdownRuntime(session, 100));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistTraceSuccess catch → warning log
+// ---------------------------------------------------------------------------
+
+describe("persistTraceSuccess trace-persistence warning", () => {
+  test("logs warning via session when trace persistence throws", async () => {
+    const warnings = [];
+    const fakeSession = {
+      async log(message, options) {
+        if (options?.level === "warning") {
+          warnings.push(message);
+        }
+      },
+    };
+
+    const pendingWork = new Set();
+    const runtime = { pendingWork, shuttingDown: false };
+
+    const { persistTraceSuccess, spawnTrackedMicrotask, trackBackgroundWork } = loadFunctions(
+      [
+        "resolveTraceSuccessRecord",
+        "buildTraceSuccessUpdates",
+        "buildDurableTraceSampleRecordFields",
+        "buildDurableTraceSampleEvidenceFields",
+        "buildDurableTraceSamplePayload",
+        "persistTraceContextInjectionUpdates",
+        "maybePruneDurableTraceSamples",
+        "persistDurableTraceSample",
+        "writeActivitySuccessUpdates",
+        "persistTraceSuccess",
+        "spawnTrackedMicrotask",
+        "trackBackgroundWork",
+      ],
+      {
+        runtime,
+        session: fakeSession,
+      },
+    );
+
+    const activeRuntime = {
+      db: {
+        upsertActivitySuccess() { throw new Error("forced db write failure"); },
+        pruneRetrievalTraceSamples() {},
+        insertRetrievalTraceSample() {},
+      },
+      config: { traceRecorder: { durableMaxRowsPerRepository: 120, durableMaxRowsGlobal: 240, durableMaxAgeMs: 1000 } },
+      tracePersistenceWrites: 0,
+    };
+
+    const traceResult = {
+      id: "trace-warn-1",
+      record: {
+        recordedAt: "2026-01-01T00:00:00.000Z",
+        output: { sectionTitles: [], contextInjected: false },
+      },
+      durableSelected: false,
+    };
+
+    persistTraceSuccess({
+      activeRuntime,
+      repository: "owner/repo",
+      traceResult,
+      durationMs: 10,
+      hook: "onSessionStart",
+      session: fakeSession,
+    });
+
+    // Wait for the microtask to run
+    await new Promise((res) => setTimeout(res, 20));
+
+    assert.ok(warnings.length >= 1, `expected at least one warning, got: ${JSON.stringify(warnings)}`);
+    assert.ok(
+      warnings[0].includes("lore trace persistence warning:"),
+      `warning message should include 'lore trace persistence warning:', got: ${warnings[0]}`,
+    );
+  });
+});

--- a/tests/unit/extension-shutdown.test.mjs
+++ b/tests/unit/extension-shutdown.test.mjs
@@ -294,6 +294,59 @@ describe("shutdownRuntime", () => {
 });
 
 // ---------------------------------------------------------------------------
+// handleSessionEndHook — shutdown runs even for empty/no-artifact sessions
+// ---------------------------------------------------------------------------
+
+describe("handleSessionEndHook empty-session shutdown", () => {
+  test("drains pending background work and closes the DB once when no session artifacts exist", async () => {
+    const closeCalls = [];
+    const runtime = {
+      pendingWork: new Set(),
+      shuttingDown: false,
+      initialized: true,
+      lastError: null,
+      config: {},
+      db: {
+        close() { closeCalls.push("close"); },
+      },
+    };
+
+    // Register a fast background job before session end to confirm drain
+    let workSettled = false;
+    const work = new Promise((res) => setTimeout(() => { workSettled = true; res(); }, 5));
+    runtime.pendingWork.add(work);
+    work.then(() => runtime.pendingWork.delete(work));
+
+    const { handleSessionEndHook, shutdownRuntime, trackBackgroundWork } = loadFunctions(
+      ["handleSessionEndHook", "shutdownRuntime", "trackBackgroundWork"],
+      {
+        runtime,
+        delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+        Promise,
+        getContext: async () => ({ runtime, workspace: "/fake/ws", repository: "owner/repo" }),
+        hooksEnabled: () => true,
+        readSessionEndExtraction: () => null,
+        applySessionExtraction: () => { throw new Error("must not be called for empty session"); },
+        maybeEnqueueDeferredSessionExtraction: () => { throw new Error("must not be called for empty session"); },
+      },
+    );
+
+    const session = { async log() {} };
+    await handleSessionEndHook({
+      session,
+      invocation: { sessionId: "session-empty-regression" },
+      input: { cwd: "/fake/cwd", reason: "normal" },
+    });
+
+    assert.equal(closeCalls.length, 1, "db.close() must be called exactly once even when no artifacts exist");
+    assert.equal(runtime.db, null, "runtime.db must be nulled after shutdown");
+    assert.equal(runtime.shuttingDown, true, "runtime.shuttingDown must be true after shutdown");
+    assert.equal(workSettled, true, "pending background work must have settled before shutdown closed the DB");
+    assert.equal(runtime.pendingWork.size, 0, "pendingWork must be empty after drain");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // persistTraceSuccess catch → warning log
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/hook-contract.test.mjs
+++ b/tests/unit/hook-contract.test.mjs
@@ -1,47 +1,43 @@
-import assert from "node:assert/strict";
-import { describe, test } from "node:test";
-import { buildLoreHooks } from "../../lib/hook-registration.mjs";
+import assert from "node:assert";
+import { buildLoreHooks, LORE_HOOK_NAMES } from "../../lib/hook-registration.mjs";
 
-// Verified SDK hook contract (seven-hook superset used for validation)
-const VERIFIED_HOOKS = [
-  "onPreToolUse",
-  "onPostToolUse",
-  "onUserPromptSubmitted",
-  "onSessionStart",
-  "onSessionEnd",
-  "onErrorOccurred",
-  "onEvent",
-];
+// Programmatic unit tests for the hook helper and canonical contract
+const run = async () => {
+  // canonical contract
+  assert(Array.isArray(LORE_HOOK_NAMES), "LORE_HOOK_NAMES should be an array");
+  assert.strictEqual(LORE_HOOK_NAMES.length, 7, "There must be seven canonical hooks");
+  assert(LORE_HOOK_NAMES.includes("onPreMcpToolCall"), "onPreMcpToolCall must be part of the canonical set");
+  assert(!LORE_HOOK_NAMES.includes("onEvent"), "onEvent must NOT be part of the canonical set");
 
-describe("hook-registration helper", () => {
-  test("returns only defined handlers and preserves function identity", () => {
-    const sentinelA = () => "a";
-    const sentinelB = function foo() { return "b"; };
-    const sentinelC = () => "c";
+  // prepare handlers with mixed values
+  const f1 = () => 1;
+  const f2 = function () { return 2; };
+  const handlers = {
+    onSessionStart: f1,
+    onPreToolUse: f2,
+    onPreMcpToolCall: () => "ok",
+    onEvent: () => "should be rejected",
+    onSessionEnd: undefined,
+    onUserPromptSubmitted: "not-a-function",
+    unknownHook: () => {},
+  };
 
-    const handlers = {
-      onSessionStart: sentinelA,
-      onUserPromptSubmitted: sentinelB,
-      onFooBar: sentinelC, // not a known/allowed hook
-      onEvent: undefined, // explicitly undefined should be omitted
-    };
+  const built = buildLoreHooks(handlers);
 
-    const built = buildLoreHooks(handlers);
+  // should only include canonical names with function values
+  assert.strictEqual(typeof built.onSessionStart, "function");
+  assert.strictEqual(built.onSessionStart, f1, "Function identity must be preserved");
+  assert.strictEqual(typeof built.onPreToolUse, "function");
+  assert.strictEqual(built.onPreToolUse, f2, "Function identity must be preserved");
+  assert.strictEqual(typeof built.onPreMcpToolCall, "function", "onPreMcpToolCall should be accepted as a named hook");
 
-    // keys should be a subset of VERIFIED_HOOKS
-    const keys = Object.keys(built);
-    for (const k of keys) {
-      assert.ok(VERIFIED_HOOKS.includes(k), `unexpected hook key: ${k}`);
-    }
+  // should NOT include non-function, undefined, or unknown keys
+  assert(!Object.prototype.hasOwnProperty.call(built, "onEvent"), "onEvent must be rejected by buildLoreHooks");
+  assert(!Object.prototype.hasOwnProperty.call(built, "unknownHook"), "unknownHook must be rejected");
+  assert(!Object.prototype.hasOwnProperty.call(built, "onSessionEnd"), "undefined-valued hooks must be omitted");
+  assert(!Object.prototype.hasOwnProperty.call(built, "onUserPromptSubmitted"), "non-function-valued hooks must be omitted");
 
-    // expected keys present
-    assert.strictEqual(built.onSessionStart, sentinelA);
-    assert.strictEqual(built.onUserPromptSubmitted, sentinelB);
+  console.log("hook-contract programmatic test: OK");
+};
 
-    // unexpected keys omitted
-    assert.equal(built.onFooBar, undefined);
-
-    // explicitly undefined omitted
-    assert.equal(built.onEvent, undefined);
-  });
-});
+await run();

--- a/tests/unit/hook-contract.test.mjs
+++ b/tests/unit/hook-contract.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { buildLoreHooks } from "../../lib/hook-registration.mjs";
+
+// Verified SDK hook contract (seven-hook superset used for validation)
+const VERIFIED_HOOKS = [
+  "onPreToolUse",
+  "onPostToolUse",
+  "onUserPromptSubmitted",
+  "onSessionStart",
+  "onSessionEnd",
+  "onErrorOccurred",
+  "onEvent",
+];
+
+describe("hook-registration helper", () => {
+  test("returns only defined handlers and preserves function identity", () => {
+    const sentinelA = () => "a";
+    const sentinelB = function foo() { return "b"; };
+    const sentinelC = () => "c";
+
+    const handlers = {
+      onSessionStart: sentinelA,
+      onUserPromptSubmitted: sentinelB,
+      onFooBar: sentinelC, // not a known/allowed hook
+      onEvent: undefined, // explicitly undefined should be omitted
+    };
+
+    const built = buildLoreHooks(handlers);
+
+    // keys should be a subset of VERIFIED_HOOKS
+    const keys = Object.keys(built);
+    for (const k of keys) {
+      assert.ok(VERIFIED_HOOKS.includes(k), `unexpected hook key: ${k}`);
+    }
+
+    // expected keys present
+    assert.strictEqual(built.onSessionStart, sentinelA);
+    assert.strictEqual(built.onUserPromptSubmitted, sentinelB);
+
+    // unexpected keys omitted
+    assert.equal(built.onFooBar, undefined);
+
+    // explicitly undefined omitted
+    assert.equal(built.onEvent, undefined);
+  });
+});

--- a/tests/unit/passive-hooks-db.test.mjs
+++ b/tests/unit/passive-hooks-db.test.mjs
@@ -1,0 +1,298 @@
+/**
+ * tests/unit/passive-hooks-db.test.mjs
+ *
+ * Tests for the error_telemetry DB table: schema/migration, insertErrorTelemetry,
+ * pruneErrorTelemetry, and no raw-message/stack persistence.
+ *
+ * Covers:
+ *   - fresh install creates error_telemetry with the expected columns
+ *   - v16→v17 upgrade (schema-statements) creates the table on existing DB
+ *   - insertErrorTelemetry persists categorical fields, returns an ID
+ *   - no raw message/stack columns in the table
+ *   - category/recoverability/fingerprint fields are persisted correctly
+ *   - pruneErrorTelemetry trims by age and by global row limit
+ *   - migration plan for v16 includes schema-statements (which creates the table)
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+import { LoreDb } from "../../lib/db.mjs";
+import { SCHEMA_VERSION } from "../../lib/schema.mjs";
+import { FTS5_AVAILABLE } from "../helpers/fixture-db.mjs";
+import { buildErrorTelemetryRecord } from "../../lib/passive-hooks.mjs";
+
+const SKIP_NO_FTS5 = !FTS5_AVAILABLE
+  ? "FTS5 not compiled into this Node.js SQLite build"
+  : false;
+
+function makeTempDir() {
+  return mkdtempSync(path.join(os.tmpdir(), "lore-passive-hooks-db-"));
+}
+
+// ---------------------------------------------------------------------------
+// Fresh install: error_telemetry table exists with correct columns
+// ---------------------------------------------------------------------------
+
+describe("error_telemetry schema — fresh install", () => {
+  test("fresh DB has error_telemetry table", { skip: SKIP_NO_FTS5 }, () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "lore.db");
+    const backupDir = path.join(tempDir, "backups");
+    try {
+      const db = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      db.initialize();
+
+      assert.strictEqual(db.getCurrentVersion(), SCHEMA_VERSION);
+
+      // Table exists
+      const table = db.db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='error_telemetry'`)
+        .get();
+      assert.ok(table, "error_telemetry table must exist after fresh init");
+
+      // Expected columns
+      const cols = db.db.prepare(`PRAGMA table_info(error_telemetry)`).all();
+      const colNames = new Set(cols.map((c) => c.name));
+      for (const expected of ["id", "session_id", "context_category", "recoverability", "fingerprint", "created_at"]) {
+        assert.ok(colNames.has(expected), `error_telemetry must have column ${expected}`);
+      }
+
+      // Forbidden columns
+      for (const forbidden of ["message", "stack", "raw_payload", "error_message", "error_stack"]) {
+        assert.ok(!colNames.has(forbidden), `error_telemetry must NOT have column ${forbidden}`);
+      }
+
+      db.close();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("fresh install migration plan includes schema-statements step", () => {
+    const db = new LoreDb({
+      paths: { derivedStorePath: "ignored.db", backupDir: "ignored-backups" },
+    });
+    const labels = db.buildMigrationPlan(0).map((s) => s.label);
+    assert.ok(labels.includes("schema-statements"), "migration plan must include schema-statements");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Upgrade v16 → v17: schema-statements creates error_telemetry
+// ---------------------------------------------------------------------------
+
+describe("error_telemetry migration — v16 → v17 upgrade", () => {
+  test("upgrading a v16 DB creates the error_telemetry table", { skip: SKIP_NO_FTS5 }, () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "lore.db");
+    const backupDir = path.join(tempDir, "backups");
+    try {
+      // Simulate an existing v16 database without error_telemetry.
+      const raw = new DatabaseSync(dbPath);
+      raw.exec(`
+        CREATE TABLE lore_schema_version (version INTEGER NOT NULL);
+        INSERT INTO lore_schema_version (version) VALUES (16);
+        CREATE TABLE deferred_extraction (
+          session_id TEXT PRIMARY KEY,
+          repository TEXT,
+          status TEXT NOT NULL DEFAULT 'pending',
+          priority INTEGER NOT NULL DEFAULT 0,
+          reason TEXT NOT NULL DEFAULT 'manual',
+          queued_at TEXT NOT NULL,
+          available_at TEXT NOT NULL,
+          started_at TEXT,
+          completed_at TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          last_error TEXT,
+          owner_token TEXT,
+          lease_expires_at TEXT,
+          heartbeat_at TEXT,
+          metadata_json TEXT NOT NULL DEFAULT '{}'
+        );
+      `);
+      raw.close();
+
+      const db = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      db.initialize();
+
+      assert.strictEqual(db.getCurrentVersion(), SCHEMA_VERSION);
+
+      const table = db.db
+        .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='error_telemetry'`)
+        .get();
+      assert.ok(table, "error_telemetry table must exist after v16 → v17 upgrade");
+
+      db.close();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("v16 migration plan includes schema-statements step", () => {
+    const db = new LoreDb({
+      paths: { derivedStorePath: "ignored.db", backupDir: "ignored-backups" },
+    });
+    const labels = db.buildMigrationPlan(16).map((s) => s.label);
+    assert.ok(labels.includes("schema-statements"), "plan for v16 must include schema-statements");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// insertErrorTelemetry — categorical persistence, no raw text
+// ---------------------------------------------------------------------------
+
+describe("LoreDb.insertErrorTelemetry", () => {
+  test("persists categorical fields and returns a non-empty ID", { skip: SKIP_NO_FTS5 }, () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "lore.db");
+    const backupDir = path.join(tempDir, "backups");
+    try {
+      const db = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      db.initialize();
+
+      const record = buildErrorTelemetryRecord(
+        { error: { code: "EACCES", name: "Error" } },
+        "test-session-1",
+      );
+      assert.ok(record, "buildErrorTelemetryRecord should return a record");
+      const id = db.insertErrorTelemetry(record);
+
+      assert.ok(typeof id === "string" && id.length > 0, "insertErrorTelemetry must return an ID");
+
+      const row = db.db.prepare(
+        `SELECT * FROM error_telemetry WHERE id = ?`,
+      ).get(id);
+      assert.ok(row, "row must exist after insert");
+
+      // Categorical fields persisted correctly
+      assert.strictEqual(row.session_id, "test-session-1");
+      assert.strictEqual(row.context_category, "permission");
+      assert.strictEqual(row.recoverability, "unrecoverable");
+      assert.ok(typeof row.fingerprint === "string" && row.fingerprint.length === 16);
+      assert.ok(typeof row.created_at === "string" && row.created_at.length > 0);
+
+      // Raw message/stack must not be in any column
+      const colNames = Object.keys(row);
+      assert.ok(!colNames.includes("message"), "message must not be a column");
+      assert.ok(!colNames.includes("stack"), "stack must not be a column");
+      assert.ok(!colNames.includes("raw_payload"), "raw_payload must not be a column");
+
+      db.close();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("null session ID stored as NULL", { skip: SKIP_NO_FTS5 }, () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "lore.db");
+    const backupDir = path.join(tempDir, "backups");
+    try {
+      const db = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      db.initialize();
+
+      const record = buildErrorTelemetryRecord({}, null);
+      const id = db.insertErrorTelemetry(record);
+      const row = db.db.prepare(`SELECT session_id FROM error_telemetry WHERE id = ?`).get(id);
+      assert.strictEqual(row.session_id, null, "null session_id should be stored as NULL");
+
+      db.close();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pruneErrorTelemetry — retention compliance
+// ---------------------------------------------------------------------------
+
+describe("LoreDb.pruneErrorTelemetry — retention/compaction", () => {
+  test("deletes rows older than maxAgeMs", { skip: SKIP_NO_FTS5 }, () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "lore.db");
+    const backupDir = path.join(tempDir, "backups");
+    try {
+      const db = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      db.initialize();
+
+      // Insert a row with an old timestamp via direct SQL (simulating an old record)
+      db.db.prepare(`
+        INSERT INTO error_telemetry (id, session_id, context_category, recoverability, fingerprint, created_at)
+        VALUES ('old-row', NULL, 'unknown', 'unknown', 'abc1234567890123', '2020-01-01T00:00:00.000Z')
+      `).run();
+      db.db.prepare(`
+        INSERT INTO error_telemetry (id, session_id, context_category, recoverability, fingerprint, created_at)
+        VALUES ('new-row', NULL, 'unknown', 'unknown', 'def1234567890123', datetime('now'))
+      `).run();
+
+      const countBefore = db.db.prepare(`SELECT COUNT(*) AS n FROM error_telemetry`).get().n;
+      assert.strictEqual(countBefore, 2);
+
+      const result = db.pruneErrorTelemetry({ maxRowsGlobal: 500, maxAgeMs: 1 });
+      // maxAgeMs=1 means anything older than 1ms is eligible; both rows survive since 'now'
+      // is after the cutoff. But 'old-row' (2020) must be deleted.
+      assert.ok(result.deletedByAge >= 1, `should have deleted at least 1 old row, got ${result.deletedByAge}`);
+
+      const remaining = db.db.prepare(`SELECT id FROM error_telemetry`).all();
+      const ids = remaining.map((r) => r.id);
+      assert.ok(!ids.includes("old-row"), "old row must be pruned by age");
+
+      db.close();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("trims to maxRowsGlobal", { skip: SKIP_NO_FTS5 }, () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "lore.db");
+    const backupDir = path.join(tempDir, "backups");
+    try {
+      const db = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      db.initialize();
+
+      // Insert 5 rows
+      for (let i = 0; i < 5; i++) {
+        db.db.prepare(`
+          INSERT INTO error_telemetry (id, session_id, context_category, recoverability, fingerprint, created_at)
+          VALUES (?, NULL, 'unknown', 'unknown', 'fp0000000000000' || ?, datetime('now'))
+        `).run(`row-${i}`, String(i));
+      }
+
+      // Prune to 3 rows global limit (no age pruning — maxAgeMs large)
+      const result = db.pruneErrorTelemetry({ maxRowsGlobal: 3, maxAgeMs: 999999999999 });
+      assert.ok(result.deletedByLimit >= 2, "should delete at least 2 rows to reach limit of 3");
+
+      const count = db.db.prepare(`SELECT COUNT(*) AS n FROM error_telemetry`).get().n;
+      assert.strictEqual(count, 3);
+
+      db.close();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("no-op on empty table", { skip: SKIP_NO_FTS5 }, () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "lore.db");
+    const backupDir = path.join(tempDir, "backups");
+    try {
+      const db = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      db.initialize();
+
+      const result = db.pruneErrorTelemetry({});
+      assert.strictEqual(result.deletedByAge, 0);
+      assert.strictEqual(result.deletedByLimit, 0);
+
+      db.close();
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/passive-hooks.test.mjs
+++ b/tests/unit/passive-hooks.test.mjs
@@ -1,0 +1,292 @@
+/**
+ * tests/unit/passive-hooks.test.mjs
+ *
+ * Unit tests for lib/passive-hooks.mjs.
+ *
+ * Covers:
+ *   - buildErrorTelemetryRecord: null/undefined/malformed payloads return null
+ *   - buildErrorTelemetryRecord: valid payloads produce correct category, recoverability, fingerprint
+ *   - No raw message/stack fields ever appear in the returned record
+ *   - deriveToolCategory: correct category from known tool names
+ *   - normalizeToolArgsShape: JSON-string toolArgs safely parsed (structural shape only)
+ *   - buildPostToolUseObservation: null/undefined/malformed return null
+ *   - buildPostToolUseObservation: valid payloads return categorical fields, no raw args/result
+ *   - buildErrorFingerprint: deterministic for same inputs, distinct for different inputs
+ */
+
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ERROR_CONTEXT_CATEGORY,
+  RECOVERABILITY,
+  TOOL_CATEGORY,
+  buildErrorFingerprint,
+  buildErrorTelemetryRecord,
+  buildPostToolUseObservation,
+  deriveToolCategory,
+  normalizeToolArgsShape,
+} from "../../lib/passive-hooks.mjs";
+
+// ---------------------------------------------------------------------------
+// buildErrorTelemetryRecord — null / undefined / malformed
+// ---------------------------------------------------------------------------
+
+describe("buildErrorTelemetryRecord — absent/malformed payloads return null", () => {
+  test("returns null for null payload", () => {
+    assert.strictEqual(buildErrorTelemetryRecord(null), null);
+  });
+
+  test("returns null for undefined payload", () => {
+    assert.strictEqual(buildErrorTelemetryRecord(undefined), null);
+  });
+
+  test("returns null for primitive string payload", () => {
+    assert.strictEqual(buildErrorTelemetryRecord("error string"), null);
+  });
+
+  test("returns null for number payload", () => {
+    assert.strictEqual(buildErrorTelemetryRecord(42), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildErrorTelemetryRecord — valid payloads
+// ---------------------------------------------------------------------------
+
+describe("buildErrorTelemetryRecord — valid payloads produce correct categorical fields", () => {
+  test("empty object produces unknown category and unknown recoverability", () => {
+    const record = buildErrorTelemetryRecord({});
+    assert.ok(record, "should return a record");
+    assert.strictEqual(record.contextCategory, ERROR_CONTEXT_CATEGORY.UNKNOWN);
+    assert.strictEqual(record.recoverability, RECOVERABILITY.UNKNOWN);
+    assert.ok(typeof record.fingerprint === "string" && record.fingerprint.length === 16);
+  });
+
+  test("passes session ID through", () => {
+    const record = buildErrorTelemetryRecord({}, "sess-123");
+    assert.strictEqual(record.sessionId, "sess-123");
+  });
+
+  test("null / empty session ID normalised to null", () => {
+    assert.strictEqual(buildErrorTelemetryRecord({}, null)?.sessionId, null);
+    assert.strictEqual(buildErrorTelemetryRecord({}, "")?.sessionId, null);
+    assert.strictEqual(buildErrorTelemetryRecord({})?.sessionId, null);
+  });
+
+  test("timeout error code → timeout category", () => {
+    const record = buildErrorTelemetryRecord({ error: { code: "ETIMEDOUT", name: "Error" } });
+    assert.strictEqual(record.contextCategory, ERROR_CONTEXT_CATEGORY.TIMEOUT);
+  });
+
+  test("EACCES error code → permission category + unrecoverable", () => {
+    const record = buildErrorTelemetryRecord({ error: { code: "EACCES", name: "Error" } });
+    assert.strictEqual(record.contextCategory, ERROR_CONTEXT_CATEGORY.PERMISSION);
+    assert.strictEqual(record.recoverability, RECOVERABILITY.UNRECOVERABLE);
+  });
+
+  test("network context hint → network category", () => {
+    const record = buildErrorTelemetryRecord({ context: "network fetch failed", error: {} });
+    assert.strictEqual(record.contextCategory, ERROR_CONTEXT_CATEGORY.NETWORK);
+  });
+
+  test("tool context hint → tool_use category", () => {
+    const record = buildErrorTelemetryRecord({ context: "tool execution error", error: {} });
+    assert.strictEqual(record.contextCategory, ERROR_CONTEXT_CATEGORY.TOOL_USE);
+  });
+
+  test("retryable: true → recoverable", () => {
+    const record = buildErrorTelemetryRecord({ retryable: true, error: {} });
+    assert.strictEqual(record.recoverability, RECOVERABILITY.RECOVERABLE);
+  });
+
+  test("retryable: false → unrecoverable", () => {
+    const record = buildErrorTelemetryRecord({ retryable: false, error: {} });
+    assert.strictEqual(record.recoverability, RECOVERABILITY.UNRECOVERABLE);
+  });
+
+  test("SyntaxError name → parse category", () => {
+    const record = buildErrorTelemetryRecord({ error: { name: "SyntaxError" } });
+    assert.strictEqual(record.contextCategory, ERROR_CONTEXT_CATEGORY.PARSE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildErrorTelemetryRecord — no raw message/stack persisted
+// ---------------------------------------------------------------------------
+
+describe("buildErrorTelemetryRecord — never exposes raw message/stack", () => {
+  test("returned record has no message or stack fields", () => {
+    const payload = {
+      error: {
+        message: "Sensitive: /home/user/.ssh/id_rsa not found",
+        stack: "Error: Sensitive\n    at doThing (index.js:42:7)\n    at ...",
+        name: "Error",
+        code: "ENOENT",
+      },
+      context: "file access",
+    };
+    const record = buildErrorTelemetryRecord(payload, "sess-1");
+    assert.ok(record, "should return a record");
+    assert.strictEqual("message" in record, false, "message must not appear in record");
+    assert.strictEqual("stack" in record, false, "stack must not appear in record");
+    assert.strictEqual("error" in record, false, "raw error object must not appear in record");
+    assert.strictEqual("payload" in record, false, "raw payload must not appear in record");
+
+    // Verify the record only has the expected safe keys
+    const allowedKeys = new Set(["sessionId", "contextCategory", "recoverability", "fingerprint"]);
+    for (const key of Object.keys(record)) {
+      assert.ok(allowedKeys.has(key), `unexpected key in record: ${key}`);
+    }
+  });
+
+  test("fingerprint is non-reversible: same category+recoverability+name produces same hash", () => {
+    const fp1 = buildErrorFingerprint("tool_use", "unknown", "TypeError");
+    const fp2 = buildErrorFingerprint("tool_use", "unknown", "TypeError");
+    assert.strictEqual(fp1, fp2, "same inputs must produce same fingerprint");
+    assert.strictEqual(fp1.length, 16, "fingerprint must be 16 hex characters");
+    // Confirm it does not contain recognisable raw text
+    assert.ok(!fp1.includes("TypeError"), "fingerprint must not contain raw error name");
+  });
+
+  test("different categories produce different fingerprints", () => {
+    const fp1 = buildErrorFingerprint("tool_use", "unknown", "");
+    const fp2 = buildErrorFingerprint("network", "unknown", "");
+    assert.notStrictEqual(fp1, fp2, "different categories must produce different fingerprints");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveToolCategory
+// ---------------------------------------------------------------------------
+
+describe("deriveToolCategory", () => {
+  test("bash → bash", () => assert.strictEqual(deriveToolCategory("bash"), TOOL_CATEGORY.BASH));
+  test("run_command → bash", () => assert.strictEqual(deriveToolCategory("run_command"), TOOL_CATEGORY.BASH));
+  test("read_file → file", () => assert.strictEqual(deriveToolCategory("read_file"), TOOL_CATEGORY.FILE));
+  test("view → file", () => assert.strictEqual(deriveToolCategory("view"), TOOL_CATEGORY.FILE));
+  test("grep → search", () => assert.strictEqual(deriveToolCategory("grep"), TOOL_CATEGORY.SEARCH));
+  test("glob → search", () => assert.strictEqual(deriveToolCategory("glob"), TOOL_CATEGORY.SEARCH));
+  test("web_fetch → network", () => assert.strictEqual(deriveToolCategory("web_fetch"), TOOL_CATEGORY.NETWORK));
+  test("lore_recall → memory", () => assert.strictEqual(deriveToolCategory("lore_recall"), TOOL_CATEGORY.MEMORY));
+  test("memory_search → memory", () => assert.strictEqual(deriveToolCategory("memory_search"), TOOL_CATEGORY.MEMORY));
+  test("unknown_tool → other", () => assert.strictEqual(deriveToolCategory("unknown_tool"), TOOL_CATEGORY.OTHER));
+  test("null → other", () => assert.strictEqual(deriveToolCategory(null), TOOL_CATEGORY.OTHER));
+  test("undefined → other", () => assert.strictEqual(deriveToolCategory(undefined), TOOL_CATEGORY.OTHER));
+  test("empty string → other", () => assert.strictEqual(deriveToolCategory(""), TOOL_CATEGORY.OTHER));
+});
+
+// ---------------------------------------------------------------------------
+// normalizeToolArgsShape
+// ---------------------------------------------------------------------------
+
+describe("normalizeToolArgsShape — structural shape only, never raw args", () => {
+  test("null → empty", () => {
+    const shape = normalizeToolArgsShape(null);
+    assert.deepStrictEqual(shape, { parsed: true, isObject: false, isEmpty: true });
+  });
+
+  test("undefined → empty", () => {
+    const shape = normalizeToolArgsShape(undefined);
+    assert.deepStrictEqual(shape, { parsed: true, isObject: false, isEmpty: true });
+  });
+
+  test("plain object → parsed, isObject, not empty", () => {
+    const shape = normalizeToolArgsShape({ command: "ls" });
+    assert.deepStrictEqual(shape, { parsed: true, isObject: true, isEmpty: false });
+  });
+
+  test("empty object → parsed, isObject, empty", () => {
+    const shape = normalizeToolArgsShape({});
+    assert.deepStrictEqual(shape, { parsed: true, isObject: true, isEmpty: true });
+  });
+
+  test("JSON string of object → parsed, isObject, not empty", () => {
+    const shape = normalizeToolArgsShape('{"command":"ls"}');
+    assert.deepStrictEqual(shape, { parsed: true, isObject: true, isEmpty: false });
+  });
+
+  test("JSON string of empty object → parsed, isObject, empty", () => {
+    const shape = normalizeToolArgsShape("{}");
+    assert.deepStrictEqual(shape, { parsed: true, isObject: true, isEmpty: true });
+  });
+
+  test("malformed JSON string → not parsed", () => {
+    const shape = normalizeToolArgsShape("{bad json");
+    assert.deepStrictEqual(shape, { parsed: false, isObject: false, isEmpty: false });
+  });
+
+  test("JSON string of array → parsed, not isObject", () => {
+    const shape = normalizeToolArgsShape('["a","b"]');
+    assert.deepStrictEqual(shape, { parsed: true, isObject: false, isEmpty: false });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildPostToolUseObservation — absent/malformed payloads return null
+// ---------------------------------------------------------------------------
+
+describe("buildPostToolUseObservation — absent/malformed payloads return null", () => {
+  test("null payload → null", () => assert.strictEqual(buildPostToolUseObservation(null), null));
+  test("undefined payload → null", () => assert.strictEqual(buildPostToolUseObservation(undefined), null));
+  test("string payload → null", () => assert.strictEqual(buildPostToolUseObservation("bash"), null));
+  test("empty object (no toolName) → null", () => assert.strictEqual(buildPostToolUseObservation({}), null));
+});
+
+// ---------------------------------------------------------------------------
+// buildPostToolUseObservation — valid payloads
+// ---------------------------------------------------------------------------
+
+describe("buildPostToolUseObservation — valid payloads produce categorical fields, no raw args/result", () => {
+  test("bash tool with success=true", () => {
+    const obs = buildPostToolUseObservation({ toolName: "bash", success: true, toolArgs: { command: "ls" } });
+    assert.ok(obs, "should return an observation");
+    assert.strictEqual(obs.toolName, "bash");
+    assert.strictEqual(obs.toolCategory, TOOL_CATEGORY.BASH);
+    assert.strictEqual(obs.success, true);
+    // argsShape is structural metadata, not raw args content
+    assert.deepStrictEqual(obs.argsShape, { parsed: true, isObject: true, isEmpty: false });
+    assert.strictEqual("toolResult" in obs, false, "toolResult must not appear in observation");
+    assert.strictEqual("args" in obs, false, "raw args must not appear in observation");
+  });
+
+  test("success derived from outcome field", () => {
+    const obs = buildPostToolUseObservation({ toolName: "grep", outcome: "success" });
+    assert.strictEqual(obs.success, true);
+  });
+
+  test("failure when success=false", () => {
+    const obs = buildPostToolUseObservation({ toolName: "grep", success: false });
+    assert.strictEqual(obs.success, false);
+  });
+
+  test("JSON-string toolArgs parsed structurally", () => {
+    const obs = buildPostToolUseObservation({
+      toolName: "bash",
+      success: true,
+      toolArgs: '{"command":"ls -la"}',
+    });
+    assert.ok(obs, "should return an observation");
+    assert.deepStrictEqual(obs.argsShape, { parsed: true, isObject: true, isEmpty: false });
+  });
+
+  test("returned observation has only allowed keys", () => {
+    const obs = buildPostToolUseObservation({ toolName: "read_file", success: true });
+    const allowedKeys = new Set(["toolName", "toolCategory", "success", "argsShape"]);
+    for (const key of Object.keys(obs)) {
+      assert.ok(allowedKeys.has(key), `unexpected key in observation: ${key}`);
+    }
+  });
+
+  test("memory tool category", () => {
+    const obs = buildPostToolUseObservation({ toolName: "lore_retain", success: true });
+    assert.strictEqual(obs.toolCategory, TOOL_CATEGORY.MEMORY);
+  });
+
+  test("toolName truncated to 64 characters", () => {
+    const longName = "a".repeat(100);
+    const obs = buildPostToolUseObservation({ toolName: longName });
+    assert.ok(obs, "should return an observation for long names");
+    assert.strictEqual(obs.toolName.length, 64);
+  });
+});

--- a/tests/unit/pre-tool-use-guardrail.test.mjs
+++ b/tests/unit/pre-tool-use-guardrail.test.mjs
@@ -1,0 +1,357 @@
+/**
+ * tests/unit/pre-tool-use-guardrail.test.mjs
+ *
+ * Unit tests for lib/pre-tool-use-guardrail.mjs.
+ *
+ * Covers:
+ *   - Flag off (default): runPreToolUseGuardrail returns undefined for all inputs
+ *   - Flag on + tool not in allowlist: returns undefined (non-blocking)
+ *   - Flag on + tool in allowlist + no active sub-agent: returns undefined
+ *   - Flag on + tool in allowlist + active sub-agent: returns { additionalContext }
+ *   - Explicit allowlist contents: lore_retain, lore_reflect, memory_save
+ *   - isToolInAllowlist: returns correct boolean for known/unknown/edge cases
+ *   - Timeout: fails open (returns undefined) when check exceeds GUARDRAIL_TIMEOUT_MS
+ *   - Error inside check: fails open
+ *   - Malformed payload (null, string, missing toolName): returns undefined
+ *   - No raw args persisted or surfaced
+ *   - Advisory additionalContext does not contain raw arg content
+ *   - Unknown flag config (null/undefined): fails open
+ */
+
+import { describe, test, mock } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  PRE_TOOL_USE_ALLOWLIST,
+  GUARDRAIL_TIMEOUT_MS,
+  isToolInAllowlist,
+  runPreToolUseGuardrail,
+} from "../../lib/pre-tool-use-guardrail.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal config with preToolUseGuardrail flag set. */
+function cfg(preToolUseGuardrail) {
+  return { rollout: { preToolUseGuardrail } };
+}
+
+/** Build a fake PreToolUseHookInput. */
+function makeInput(toolName, toolArgs = { sensitiveArg: "SHOULD_NOT_APPEAR" }) {
+  return { toolName, toolArgs, sessionId: "sess-test", timestamp: new Date(), workingDirectory: "/work" };
+}
+
+/** Build a fake scope tracker that returns the given agent name. */
+function makeScopeTracker(agentName) {
+  return {
+    getActiveScopeMetadata: () =>
+      agentName
+        ? { activeSubagent: { name: agentName, displayName: `${agentName} Display` } }
+        : null,
+  };
+}
+
+/** Null scope tracker (no active agent). */
+const noAgentTracker = makeScopeTracker(null);
+
+// ---------------------------------------------------------------------------
+// PRE_TOOL_USE_ALLOWLIST — shape and membership
+// ---------------------------------------------------------------------------
+
+describe("PRE_TOOL_USE_ALLOWLIST", () => {
+  test("is a frozen Set", () => {
+    assert.ok(PRE_TOOL_USE_ALLOWLIST instanceof Set, "must be a Set");
+    assert.ok(Object.isFrozen(PRE_TOOL_USE_ALLOWLIST), "must be frozen");
+  });
+
+  test("contains exactly the expected Lore-relevant tools", () => {
+    const expected = ["lore_retain", "lore_reflect", "memory_save"];
+    for (const name of expected) {
+      assert.ok(PRE_TOOL_USE_ALLOWLIST.has(name), `${name} must be in allowlist`);
+    }
+    assert.strictEqual(PRE_TOOL_USE_ALLOWLIST.size, expected.length);
+  });
+
+  test("does not contain bash, grep, or other non-memory tools", () => {
+    assert.strictEqual(PRE_TOOL_USE_ALLOWLIST.has("bash"), false);
+    assert.strictEqual(PRE_TOOL_USE_ALLOWLIST.has("grep"), false);
+    assert.strictEqual(PRE_TOOL_USE_ALLOWLIST.has("lore_recall"), false);
+    assert.strictEqual(PRE_TOOL_USE_ALLOWLIST.has("web_fetch"), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isToolInAllowlist
+// ---------------------------------------------------------------------------
+
+describe("isToolInAllowlist", () => {
+  test("lore_retain → true", () => assert.strictEqual(isToolInAllowlist("lore_retain"), true));
+  test("lore_reflect → true", () => assert.strictEqual(isToolInAllowlist("lore_reflect"), true));
+  test("memory_save → true", () => assert.strictEqual(isToolInAllowlist("memory_save"), true));
+  test("bash → false", () => assert.strictEqual(isToolInAllowlist("bash"), false));
+  test("lore_recall → false", () => assert.strictEqual(isToolInAllowlist("lore_recall"), false));
+  test("null → false", () => assert.strictEqual(isToolInAllowlist(null), false));
+  test("undefined → false", () => assert.strictEqual(isToolInAllowlist(undefined), false));
+  test("empty string → false", () => assert.strictEqual(isToolInAllowlist(""), false));
+  test("42 → false", () => assert.strictEqual(isToolInAllowlist(42), false));
+  test("whitespace-padded name: '  lore_retain  ' → true", () => {
+    assert.strictEqual(isToolInAllowlist("  lore_retain  "), true);
+  });
+  test("name longer than 64 chars → false (truncated beyond allowlist)", () => {
+    const longName = "lore_retain" + "x".repeat(60);
+    assert.strictEqual(isToolInAllowlist(longName), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flag off (default) — returns undefined for everything
+// ---------------------------------------------------------------------------
+
+describe("runPreToolUseGuardrail — flag off", () => {
+  test("returns undefined when rollout flag is false", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: cfg(false), scopeTracker: makeScopeTracker("impl-planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined when config is null", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: null, scopeTracker: makeScopeTracker("impl-planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined when config is undefined", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: undefined },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined when opts is omitted", async () => {
+    const result = await runPreToolUseGuardrail(makeInput("lore_retain"));
+    assert.strictEqual(result, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flag on — tool not in allowlist
+// ---------------------------------------------------------------------------
+
+describe("runPreToolUseGuardrail — flag on, tool not in allowlist", () => {
+  test("returns undefined for bash", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("bash"),
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined for lore_recall", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_recall"),
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined for unknown tool", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("some_unknown_tool"),
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flag on — tool in allowlist, no active sub-agent
+// ---------------------------------------------------------------------------
+
+describe("runPreToolUseGuardrail — flag on, allowlisted tool, no active agent", () => {
+  test("returns undefined when scope tracker returns null", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: cfg(true), scopeTracker: noAgentTracker },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined when scopeTracker is absent", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: cfg(true) },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("returns undefined when scopeTracker.getActiveScopeMetadata is missing", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: cfg(true), scopeTracker: {} },
+    );
+    assert.strictEqual(result, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Flag on — tool in allowlist, active sub-agent
+// ---------------------------------------------------------------------------
+
+describe("runPreToolUseGuardrail — flag on, allowlisted tool, active agent", () => {
+  test("lore_retain: returns additionalContext with agent name", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: cfg(true), scopeTracker: makeScopeTracker("impl-planner") },
+    );
+    assert.ok(result, "must return result");
+    assert.ok(typeof result.additionalContext === "string", "additionalContext must be string");
+    assert.ok(result.additionalContext.includes("impl-planner"), "must include agent name");
+  });
+
+  test("lore_reflect: returns additionalContext", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_reflect"),
+      { config: cfg(true), scopeTracker: makeScopeTracker("reviewer") },
+    );
+    assert.ok(result?.additionalContext, "must return additionalContext");
+    assert.ok(result.additionalContext.includes("reviewer"));
+  });
+
+  test("memory_save: returns additionalContext", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("memory_save"),
+      { config: cfg(true), scopeTracker: makeScopeTracker("coder") },
+    );
+    assert.ok(result?.additionalContext, "must return additionalContext");
+  });
+
+  test("returned additionalContext has exactly { additionalContext } key — no permission override", async () => {
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.ok(result, "must return result");
+    // permissionDecision must be absent — never block
+    assert.strictEqual("permissionDecision" in result, false, "must not include permissionDecision");
+    assert.strictEqual("modifiedArgs" in result, false, "must not include modifiedArgs");
+    assert.strictEqual("suppressOutput" in result, false, "must not include suppressOutput");
+    // Only allowed key in Phase 3 output
+    assert.ok("additionalContext" in result);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No raw args persisted or surfaced
+// ---------------------------------------------------------------------------
+
+describe("runPreToolUseGuardrail — no raw args in output", () => {
+  test("additionalContext does not contain raw toolArgs content", async () => {
+    const sensitiveInput = makeInput("lore_retain", {
+      content: "SENSITIVE_CONTENT_12345",
+      path: "/home/user/.ssh/id_rsa",
+    });
+    const result = await runPreToolUseGuardrail(
+      sensitiveInput,
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    if (result) {
+      const ctx = result.additionalContext ?? "";
+      assert.ok(!ctx.includes("SENSITIVE_CONTENT_12345"), "must not include toolArgs content");
+      assert.ok(!ctx.includes("id_rsa"), "must not include toolArgs path");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Malformed / absent payloads
+// ---------------------------------------------------------------------------
+
+describe("runPreToolUseGuardrail — malformed payloads fail open", () => {
+  test("null input → undefined", async () => {
+    const result = await runPreToolUseGuardrail(
+      null,
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("undefined input → undefined", async () => {
+    const result = await runPreToolUseGuardrail(
+      undefined,
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("string input → undefined", async () => {
+    const result = await runPreToolUseGuardrail(
+      "lore_retain",
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("input with non-string toolName → undefined", async () => {
+    const result = await runPreToolUseGuardrail(
+      { toolName: 42, toolArgs: {} },
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("empty object (no toolName) → undefined", async () => {
+    const result = await runPreToolUseGuardrail(
+      {},
+      { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+    );
+    assert.strictEqual(result, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail open on error in scopeTracker
+// ---------------------------------------------------------------------------
+
+describe("runPreToolUseGuardrail — fail open on error", () => {
+  test("throws in scopeTracker.getActiveScopeMetadata → returns undefined", async () => {
+    const brokenTracker = {
+      getActiveScopeMetadata: () => {
+        throw new Error("tracker exploded");
+      },
+    };
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: cfg(true), scopeTracker: brokenTracker },
+    );
+    assert.strictEqual(result, undefined);
+  });
+
+  test("scopeTracker.getActiveScopeMetadata returns null agent name → returns undefined", async () => {
+    const trackerNoName = {
+      getActiveScopeMetadata: () => ({ activeSubagent: { name: "", displayName: null } }),
+    };
+    const result = await runPreToolUseGuardrail(
+      makeInput("lore_retain"),
+      { config: cfg(true), scopeTracker: trackerNoName },
+    );
+    assert.strictEqual(result, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GUARDRAIL_TIMEOUT_MS constant
+// ---------------------------------------------------------------------------
+
+describe("GUARDRAIL_TIMEOUT_MS", () => {
+  test("is a positive number at most 100 ms", () => {
+    assert.ok(typeof GUARDRAIL_TIMEOUT_MS === "number");
+    assert.ok(GUARDRAIL_TIMEOUT_MS > 0);
+    assert.ok(GUARDRAIL_TIMEOUT_MS <= 100, "timeout must be short (≤100ms)");
+  });
+});

--- a/tests/unit/pre-tool-use-guardrail.test.mjs
+++ b/tests/unit/pre-tool-use-guardrail.test.mjs
@@ -11,6 +11,8 @@
  *   - Explicit allowlist contents: lore_retain, lore_reflect, memory_save
  *   - isToolInAllowlist: returns correct boolean for known/unknown/edge cases
  *   - Timeout: fails open (returns undefined) when check exceeds GUARDRAIL_TIMEOUT_MS
+ *   - Timer cleanup: clearTimeout called with hoisted handle after race settles
+ *   - Timer cleanup on check error: try/finally clears timer even when check throws
  *   - Error inside check: fails open
  *   - Malformed payload (null, string, missing toolName): returns undefined
  *   - No raw args persisted or surfaced
@@ -353,5 +355,69 @@ describe("GUARDRAIL_TIMEOUT_MS", () => {
     assert.ok(typeof GUARDRAIL_TIMEOUT_MS === "number");
     assert.ok(GUARDRAIL_TIMEOUT_MS > 0);
     assert.ok(GUARDRAIL_TIMEOUT_MS <= 100, "timeout must be short (≤100ms)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timer lifecycle — clearTimeout called with hoisted handle, try/finally
+// ---------------------------------------------------------------------------
+
+describe("runPreToolUseGuardrail — timer lifecycle", () => {
+  test("clearTimeout is called with the timer handle after check resolves", async () => {
+    const setTimeoutSpy = mock.method(globalThis, "setTimeout");
+    const clearTimeoutSpy = mock.method(globalThis, "clearTimeout");
+    try {
+      const result = await runPreToolUseGuardrail(
+        makeInput("lore_retain"),
+        { config: cfg(true), scopeTracker: makeScopeTracker("planner") },
+      );
+      assert.ok(result?.additionalContext, "check must resolve with context");
+
+      // Locate the guardrail timer by its registered delay
+      const guardCall = setTimeoutSpy.mock.calls.find(
+        (c) => c.arguments[1] === GUARDRAIL_TIMEOUT_MS,
+      );
+      assert.ok(guardCall, "guardrail must register a timer with GUARDRAIL_TIMEOUT_MS delay");
+      const timerId = guardCall.result;
+
+      // clearTimeout must have been called with that handle (not inside the timer callback)
+      const clearCall = clearTimeoutSpy.mock.calls.find(
+        (c) => c.arguments[0] === timerId,
+      );
+      assert.ok(clearCall, "clearTimeout must be called with the timer handle after race settles");
+    } finally {
+      setTimeoutSpy.mock.restore();
+      clearTimeoutSpy.mock.restore();
+    }
+  });
+
+  test("timer is cleared even when check throws (try/finally guarantees cleanup)", async () => {
+    const setTimeoutSpy = mock.method(globalThis, "setTimeout");
+    const clearTimeoutSpy = mock.method(globalThis, "clearTimeout");
+    try {
+      const throwingTracker = {
+        getActiveScopeMetadata: () => { throw new Error("checker exploded"); },
+      };
+      const result = await runPreToolUseGuardrail(
+        makeInput("lore_retain"),
+        { config: cfg(true), scopeTracker: throwingTracker },
+      );
+      assert.strictEqual(result, undefined, "must fail open on check error");
+
+      // Timer must have been registered and then cleared via finally
+      const guardCall = setTimeoutSpy.mock.calls.find(
+        (c) => c.arguments[1] === GUARDRAIL_TIMEOUT_MS,
+      );
+      assert.ok(guardCall, "timer must have been registered before the check threw");
+      const timerId = guardCall.result;
+
+      const clearCall = clearTimeoutSpy.mock.calls.find(
+        (c) => c.arguments[0] === timerId,
+      );
+      assert.ok(clearCall, "clearTimeout must be called even when the check throws");
+    } finally {
+      setTimeoutSpy.mock.restore();
+      clearTimeoutSpy.mock.restore();
+    }
   });
 });

--- a/tests/unit/rollout-flag-utils.test.mjs
+++ b/tests/unit/rollout-flag-utils.test.mjs
@@ -1,0 +1,113 @@
+/**
+ * tests/unit/rollout-flag-utils.test.mjs
+ *
+ * Unit tests for lib/rollout-flag-utils.mjs.
+ *
+ * Covers:
+ *   - readRolloutBoolean reads the key from config.rollout with the given fallback.
+ *   - createRolloutBooleanReader factory returns a reader that gates on its own key.
+ *   - Parent-reader gating: when a parentReader returns false the child reader
+ *     returns false even when the child flag is explicitly true.
+ *   - Null/undefined config handling: no crash, sensible fallback.
+ *
+ * Run:
+ *   node --test tests/unit/rollout-flag-utils.test.mjs
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  readRolloutBoolean,
+  createRolloutBooleanReader,
+} from "../../lib/rollout-flag-utils.mjs";
+
+describe("readRolloutBoolean", () => {
+  test("returns true when key is true", () => {
+    assert.equal(readRolloutBoolean({ rollout: { myFlag: true } }, "myFlag", false), true);
+  });
+
+  test("returns false when key is false", () => {
+    assert.equal(readRolloutBoolean({ rollout: { myFlag: false } }, "myFlag", true), false);
+  });
+
+  test("returns fallback when key is absent", () => {
+    assert.equal(readRolloutBoolean({ rollout: {} }, "myFlag", true), true);
+    assert.equal(readRolloutBoolean({ rollout: {} }, "myFlag", false), false);
+  });
+
+  test("returns fallback when rollout is absent", () => {
+    assert.equal(readRolloutBoolean({}, "myFlag", true), true);
+  });
+
+  test("returns fallback when config is null", () => {
+    assert.equal(readRolloutBoolean(null, "myFlag", true), true);
+  });
+
+  test("returns fallback when config is undefined", () => {
+    assert.equal(readRolloutBoolean(undefined, "myFlag", false), false);
+  });
+});
+
+describe("createRolloutBooleanReader", () => {
+  test("returns true when flag is true and no parent", () => {
+    const reader = createRolloutBooleanReader("featureA", false);
+    assert.equal(reader({ rollout: { featureA: true } }), true);
+  });
+
+  test("returns false when flag is false and no parent", () => {
+    const reader = createRolloutBooleanReader("featureA", true);
+    assert.equal(reader({ rollout: { featureA: false } }), false);
+  });
+
+  test("returns fallback when key is absent and no parent", () => {
+    const trueReader = createRolloutBooleanReader("featureA", true);
+    const falseReader = createRolloutBooleanReader("featureA", false);
+    assert.equal(trueReader({ rollout: {} }), true);
+    assert.equal(falseReader({ rollout: {} }), false);
+  });
+
+  test("returns false when config is null and no parent", () => {
+    const reader = createRolloutBooleanReader("featureA", false);
+    assert.equal(reader(null), false);
+  });
+
+  describe("parent-reader gating", () => {
+    test("returns child value when parent returns true", () => {
+      const parent = createRolloutBooleanReader("parentFlag", false);
+      const child = createRolloutBooleanReader("childFlag", false, parent);
+      const config = { rollout: { parentFlag: true, childFlag: true } };
+      assert.equal(child(config), true);
+    });
+
+    test("returns false when parent returns false, even if child flag is true", () => {
+      const parent = createRolloutBooleanReader("parentFlag", true);
+      const child = createRolloutBooleanReader("childFlag", false, parent);
+      const config = { rollout: { parentFlag: false, childFlag: true } };
+      assert.equal(child(config), false);
+    });
+
+    test("returns false when both parent and child flags are false", () => {
+      const parent = createRolloutBooleanReader("parentFlag", true);
+      const child = createRolloutBooleanReader("childFlag", true, parent);
+      const config = { rollout: { parentFlag: false, childFlag: false } };
+      assert.equal(child(config), false);
+    });
+
+    test("returns false when parent is false and child is absent (fallback true)", () => {
+      const parent = createRolloutBooleanReader("parentFlag", true);
+      const child = createRolloutBooleanReader("childFlag", true, parent);
+      const config = { rollout: { parentFlag: false } };
+      assert.equal(child(config), false);
+    });
+
+    test("chains three levels: grandparent gates grandchild", () => {
+      const grandparent = createRolloutBooleanReader("gpFlag", false);
+      const parent = createRolloutBooleanReader("pFlag", false, grandparent);
+      const child = createRolloutBooleanReader("cFlag", false, parent);
+      const allOn = { rollout: { gpFlag: true, pFlag: true, cFlag: true } };
+      assert.equal(child(allOn), true);
+      const gpOff = { rollout: { gpFlag: false, pFlag: true, cFlag: true } };
+      assert.equal(child(gpOff), false);
+    });
+  });
+});

--- a/tests/unit/rollout-flags.test.mjs
+++ b/tests/unit/rollout-flags.test.mjs
@@ -37,6 +37,8 @@ import {
   readApprovalSubstrateEnabled,
   readErrorTelemetryEnabled,
   readPostToolUseEnabled,
+  readSubagentScopeTrackingEnabled,
+  readPreToolUseGuardrailEnabled,
 } from "../../lib/rollout-flags.mjs";
 
 // ---------------------------------------------------------------------------
@@ -567,5 +569,77 @@ describe("readPostToolUseEnabled — standalone, default-off", () => {
 
   test('"0" string coerces to false', () => {
     assert.strictEqual(readPostToolUseEnabled(cfg({ postToolUse: "0" })), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readSubagentScopeTrackingEnabled — standalone, default-off (Phase 3)
+// ---------------------------------------------------------------------------
+
+describe("readSubagentScopeTrackingEnabled — standalone, default-off", () => {
+  test("returns true when subagentScopeTracking is true", () => {
+    assert.strictEqual(readSubagentScopeTrackingEnabled(cfg({ subagentScopeTracking: true })), true);
+  });
+
+  test("returns false when subagentScopeTracking is false", () => {
+    assert.strictEqual(readSubagentScopeTrackingEnabled(cfg({ subagentScopeTracking: false })), false);
+  });
+
+  test("falls back to false when subagentScopeTracking is absent (default-off)", () => {
+    assert.strictEqual(readSubagentScopeTrackingEnabled(cfg({})), false);
+  });
+
+  test("is independent of memoryOperations (no parent dependency)", () => {
+    const c = cfg({ memoryOperations: false, subagentScopeTracking: true });
+    assert.strictEqual(readSubagentScopeTrackingEnabled(c), true);
+  });
+
+  test("returns false for null/undefined config (default-off)", () => {
+    assert.strictEqual(readSubagentScopeTrackingEnabled(null), false);
+    assert.strictEqual(readSubagentScopeTrackingEnabled(undefined), false);
+  });
+
+  test('"true" string coerces to true', () => {
+    assert.strictEqual(readSubagentScopeTrackingEnabled(cfg({ subagentScopeTracking: "true" })), true);
+  });
+
+  test('"false" string coerces to false', () => {
+    assert.strictEqual(readSubagentScopeTrackingEnabled(cfg({ subagentScopeTracking: "false" })), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readPreToolUseGuardrailEnabled — standalone, default-off (Phase 3)
+// ---------------------------------------------------------------------------
+
+describe("readPreToolUseGuardrailEnabled — standalone, default-off", () => {
+  test("returns true when preToolUseGuardrail is true", () => {
+    assert.strictEqual(readPreToolUseGuardrailEnabled(cfg({ preToolUseGuardrail: true })), true);
+  });
+
+  test("returns false when preToolUseGuardrail is false", () => {
+    assert.strictEqual(readPreToolUseGuardrailEnabled(cfg({ preToolUseGuardrail: false })), false);
+  });
+
+  test("falls back to false when preToolUseGuardrail is absent (default-off)", () => {
+    assert.strictEqual(readPreToolUseGuardrailEnabled(cfg({})), false);
+  });
+
+  test("is independent of memoryOperations (no parent dependency)", () => {
+    const c = cfg({ memoryOperations: false, preToolUseGuardrail: true });
+    assert.strictEqual(readPreToolUseGuardrailEnabled(c), true);
+  });
+
+  test("returns false for null/undefined config (default-off)", () => {
+    assert.strictEqual(readPreToolUseGuardrailEnabled(null), false);
+    assert.strictEqual(readPreToolUseGuardrailEnabled(undefined), false);
+  });
+
+  test('"1" string coerces to true', () => {
+    assert.strictEqual(readPreToolUseGuardrailEnabled(cfg({ preToolUseGuardrail: "1" })), true);
+  });
+
+  test('"0" string coerces to false', () => {
+    assert.strictEqual(readPreToolUseGuardrailEnabled(cfg({ preToolUseGuardrail: "0" })), false);
   });
 });

--- a/tests/unit/rollout-flags.test.mjs
+++ b/tests/unit/rollout-flags.test.mjs
@@ -35,6 +35,8 @@ import {
   readHybridRetrievalEnabled,
   readReviewGateEnabled,
   readApprovalSubstrateEnabled,
+  readErrorTelemetryEnabled,
+  readPostToolUseEnabled,
 } from "../../lib/rollout-flags.mjs";
 
 // ---------------------------------------------------------------------------
@@ -64,6 +66,8 @@ const ALL_ON = cfg({
   hybridRetrieval: true,
   reviewGate: true,
   approvalSubstrate: true,
+  errorTelemetry: true,
+  postToolUse: true,
 });
 
 /** All flags off */
@@ -84,6 +88,8 @@ const ALL_OFF = cfg({
   hybridRetrieval: false,
   reviewGate: false,
   approvalSubstrate: false,
+  errorTelemetry: false,
+  postToolUse: false,
 });
 
 // ---------------------------------------------------------------------------
@@ -484,5 +490,82 @@ describe("readApprovalSubstrateEnabled — cascading", () => {
   test("returns true for null/undefined config (evolutionLedger defaults true, approvalSubstrate defaults true)", () => {
     assert.strictEqual(readApprovalSubstrateEnabled(null), true);
     assert.strictEqual(readApprovalSubstrateEnabled(undefined), true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readErrorTelemetryEnabled — standalone, default-off
+// ---------------------------------------------------------------------------
+
+describe("readErrorTelemetryEnabled — standalone, default-off", () => {
+  test("returns true when errorTelemetry is true", () => {
+    assert.strictEqual(readErrorTelemetryEnabled(ALL_ON), true);
+  });
+
+  test("returns false when errorTelemetry is false", () => {
+    assert.strictEqual(readErrorTelemetryEnabled(ALL_OFF), false);
+  });
+
+  test("falls back to false when errorTelemetry is absent (default-off)", () => {
+    assert.strictEqual(readErrorTelemetryEnabled(cfg({})), false);
+  });
+
+  test("is independent of memoryOperations (no parent dependency)", () => {
+    const c = cfg({ memoryOperations: false, errorTelemetry: true });
+    assert.strictEqual(readErrorTelemetryEnabled(c), true);
+  });
+
+  test("is independent of evolutionLedger (no parent dependency)", () => {
+    const c = cfg({ evolutionLedger: false, errorTelemetry: true });
+    assert.strictEqual(readErrorTelemetryEnabled(c), true);
+  });
+
+  test("returns false for null/undefined config (default-off)", () => {
+    assert.strictEqual(readErrorTelemetryEnabled(null), false);
+    assert.strictEqual(readErrorTelemetryEnabled(undefined), false);
+  });
+
+  test('"true" string coerces to true', () => {
+    assert.strictEqual(readErrorTelemetryEnabled(cfg({ errorTelemetry: "true" })), true);
+  });
+
+  test('"false" string coerces to false', () => {
+    assert.strictEqual(readErrorTelemetryEnabled(cfg({ errorTelemetry: "false" })), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readPostToolUseEnabled — standalone, default-off
+// ---------------------------------------------------------------------------
+
+describe("readPostToolUseEnabled — standalone, default-off", () => {
+  test("returns true when postToolUse is true", () => {
+    assert.strictEqual(readPostToolUseEnabled(ALL_ON), true);
+  });
+
+  test("returns false when postToolUse is false", () => {
+    assert.strictEqual(readPostToolUseEnabled(ALL_OFF), false);
+  });
+
+  test("falls back to false when postToolUse is absent (default-off)", () => {
+    assert.strictEqual(readPostToolUseEnabled(cfg({})), false);
+  });
+
+  test("is independent of memoryOperations (no parent dependency)", () => {
+    const c = cfg({ memoryOperations: false, postToolUse: true });
+    assert.strictEqual(readPostToolUseEnabled(c), true);
+  });
+
+  test("returns false for null/undefined config (default-off)", () => {
+    assert.strictEqual(readPostToolUseEnabled(null), false);
+    assert.strictEqual(readPostToolUseEnabled(undefined), false);
+  });
+
+  test('"1" string coerces to true', () => {
+    assert.strictEqual(readPostToolUseEnabled(cfg({ postToolUse: "1" })), true);
+  });
+
+  test('"0" string coerces to false', () => {
+    assert.strictEqual(readPostToolUseEnabled(cfg({ postToolUse: "0" })), false);
   });
 });

--- a/tests/unit/subagent-scope-tracker.test.mjs
+++ b/tests/unit/subagent-scope-tracker.test.mjs
@@ -1,0 +1,393 @@
+/**
+ * tests/unit/subagent-scope-tracker.test.mjs
+ *
+ * Unit tests for lib/subagent-scope-tracker.mjs.
+ *
+ * Covers:
+ *   - Initial state: no active sub-agent, isActive() false, getActiveScopeMetadata() null
+ *   - handleSelected: sets active identity from SubagentSelectedEvent shape
+ *   - handleDeselected: clears identity
+ *   - handleStarted: reinforces identity from SubagentStartedEvent shape
+ *   - handleCompleted: clears identity
+ *   - handleFailed: clears identity (never reads error field)
+ *   - reset(): clears all state; safe to call multiple times
+ *   - Lifecycle: selected → started → completed resets; selected → deselected resets
+ *   - Scope metadata: additive, never leaks across reset() calls
+ *   - Malformed/absent/unknown payloads: safe no-ops
+ *   - Unknown event types do not affect state
+ *   - getActiveScopeMetadata() returns correct structure when active
+ *   - Multiple trackers are independent (no shared state)
+ */
+
+import { describe, test, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import { createSubagentScopeTracker } from "../../lib/subagent-scope-tracker.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function selectedEvent(agentName, agentDisplayName = "Display Name", tools = null) {
+  return {
+    type: "subagent.selected",
+    data: { agentName, agentDisplayName, tools },
+  };
+}
+
+function deselectedEvent() {
+  return { type: "subagent.deselected", data: {} };
+}
+
+function startedEvent(agentName, agentDisplayName = "Display Name") {
+  return {
+    type: "subagent.started",
+    data: { agentName, agentDisplayName, agentDescription: "A helper agent", toolCallId: "tc-1" },
+  };
+}
+
+function completedEvent(agentName) {
+  return {
+    type: "subagent.completed",
+    data: { agentName, agentDisplayName: "Display Name", toolCallId: "tc-1" },
+  };
+}
+
+function failedEvent(agentName) {
+  return {
+    type: "subagent.failed",
+    data: {
+      agentName,
+      agentDisplayName: "Display Name",
+      error: "SENSITIVE ERROR MESSAGE MUST NOT BE READ",
+      toolCallId: "tc-1",
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Initial state
+// ---------------------------------------------------------------------------
+
+describe("createSubagentScopeTracker — initial state", () => {
+  test("isActive() returns false before any events", () => {
+    const tracker = createSubagentScopeTracker();
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("getActiveScopeMetadata() returns null before any events", () => {
+    const tracker = createSubagentScopeTracker();
+    assert.strictEqual(tracker.getActiveScopeMetadata(), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleSelected
+// ---------------------------------------------------------------------------
+
+describe("handleSelected", () => {
+  test("sets active identity from valid SubagentSelectedEvent", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("my-agent", "My Agent"));
+    assert.strictEqual(tracker.isActive(), true);
+    const meta = tracker.getActiveScopeMetadata();
+    assert.ok(meta, "should return metadata");
+    assert.strictEqual(meta.activeSubagent.name, "my-agent");
+    assert.strictEqual(meta.activeSubagent.displayName, "My Agent");
+  });
+
+  test("safe no-op when event is null", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(null);
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("safe no-op when event is undefined", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(undefined);
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("safe no-op when event has no data", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected({ type: "subagent.selected" });
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("safe no-op when agentName is missing", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected({ data: { agentDisplayName: "X" } });
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("safe no-op when agentName is not a string", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected({ data: { agentName: 42 } });
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("agentName is truncated to 128 chars", () => {
+    const tracker = createSubagentScopeTracker();
+    const longName = "a".repeat(200);
+    tracker.handleSelected({ data: { agentName: longName } });
+    assert.strictEqual(tracker.getActiveScopeMetadata().activeSubagent.name.length, 128);
+  });
+
+  test("agentDisplayName is truncated to 256 chars", () => {
+    const tracker = createSubagentScopeTracker();
+    const longDisplay = "d".repeat(300);
+    tracker.handleSelected({ data: { agentName: "agent", agentDisplayName: longDisplay } });
+    assert.strictEqual(tracker.getActiveScopeMetadata().activeSubagent.displayName.length, 256);
+  });
+
+  test("displayName defaults to null when absent", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected({ data: { agentName: "agent" } });
+    assert.strictEqual(tracker.getActiveScopeMetadata().activeSubagent.displayName, null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleDeselected
+// ---------------------------------------------------------------------------
+
+describe("handleDeselected", () => {
+  test("clears active identity set by handleSelected", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("agent-1"));
+    assert.strictEqual(tracker.isActive(), true);
+    tracker.handleDeselected(deselectedEvent());
+    assert.strictEqual(tracker.isActive(), false);
+    assert.strictEqual(tracker.getActiveScopeMetadata(), null);
+  });
+
+  test("safe no-op when no agent was active", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleDeselected(deselectedEvent());
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("safe no-op when event is null", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("agent-1"));
+    tracker.handleDeselected(null);
+    assert.strictEqual(tracker.isActive(), false); // deselected still clears
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleStarted
+// ---------------------------------------------------------------------------
+
+describe("handleStarted", () => {
+  test("reinforces identity when agent name matches selected", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("impl-planner", "Impl Planner"));
+    tracker.handleStarted(startedEvent("impl-planner", "Impl Planner v2"));
+    const meta = tracker.getActiveScopeMetadata();
+    assert.strictEqual(meta.activeSubagent.name, "impl-planner");
+    assert.strictEqual(meta.activeSubagent.displayName, "Impl Planner v2");
+  });
+
+  test("sets identity from started when no prior selection", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleStarted(startedEvent("auto-agent", "Auto Agent"));
+    assert.strictEqual(tracker.isActive(), true);
+    assert.strictEqual(tracker.getActiveScopeMetadata().activeSubagent.name, "auto-agent");
+  });
+
+  test("does not override a different already-active agent", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("agent-a", "Agent A"));
+    tracker.handleStarted(startedEvent("agent-b", "Agent B"));
+    // agent-a already active and agent-b name doesn't match
+    const meta = tracker.getActiveScopeMetadata();
+    assert.strictEqual(meta.activeSubagent.name, "agent-a");
+  });
+
+  test("safe no-op when event is null", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleStarted(null);
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("safe no-op when agentName is absent", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleStarted({ data: {} });
+    assert.strictEqual(tracker.isActive(), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleCompleted
+// ---------------------------------------------------------------------------
+
+describe("handleCompleted", () => {
+  test("clears active identity on completion", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("planner"));
+    tracker.handleCompleted(completedEvent("planner"));
+    assert.strictEqual(tracker.isActive(), false);
+    assert.strictEqual(tracker.getActiveScopeMetadata(), null);
+  });
+
+  test("safe no-op when event is null", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("agent"));
+    tracker.handleCompleted(null);
+    assert.strictEqual(tracker.isActive(), false); // still clears
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handleFailed
+// ---------------------------------------------------------------------------
+
+describe("handleFailed", () => {
+  test("clears active identity on failure", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("coder"));
+    tracker.handleFailed(failedEvent("coder"));
+    assert.strictEqual(tracker.isActive(), false);
+    assert.strictEqual(tracker.getActiveScopeMetadata(), null);
+  });
+
+  test("does not read or retain error field from failed event", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("coder"));
+    const sensitiveEvent = failedEvent("coder");
+    sensitiveEvent.data.error = "SENSITIVE: /home/user/.ssh/id_rsa permission denied";
+    tracker.handleFailed(sensitiveEvent);
+    // Confirm the tracker is cleared and error value is not accessible
+    assert.strictEqual(tracker.isActive(), false);
+    assert.strictEqual(tracker.getActiveScopeMetadata(), null);
+  });
+
+  test("safe no-op when event is null", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("agent"));
+    tracker.handleFailed(null);
+    assert.strictEqual(tracker.isActive(), false); // still clears
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reset()
+// ---------------------------------------------------------------------------
+
+describe("reset()", () => {
+  test("clears active state", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("impl-planner"));
+    tracker.reset();
+    assert.strictEqual(tracker.isActive(), false);
+    assert.strictEqual(tracker.getActiveScopeMetadata(), null);
+  });
+
+  test("safe to call multiple times when already cleared", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.reset();
+    tracker.reset();
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("state does not leak after reset followed by new events", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("agent-1", "First"));
+    tracker.reset();
+
+    // Confirm clean state before second lifecycle
+    assert.strictEqual(tracker.getActiveScopeMetadata(), null);
+
+    tracker.handleSelected(selectedEvent("agent-2", "Second"));
+    const meta = tracker.getActiveScopeMetadata();
+    assert.strictEqual(meta.activeSubagent.name, "agent-2");
+    assert.strictEqual(meta.activeSubagent.displayName, "Second");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full lifecycle sequences
+// ---------------------------------------------------------------------------
+
+describe("lifecycle: select → start → complete", () => {
+  test("state is active between selected and completed", () => {
+    const tracker = createSubagentScopeTracker();
+    assert.strictEqual(tracker.isActive(), false);
+
+    tracker.handleSelected(selectedEvent("planner", "Planner"));
+    assert.strictEqual(tracker.isActive(), true);
+
+    tracker.handleStarted(startedEvent("planner", "Planner"));
+    assert.strictEqual(tracker.isActive(), true);
+
+    tracker.handleCompleted(completedEvent("planner"));
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("state is active between selected and failed", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("coder", "Coder"));
+    assert.strictEqual(tracker.isActive(), true);
+    tracker.handleFailed(failedEvent("coder"));
+    assert.strictEqual(tracker.isActive(), false);
+  });
+
+  test("state is active between selected and deselected", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("agent"));
+    assert.strictEqual(tracker.isActive(), true);
+    tracker.handleDeselected(deselectedEvent());
+    assert.strictEqual(tracker.isActive(), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scope metadata shape
+// ---------------------------------------------------------------------------
+
+describe("getActiveScopeMetadata — shape invariants", () => {
+  test("returned object has exactly { activeSubagent: { name, displayName } }", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected(selectedEvent("impl-planner", "Implementation Planner"));
+    const meta = tracker.getActiveScopeMetadata();
+    assert.ok(meta, "must return metadata");
+    assert.deepStrictEqual(Object.keys(meta), ["activeSubagent"]);
+    assert.deepStrictEqual(Object.keys(meta.activeSubagent), ["name", "displayName"]);
+  });
+
+  test("does not contain session IDs, tool args, or private fields", () => {
+    const tracker = createSubagentScopeTracker();
+    tracker.handleSelected({
+      data: {
+        agentName: "agent",
+        agentDisplayName: "Agent",
+        tools: ["bash", "grep"],
+        sessionId: "should-not-appear",
+      },
+    });
+    const meta = tracker.getActiveScopeMetadata();
+    const metaStr = JSON.stringify(meta);
+    assert.ok(!metaStr.includes("should-not-appear"), "sessionId must not appear in metadata");
+    assert.ok(!metaStr.includes("bash"), "tool list must not appear in metadata");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Multiple independent trackers
+// ---------------------------------------------------------------------------
+
+describe("multiple trackers are independent", () => {
+  test("state change in tracker A does not affect tracker B", () => {
+    const trackerA = createSubagentScopeTracker();
+    const trackerB = createSubagentScopeTracker();
+
+    trackerA.handleSelected(selectedEvent("agent-a"));
+    assert.strictEqual(trackerA.isActive(), true);
+    assert.strictEqual(trackerB.isActive(), false);
+
+    trackerA.reset();
+    assert.strictEqual(trackerA.isActive(), false);
+    assert.strictEqual(trackerB.isActive(), false);
+  });
+});


### PR DESCRIPTION
## Summary

This PR delivers the reliability-first Lore hook roadmap: durable background-work recovery, passive hook telemetry, scoped opt-in guardrails, and externally scheduled maintenance.

## Motivation / related issue

Lore previously relied on a small set of session hooks while background extraction, shutdown, and maintenance recovery had limited durability and visibility. This change expands the supported lifecycle surface without changing default behavior or persisting sensitive payloads.

## Changes

- Establish the verified seven-hook SDK contract and registration seam.
- Add deferred-extraction leases, heartbeats, stale-lease recovery, idempotent completion, tracked shutdown draining, and visible trace failures.
- Add default-off `onErrorOccurred` and `onPostToolUse` categorical telemetry with privacy-minimized storage.
- Add default-off sub-agent scope tracking and a narrow fail-open `onPreToolUse` guardrail with timeout cleanup.
- Document the intentionally deferred `onPreMcpToolCall` use case and unsupported speculative hook names.
- Formalize `scripts/run-maintenance.mjs` for external scheduling, including fail-closed task validation and launchd/cron guidance.

## Testing

```
npm test                 # 726 passing
npm run test:smoke       # 33 passing
npm run validate-schema  # Schema and config defaults are in parity
npm run lint             # Passes; one pre-existing warning
git diff --check         # Clean
```

Fallow was not available in the local environment and was not installed.

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run validate-schema` passes
- [x] Docs updated where behavior changed
