### PR TITLE
fix: make Lore tests path-independent

### DIFF
--- a/lib/lore-doctor.mjs
+++ b/lib/lore-doctor.mjs
@@ -9,9 +9,9 @@
 
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 import { checkProposalSections } from "./review-gate.mjs";
+import { resolveCopilotRoot } from "./repository-utils.mjs";
 
 // ---------------------------------------------------------------------------
 // Incident kind constants
@@ -51,8 +51,6 @@ function clampLimit(value, fallback, { min = 1, max = 50 } = {}) {
 // Proposal-doc structural review helpers (observe-only, no mutation)
 // ---------------------------------------------------------------------------
 
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
-
 function readProposalSignals(db, { limit = 5 } = {}) {
   const rows = db.listImprovementArtifacts({ status: "active", hasProposal: true, limit });
   return rows.map((row) => ({
@@ -63,13 +61,13 @@ function readProposalSignals(db, { limit = 5 } = {}) {
   }));
 }
 
-function classifyProposalReview(proposals) {
+function classifyProposalReview(proposals, repoRoot) {
   const incidents = [];
   for (const p of proposals) {
     if (!p.proposalPath) continue;
     let text;
     try {
-      text = readFileSync(path.join(REPO_ROOT, p.proposalPath), "utf8");
+      text = readFileSync(path.join(repoRoot, p.proposalPath), "utf8");
     } catch (err) {
       incidents.push({
         kind: INCIDENT_KINDS.PROPOSAL_REVIEW_FINDING,
@@ -506,6 +504,7 @@ export function runDoctorObservation({
   const statsSignals = readStatsSignals(runtime.db);
   const latencySignals = readLatencySignals(runtime.metrics ?? null);
   const proposalSignals = readProposalSignals(runtime.db);
+  const repoRoot = resolveCopilotRoot(runtime.config, import.meta.url);
   const unansweredStallSignals = readUnansweredStallSignals(runtime.db, {
     repository: repository ?? undefined,
   });
@@ -516,7 +515,7 @@ export function runDoctorObservation({
     ...classifyTrajectorySignals(trajectorySignals),
     ...classifyLatency(latencySignals),
     ...classifyBacklogStats(statsSignals),
-    ...classifyProposalReview(proposalSignals),
+    ...classifyProposalReview(proposalSignals, repoRoot),
     ...classifyUnansweredWorkStall(unansweredStallSignals),
   ];
 

--- a/lib/proposal-generator.mjs
+++ b/lib/proposal-generator.mjs
@@ -1,12 +1,12 @@
 import crypto from "node:crypto";
 import path from "node:path";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
 
 import {
   readGeneratedArtifactIntegrityEnabled,
   readProposalGenerationEnabled,
 } from "./rollout-flags.mjs";
+import { resolveCopilotRoot } from "./repository-utils.mjs";
 
 const REVIEW_STATES = Object.freeze(["draft", "approved", "rejected", "superseded"]);
 
@@ -37,16 +37,16 @@ function coerceReviewState(value) {
   return REVIEW_STATES.includes(normalized) ? normalized : "draft";
 }
 
-function repoRootFromModule() {
-  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+function repoRootFromConfig(config) {
+  return resolveCopilotRoot(config, import.meta.url);
 }
 
-function proposalDocsRoot() {
-  return path.join(repoRootFromModule(), "extensions", "lore", "docs", "proposals");
+function proposalDocsRoot(config) {
+  return path.join(repoRootFromConfig(config), "extensions", "lore", "docs", "proposals");
 }
 
-function relativePathFromRepo(absolutePath) {
-  return path.relative(repoRootFromModule(), absolutePath).replaceAll(path.sep, "/");
+function relativePathFromRepo(config, absolutePath) {
+  return path.relative(repoRootFromConfig(config), absolutePath).replaceAll(path.sep, "/");
 }
 
 function inferProposalType(artifact) {
@@ -186,11 +186,11 @@ async function ensureProposalDirectory(dirPath) {
   await mkdir(dirPath, { recursive: true });
 }
 
-function buildProposalAbsolutePath({ artifact, proposalType }) {
+function buildProposalAbsolutePath({ artifact, proposalType, config }) {
   const directory = PROPOSAL_TYPE_DIRECTORIES[proposalType] ?? PROPOSAL_TYPE_DIRECTORIES.extension_heuristic;
   const datePrefix = String(artifact.updated_at || artifact.created_at || nowIso()).slice(0, 10);
   const filename = `${datePrefix}-${slugify(artifact.title)}-${artifact.id.slice(0, 8)}.md`;
-  return path.join(proposalDocsRoot(), directory, filename);
+  return path.join(proposalDocsRoot(config), directory, filename);
 }
 
 function collectCandidates({ runtime, ids = [], limit = 10, updatedBefore = null }) {
@@ -212,10 +212,10 @@ async function writeProposalIndex(runtime) {
     hasProposal: true,
     limit: 200,
   });
-  const indexPath = path.join(proposalDocsRoot(), "PROPOSAL_INDEX.md");
+  const indexPath = path.join(proposalDocsRoot(runtime.config), "PROPOSAL_INDEX.md");
   await ensureProposalDirectory(path.dirname(indexPath));
   await writeFile(indexPath, renderProposalIndex(rows), "utf8");
-  return relativePathFromRepo(indexPath);
+  return relativePathFromRepo(runtime.config, indexPath);
 }
 
 export async function generateProposalArtifacts({
@@ -252,8 +252,8 @@ export async function generateProposalArtifacts({
     }
 
     const proposalType = inferProposalType(artifact);
-    const absolutePath = buildProposalAbsolutePath({ artifact, proposalType });
-    const proposalPath = relativePathFromRepo(absolutePath);
+    const absolutePath = buildProposalAbsolutePath({ artifact, proposalType, config: runtime.config });
+    const proposalPath = relativePathFromRepo(runtime.config, absolutePath);
     const reviewState = coerceReviewState(artifact.review_state);
     const proposalId = artifact.id;
     const content = renderProposalContent({
@@ -355,12 +355,12 @@ export async function verifyProposalArtifacts({
   };
 }
 
-function buildProposalVerificationState(row) {
+function buildProposalVerificationState(row, config) {
   const proposalType = row.proposal_type ?? inferProposalType(row);
   const absolutePath = row.proposal_path
-    ? path.join(repoRootFromModule(), row.proposal_path)
-    : buildProposalAbsolutePath({ artifact: row, proposalType });
-  const proposalPath = row.proposal_path ?? relativePathFromRepo(absolutePath);
+    ? path.join(repoRootFromConfig(config), row.proposal_path)
+    : buildProposalAbsolutePath({ artifact: row, proposalType, config });
+  const proposalPath = row.proposal_path ?? relativePathFromRepo(config, absolutePath);
   const reviewState = coerceReviewState(row.review_state);
   const generatedAt = row.review_requested_at ?? row.updated_at ?? row.created_at ?? nowIso();
   const content = renderProposalContent({
@@ -411,7 +411,7 @@ async function repairProposalArtifact({ runtime, row, state, type, dryRun, repai
 }
 
 async function verifyProposalArtifactRow({ row, runtime, repair, dryRun }) {
-  const state = buildProposalVerificationState(row);
+  const state = buildProposalVerificationState(row, runtime.config);
   try {
     const actualHash = sha256(await readFile(state.absolutePath, "utf8"));
     if (row.proposal_hash === state.expectedHash && actualHash === state.expectedHash) {
@@ -448,11 +448,11 @@ async function verifyProposalArtifactRow({ row, runtime, repair, dryRun }) {
   }
 }
 
-function buildProposalIndexState(rows) {
-  const indexPath = path.join(proposalDocsRoot(), "PROPOSAL_INDEX.md");
+function buildProposalIndexState(rows, config) {
+  const indexPath = path.join(proposalDocsRoot(config), "PROPOSAL_INDEX.md");
   return {
     indexPath,
-    proposalPath: relativePathFromRepo(indexPath),
+    proposalPath: relativePathFromRepo(config, indexPath),
     expectedContent: renderProposalIndex(rows),
   };
 }
@@ -473,7 +473,7 @@ async function verifyProposalIndexArtifacts({ runtime, rows, limit, repair, dryR
       limit,
     })
     : rows;
-  const state = buildProposalIndexState(indexRows);
+  const state = buildProposalIndexState(indexRows, runtime.config);
   const issues = [];
   const repaired = [];
 

--- a/lib/repository-utils.mjs
+++ b/lib/repository-utils.mjs
@@ -1,5 +1,16 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
 export function normalizeRepository(repository) {
   return typeof repository === "string" && repository.trim().length > 0
     ? repository.trim()
     : null;
+}
+
+export function resolveCopilotRoot(config, moduleUrl) {
+  const configuredRoot = config?.paths?.copilotHome;
+  if (typeof configuredRoot === "string" && configuredRoot.trim().length > 0) {
+    return path.resolve(configuredRoot);
+  }
+  return path.resolve(path.dirname(fileURLToPath(moduleUrl)), "..", "..", "..");
 }

--- a/tests/unit/extraction-hydration-hotspots.test.mjs
+++ b/tests/unit/extraction-hydration-hotspots.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { describe, test } from "node:test";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -26,15 +27,7 @@ async function loadRuleExtractorHotspots() {
 }
 
 function createWorkspaceDir(name) {
-  const root = path.join(
-    path.dirname(fileURLToPath(import.meta.url)),
-    "..",
-    ".scratch",
-    "extraction-hydration-hotspots",
-  );
-  mkdirSync(root, { recursive: true });
-  const workspacePath = path.join(root, `${name}-${process.pid}-${Date.now()}`);
-  mkdirSync(workspacePath, { recursive: true });
+  const workspacePath = mkdtempSync(path.join(os.tmpdir(), `lore-${name}-`));
   return {
     workspacePath,
     cleanup() {

--- a/tests/unit/lore-doctor.test.mjs
+++ b/tests/unit/lore-doctor.test.mjs
@@ -1,12 +1,18 @@
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, test } from "node:test";
 
 import { runDoctorObservation } from "../../lib/lore-doctor.mjs";
 
 function createRuntime({
   maintenanceTaskStates = [],
+  proposalRows = [],
+  config = {},
 } = {}) {
   return {
+    config,
     db: {
       listMaintenanceTaskStates() {
         return maintenanceTaskStates;
@@ -18,7 +24,7 @@ function createRuntime({
         return {};
       },
       listImprovementArtifacts() {
-        return [];
+        return proposalRows;
       },
       db: {
         prepare() {
@@ -64,5 +70,34 @@ describe("runDoctorObservation", () => {
     assert.equal(report.incidents[0]?.kind, "replay_corpus_attention");
     assert.equal(report.incidents[0]?.context.rankingTargetMissing, 2);
     assert.equal(report.incidents[0]?.context.rankingTargetPartial, 1);
+  });
+
+  test("reads proposal documents from the configured Copilot root", async () => {
+    const copilotRoot = await mkdtemp(path.join(os.tmpdir(), "lore-doctor-"));
+    const proposalPath = "extensions/lore/docs/proposals/fixture.md";
+    const absoluteProposalPath = path.join(copilotRoot, proposalPath);
+    await mkdir(path.dirname(absoluteProposalPath), { recursive: true });
+    await writeFile(absoluteProposalPath, "# Fixture proposal\n", "utf8");
+
+    try {
+      const report = runDoctorObservation({
+        runtime: createRuntime({
+          config: { paths: { copilotHome: copilotRoot } },
+          proposalRows: [{
+            id: "proposal-fixture",
+            title: "Fixture proposal",
+            proposal_path: proposalPath,
+            review_state: "draft",
+          }],
+        }),
+        dryRun: true,
+      });
+
+      assert.equal(report.infoCount, 1);
+      assert.equal(report.incidents[0]?.context.unreadable, undefined);
+      assert.ok(report.incidents[0]?.context.missingSections.length > 0);
+    } finally {
+      await rm(copilotRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/proposal-generator.test.mjs
+++ b/tests/unit/proposal-generator.test.mjs
@@ -1,7 +1,6 @@
 import assert from "node:assert/strict";
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, test } from "node:test";
 
 import {
@@ -14,11 +13,6 @@ const SKIP_NO_FTS5 = !FTS5_AVAILABLE
   ? "FTS5 not compiled into this Node.js SQLite build (Copilot CLI runtime has it; check your local Node install)"
   : false;
 
-const TEST_DIR = path.dirname(fileURLToPath(import.meta.url));
-const COPILOT_ROOT = path.resolve(TEST_DIR, "../../../..");
-const PROPOSALS_ROOT = path.join(COPILOT_ROOT, "extensions", "lore", "docs", "proposals");
-const INDEX_PATH = path.join(PROPOSALS_ROOT, "PROPOSAL_INDEX.md");
-
 function buildRuntime(db, config) {
   return {
     db,
@@ -26,8 +20,12 @@ function buildRuntime(db, config) {
   };
 }
 
-function toRepoRelative(absolutePath) {
-  return path.relative(COPILOT_ROOT, absolutePath).replaceAll(path.sep, "/");
+function proposalDocsRoot(config) {
+  return path.join(config.paths.copilotHome, "extensions", "lore", "docs", "proposals");
+}
+
+function toRepoRelative(config, absolutePath) {
+  return path.relative(config.paths.copilotHome, absolutePath).replaceAll(path.sep, "/");
 }
 
 async function pathExists(targetPath) {
@@ -66,12 +64,14 @@ describe("proposal generator integrity checks", () => {
         },
       },
     });
-    const fixturePath = path.join(PROPOSALS_ROOT, "test-fixtures", "missing-proposal.md");
-    const fixtureRelativePath = toRepoRelative(fixturePath);
-    const originalIndex = await readIfExists(INDEX_PATH);
+    const proposalsRoot = proposalDocsRoot(config);
+    const indexPath = path.join(proposalsRoot, "PROPOSAL_INDEX.md");
+    const fixturePath = path.join(proposalsRoot, "test-fixtures", "missing-proposal.md");
+    const fixtureRelativePath = toRepoRelative(config, fixturePath);
+    const originalIndex = await readIfExists(indexPath);
     try {
       await rm(fixturePath, { force: true });
-      await rm(INDEX_PATH, { force: true });
+      await rm(indexPath, { force: true });
 
       const artifactId = db.upsertImprovementArtifact({
         sourceCaseId: "proposal-missing-file",
@@ -98,7 +98,7 @@ describe("proposal generator integrity checks", () => {
       assert.equal(result.issues.filter((issue) => issue.type === "missing_file").length, 1);
       assert.equal(result.repairedCount, 0);
     } finally {
-      await restoreFile(INDEX_PATH, originalIndex);
+      await restoreFile(indexPath, originalIndex);
       await rm(fixturePath, { force: true });
       await rm(path.dirname(fixturePath), { recursive: true, force: true });
       cleanup();
@@ -116,7 +116,8 @@ describe("proposal generator integrity checks", () => {
         },
       },
     });
-    const originalIndex = await readIfExists(INDEX_PATH);
+    const indexPath = path.join(proposalDocsRoot(config), "PROPOSAL_INDEX.md");
+    const originalIndex = await readIfExists(indexPath);
     let generatedPath = null;
     try {
       const runtime = buildRuntime(db, config);
@@ -135,7 +136,7 @@ describe("proposal generator integrity checks", () => {
       assert.equal(generated.generatedCount, 1);
 
       const artifact = db.getImprovementArtifact(artifactId);
-      generatedPath = path.join(COPILOT_ROOT, artifact.proposal_path);
+      generatedPath = path.join(config.paths.copilotHome, artifact.proposal_path);
       db.db.prepare(`
         UPDATE improvement_backlog
         SET proposal_hash = ?
@@ -152,7 +153,7 @@ describe("proposal generator integrity checks", () => {
       assert.equal(result.repairedCount, 0);
       assert.equal(await pathExists(generatedPath), true);
     } finally {
-      await restoreFile(INDEX_PATH, originalIndex);
+      await restoreFile(indexPath, originalIndex);
       if (generatedPath) {
         await rm(generatedPath, { force: true });
         await rm(path.dirname(generatedPath), { recursive: true, force: true });
@@ -171,12 +172,14 @@ describe("proposal generator integrity checks", () => {
         },
       },
     });
-    const fixturePath = path.join(PROPOSALS_ROOT, "test-fixtures", "dry-run-proposal.md");
-    const fixtureRelativePath = toRepoRelative(fixturePath);
-    const originalIndex = await readIfExists(INDEX_PATH);
+    const proposalsRoot = proposalDocsRoot(config);
+    const indexPath = path.join(proposalsRoot, "PROPOSAL_INDEX.md");
+    const fixturePath = path.join(proposalsRoot, "test-fixtures", "dry-run-proposal.md");
+    const fixtureRelativePath = toRepoRelative(config, fixturePath);
+    const originalIndex = await readIfExists(indexPath);
     try {
       await rm(fixturePath, { force: true });
-      await rm(INDEX_PATH, { force: true });
+      await rm(indexPath, { force: true });
 
       const artifactId = db.upsertImprovementArtifact({
         sourceCaseId: "proposal-dry-run",
@@ -201,9 +204,9 @@ describe("proposal generator integrity checks", () => {
       assert.equal(result.repairedCount, 0);
       assert.deepStrictEqual(result.repaired, []);
       assert.equal(await pathExists(fixturePath), false);
-      assert.equal(await pathExists(INDEX_PATH), false);
+      assert.equal(await pathExists(indexPath), false);
     } finally {
-      await restoreFile(INDEX_PATH, originalIndex);
+      await restoreFile(indexPath, originalIndex);
       await rm(fixturePath, { force: true });
       await rm(path.dirname(fixturePath), { recursive: true, force: true });
       cleanup();


### PR DESCRIPTION
Uses configured paths.copilotHome for proposal artifacts and Lore Doctor reads, and moves scratch test data to os.tmpdir(). The suite now runs from arbitrary checkout paths with read-only mounts. Validation: 744/744 tests in a fresh local microsandbox VM; targeted unit tests pass; lint passes with existing warnings.