### PR TITLE
fix: direct hook installer users to universal setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,7 +505,7 @@ Useful commands:
 | `npm run validate-schema` | Validate config/schema parity |
 | `npm run lint` | Lint runtime, adapters, browser, and scripts |
 | `npm run dev-install` | Copy a dev checkout into `~/.copilot/extensions/lore` |
-| `npm run install-hooks -- <client> [--global] [--write]` | Preview or install native Codex, Claude Code, or Antigravity lifecycle hooks |
+| `npm run install-hooks -- <client> [--global] [--write]` | Advanced native-hook helper for Codex, Claude Code, or Antigravity; use `npm run setup` for all five clients |
 | `npm run migrate-home -- --from <old> --to <new>` | Explicitly copy a Lore home without overwriting the destination |
 | `npm run maintenance` | Run the maintenance script |
 | `npm run browser` | Start the local browser dashboard |

--- a/docs/cli-integrations.md
+++ b/docs/cli-integrations.md
@@ -19,7 +19,7 @@ Keep this checkout in a stable location. Enable Lore using the README's
 `LORE_HOME`, `LORE_CONFIG`, `LORE_ENABLED`, the XDG default home, and the existing
 legacy-home fallback. They never migrate user data automatically.
 
-The installer defaults to a dry run. Add `--write` to apply its configuration:
+The `install-hooks` helper covers Codex, Claude Code, and Antigravity only. Use `npm run setup` for automatic detection and installation across all five clients. The helper defaults to a dry run; add `--write` to apply its configuration:
 
 ```sh
 node scripts/install-hooks.mjs codex --project /absolute/project --write

--- a/scripts/install-hooks.mjs
+++ b/scripts/install-hooks.mjs
@@ -6,8 +6,24 @@ import { randomUUID } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { buildCliHookConfig, mergeCliHookConfig } from "../lib/clients/cli-hook-config.mjs";
 
-try {
+const help = `Install Lore for Copilot, Pi, Codex, Claude Code, or Antigravity:
+  npm run setup
+  npm run setup -- --clients all --dry-run
+
+This advanced helper only manages native lifecycle hooks:
+  npm run install-hooks -- <codex|claude|antigravity> [--project PATH | --global] [--write] [--remove]
+It previews by default; --write applies changes. Antigravity requires --global.
+Use npm run setup for automatic client detection and Copilot/Pi installation.`;
+
+async function main() {
   const [client, ...args] = process.argv.slice(2);
+  if (!client || client === "--help" || client === "-h") {
+    console.log(help);
+    return;
+  }
+  if (!["codex", "claude", "antigravity"].includes(client)) {
+    throw new Error(`This command only manages native hooks.\n\n${help}`);
+  }
   const options = { write: false, remove: false, global: false, project: process.cwd() };
   for (let i = 0; i < args.length; i += 1) {
     if (args[i] === "--write") options.write = true;
@@ -58,6 +74,10 @@ try {
     } finally { await unlink(temporary).catch((error) => { if (error.code !== "ENOENT") throw error; }); }
     console.log(`${options.remove ? "Removed" : "Installed"} Lore hooks: ${target}`);
   }
+}
+
+try {
+  await main();
 } catch (error) {
   console.error(`lore install-hooks: ${error.message}`);
   process.exitCode = 1;

--- a/tests/smoke/cli-hooks.test.mjs
+++ b/tests/smoke/cli-hooks.test.mjs
@@ -116,3 +116,22 @@ test("installer dry runs, preserves other hooks/settings, is idempotent, and rem
     }
   } finally { rmSync(project, { recursive: true, force: true }); }
 });
+
+test("hook installer directs universal setup requests to the five-client installer without writes", () => {
+  const home = mkdtempSync(path.join(os.tmpdir(), "lore-installer-help-"));
+  try {
+    for (const args of [[], ["--help"], ["-h"], ["copilot"], ["pi"], ["all"], ["--clients", "all"]]) {
+      const result = spawnSync(process.execPath, [installer, ...args], {
+        cwd: home, env: { ...process.env, HOME: home }, encoding: "utf8", timeout: 5000,
+      });
+      assert.equal(result.status, args.length === 0 || ["--help", "-h"].includes(args[0]) ? 0 : 1);
+      const output = result.stdout + result.stderr;
+      assert.match(output, /npm run setup/);
+      assert.match(output, /--clients all --dry-run/);
+      assert.match(output, /Copilot.*Pi.*Codex.*Claude.*Antigravity/);
+      assert.equal(existsSync(path.join(home, ".codex")), false);
+      assert.equal(existsSync(path.join(home, ".claude")), false);
+      assert.equal(existsSync(path.join(home, ".gemini")), false);
+    }
+  } finally { rmSync(home, { recursive: true, force: true }); }
+});

--- a/website/src/content/docs/cli-integrations.md
+++ b/website/src/content/docs/cli-integrations.md
@@ -50,7 +50,7 @@ All clients use the same Lore database by default. See [Configuration](/guides/c
 
 ## 3. Install your client's hooks
 
-Run these commands from the Lore checkout. The installer previews changes by default:
+For automatic detection and installation across all five clients, run `npm run setup` from the Lore checkout. The `install-hooks` commands below are an advanced native-hook helper for Codex, Claude Code, and Antigravity only; they preview changes by default:
 
 ```sh
 node scripts/install-hooks.mjs codex --project /absolute/project


### PR DESCRIPTION
## Summary

Running `npm run install-hooks` without a client previously failed with “Client must be codex, claude, or antigravity”, obscuring the universal installer. Show `npm run setup` guidance for missing arguments/help and unsupported client choices, and distinguish the advanced native-hook helper from five-client setup in the documentation.

## Motivation / related issue

Follow-up to #94: universal setup exists, but the older command's error made it appear unavailable.

## Changes

- No arguments, `--help`, and `-h` display usage without writes.
- Unsupported client choices direct users to automatic detection and the all-client dry run.
- Existing native-hook installation/removal options keep their behavior.
- Align README, reference documentation, and website guidance.

## Testing

- 894 core tests passed, none failed/skipped.
- Isolated-home subprocess regression covers no arguments, help, Copilot, Pi, all, and setup-style flags without writing client settings.
- Lint and whitespace checks passed.
- Website diagnostics: 0 errors/warnings/hints; 11 tests; build and 515 local links/assets passed.

```text
✓ Schema and config defaults are in parity.
```

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run validate-schema` passes
- [x] Docs updated if behaviour changed
