### PR TITLE
fix: prevent durable trace ID collisions

### DIFF
--- a/lib/trace-recorder.mjs
+++ b/lib/trace-recorder.mjs
@@ -1,3 +1,5 @@
+import crypto from "node:crypto";
+
 import { clampInteger } from "./numeric-utils.mjs";
 
 function ensureArray(value) {
@@ -333,7 +335,7 @@ function buildTraceRecordIdentity(event, trace, options, index) {
   const eventObject = asObject(event);
   const traceObject = asObject(trace);
   return {
-    id: `trace-${index}`,
+    id: options.idPrefix ? `trace-${options.idPrefix}-${index}` : `trace-${index}`,
     recordedAt: new Date().toISOString(),
     hook: firstNonNullish([eventObject.hook], "unknown"),
     mode: firstNonNullish([traceObject.mode], null),
@@ -576,7 +578,10 @@ function removeExpiredRecords(records, cutoff) {
 }
 
 export function createTraceRecorder(config) {
-  const options = normalizeRecorderOptions(config);
+  const options = {
+    ...normalizeRecorderOptions(config),
+    idPrefix: crypto.randomUUID(),
+  };
   const state = {
     records: [],
     totalRecorded: 0,

--- a/tests/unit/trace-recorder.test.mjs
+++ b/tests/unit/trace-recorder.test.mjs
@@ -38,6 +38,19 @@ function buildRecorder() {
 }
 
 describe("createTraceRecorder", () => {
+  test("uses restart-safe IDs across recorder instances", () => {
+    const first = buildRecorder().record({
+      hook: "onSessionStart",
+      trace: {},
+    });
+    const second = buildRecorder().record({
+      hook: "onSessionStart",
+      trace: {},
+    });
+
+    assert.notEqual(first.id, second.id);
+  });
+
   test("records fallback router decisions and compact lookup payloads", () => {
     const recorder = buildRecorder();
     const result = recorder.record({


### PR DESCRIPTION
## Summary

- namespace retrieval trace IDs per recorder instance so extension restarts cannot reuse persisted primary keys
- retain the local sequence suffix for readable ordering
- add regression coverage proving fresh recorder instances emit distinct IDs

## Root cause

`retrieval_trace_sample` persists trace IDs as a primary key, but each new trace recorder restarted its counter at `trace-1`. Once durable samples survived an extension restart, the next selected sample could collide with an existing row.

## Validation

- `node --test tests/unit/trace-recorder.test.mjs`
- `npm test`
- `npm run lint`
- `node --check lib/trace-recorder.mjs`
- `git diff --check`
