### PR TITLE
feat: add durable evidence and conservative extraction

### DIFF
--- a/lib/db/db-memory-lifecycle.mjs
+++ b/lib/db/db-memory-lifecycle.mjs
@@ -213,6 +213,9 @@ export function listSemanticEvidence(owner, memoryId) {
 
 export function reconcileGeneratedMemories(owner, { sessionId, repository, memories = [], retiredEvidenceKeys = [] }) {
   owner.ensureOpen();
+  if (!owner.pendingSemanticDurability) {
+    return owner.withSemanticMemoryTransaction(() => reconcileGeneratedMemories(owner, { sessionId, repository, memories, retiredEvidenceKeys }));
+  }
   const timestamp = new Date().toISOString();
   const linked = [];
   for (const memory of Array.isArray(memories) ? memories : []) {
@@ -223,12 +226,24 @@ export function reconcileGeneratedMemories(owner, { sessionId, repository, memor
       continue;
     }
     const existingEvidence = owner.db.prepare(`
-      SELECT sm.id FROM memory_evidence me
+      SELECT sm.* FROM memory_evidence me
       JOIN semantic_memory sm ON sm.id = me.memory_id
       WHERE me.evidence_key = ? AND me.retired_at IS NULL AND sm.superseded_by IS NULL
       ORDER BY sm.updated_at DESC LIMIT 1
     `).get(evidence.key);
-    let memoryId = existingEvidence?.id ?? null;
+    const sameProposition = existingEvidence?.type === memory.type && existingEvidence?.content === memory.content;
+    const explicitExisting = existingEvidence && isExplicitLifecycleWrite(existingEvidence, parseJson(existingEvidence.metadata_json) ?? {});
+    let memoryId = sameProposition ? existingEvidence.id : null;
+    if (existingEvidence && !sameProposition) {
+      owner.db.prepare("UPDATE memory_evidence SET retired_at = ? WHERE evidence_key = ? AND retired_at IS NULL")
+        .run(timestamp, evidence.key);
+    }
+    if (memoryId && !explicitExisting) {
+      const metadata = owner.buildSemanticMemoryMetadata(parseJson(existingEvidence.metadata_json) ?? {},
+        existingEvidence.domain_key, memory.metadata ?? {}, evidence);
+      owner.db.prepare("UPDATE semantic_memory SET metadata_json = ? WHERE id = ?")
+        .run(JSON.stringify(metadata), memoryId);
+    }
     if (!memoryId) {
       memoryId = owner.insertSemanticMemory({
         ...memory,
@@ -242,7 +257,7 @@ export function reconcileGeneratedMemories(owner, { sessionId, repository, memor
           sourceKind: evidence.sourceKind,
           revision: evidence.revision,
         },
-      });
+      }, { preserveProposition: Boolean(existingEvidence && !sameProposition) });
     }
     if (!memoryId) {
       linked.push(null);
@@ -315,16 +330,16 @@ export function saveIngestionCheckpoint(owner, client, sessionId, state = {}) {
     && Number(expectedCheckpointRevision) !== Number(existing.checkpoint_revision ?? 0))) {
     const conflict = new Error("ingestion checkpoint revision conflict");
     conflict.code = "CHECKPOINT_REVISION_CONFLICT";
-    conflict.currentRevision = Number(existing.checkpoint_revision ?? 0);
-    conflict.currentSourceRevision = existing.revision;
+    conflict.currentRevision = Number(existing?.checkpoint_revision ?? 0);
+    conflict.currentSourceRevision = existing?.revision ?? null;
     throw conflict;
   }
   if (existing && expectedSourceRevision !== null
     && expectedSourceRevision !== String(existing.revision ?? "")) {
     const conflict = new Error("ingestion checkpoint source revision conflict");
     conflict.code = "CHECKPOINT_REVISION_CONFLICT";
-    conflict.currentRevision = Number(existing.checkpoint_revision ?? 0);
-    conflict.currentSourceRevision = existing.revision;
+    conflict.currentRevision = Number(existing?.checkpoint_revision ?? 0);
+    conflict.currentSourceRevision = existing?.revision ?? null;
     throw conflict;
   }
   owner.db.prepare(`

--- a/lib/db/db-memory-lifecycle.mjs
+++ b/lib/db/db-memory-lifecycle.mjs
@@ -179,7 +179,7 @@ export function upsertSessionEvidence(owner, evidence, capturedAt = new Date().t
     evidence.sourceKind, evidence.revision, evidence.propositionFingerprint, evidence.contentHash,
     JSON.stringify(evidence.metadata), capturedAt);
   const updated = owner.db.prepare("SELECT retired_at FROM session_evidence WHERE evidence_key = ?").get(evidence.key);
-  return { accepted: true, active: updated?.retired_at == null };
+  return { accepted: true, active: updated?.retired_at == null, revised: Boolean(current && (current.revision !== evidence.revision || current.content_hash !== evidence.contentHash)) };
 }
 
 export function listSemanticEvidence(owner, memoryId) {
@@ -257,7 +257,7 @@ export function reconcileGeneratedMemories(owner, { sessionId, repository, memor
           sourceKind: evidence.sourceKind,
           revision: evidence.revision,
         },
-      }, { preserveProposition: Boolean(existingEvidence && !sameProposition) });
+      }, { preserveProposition: evidenceState.revised || Boolean(existingEvidence && !sameProposition) });
     }
     if (!memoryId) {
       linked.push(null);
@@ -411,11 +411,12 @@ export function forgetMemory(owner, { id, supersededBy, actor = "user", reason =
   const evidenceRows = owner.db.prepare(`
     SELECT COALESCE(se.content_hash, se.proposition_fingerprint, se.evidence_key) AS fingerprint
     FROM memory_evidence me JOIN session_evidence se ON se.evidence_key = me.evidence_key
-    WHERE me.memory_id = ?
+    WHERE me.memory_id = ? AND me.retired_at IS NULL AND se.retired_at IS NULL
   `).all(id);
-  const fingerprints = evidenceRows.length > 0
-    ? evidenceRows.map((row) => safeEvidenceFingerprint(row.fingerprint))
-    : [buildContentEvidenceFingerprint(existing)];
+  const fingerprints = [...new Set([
+    buildContentEvidenceFingerprint(existing),
+    ...evidenceRows.map((row) => safeEvidenceFingerprint(row.fingerprint)),
+  ])];
   const canonicalFingerprint = existing.canonical_key ? buildSuppressionFingerprint({
     type: existing.type,
     canonicalKey: existing.canonical_key,

--- a/lib/db/db-memory-lifecycle.mjs
+++ b/lib/db/db-memory-lifecycle.mjs
@@ -1,0 +1,319 @@
+import crypto from "node:crypto";
+
+export function normalizeLifecycleText(value) {
+  const text = String(value ?? "").trim();
+  return text || null;
+}
+
+export function buildSuppressionFingerprint({ type, canonicalKey, scope, repository }) {
+  return crypto.createHash("sha256")
+    .update([type ?? "", canonicalKey ?? "", scope ?? "repo", repository ?? ""].join("\0"))
+    .digest("hex");
+}
+
+function acceptsRevision(incoming, current) {
+  if (current === null || current === undefined || current === "") return true;
+  if (incoming === null || incoming === undefined || incoming === "") return false;
+  const nextNumber = Number(incoming);
+  const currentNumber = Number(current);
+  if (Number.isFinite(nextNumber) && Number.isFinite(currentNumber)) return nextNumber >= currentNumber;
+  return String(incoming) === String(current);
+}
+
+export function buildFallbackEvidenceKey({ sessionId, memory, proposition }) {
+  const turn = Number.isInteger(memory?.sourceTurnIndex) ? memory.sourceTurnIndex : "unknown";
+  const type = normalizeLifecycleText(memory?.type) ?? "memory";
+  const normalized = String(proposition ?? memory?.content ?? "").trim().replace(/\s+/g, " ").toLowerCase();
+  const fingerprint = crypto.createHash("sha256").update(`${type}\0${normalized}`).digest("hex").slice(0, 32);
+  return `generated:${sessionId}:${turn}:${type}:${fingerprint}`;
+}
+
+export function normalizeEvidence({ sessionId, memory, repository }) {
+  const evidence = memory?.evidence ?? {};
+  const proposition = normalizeLifecycleText(memory?.content) ?? "";
+  const key = normalizeLifecycleText(evidence.key)
+    ?? buildFallbackEvidenceKey({ sessionId, memory, proposition });
+  const contentHash = normalizeLifecycleText(evidence.contentHash)
+    ?? crypto.createHash("sha256").update(proposition).digest("hex");
+  return {
+    key,
+    sessionId: normalizeLifecycleText(sessionId),
+    sourceIdentity: normalizeLifecycleText(evidence.sourceIdentity) ?? normalizeLifecycleText(repository),
+    sourceRecordId: normalizeLifecycleText(evidence.sourceRecordId)
+      ?? (Number.isInteger(memory?.sourceTurnIndex) ? String(memory.sourceTurnIndex) : null),
+    sourceKind: normalizeLifecycleText(evidence.sourceKind) ?? normalizeLifecycleText(memory?.type) ?? "semantic",
+    revision: normalizeLifecycleText(evidence.revision) ?? contentHash,
+    propositionFingerprint: normalizeLifecycleText(evidence.propositionFingerprint) ?? contentHash,
+    contentHash,
+    metadata: evidence.metadata && typeof evidence.metadata === "object" ? evidence.metadata : {},
+  };
+}
+
+export function isExplicitLifecycleWrite(memory, classificationMetadata = {}) {
+  const source = classificationMetadata.source ?? memory?.metadata?.source;
+  return source === "memory_save"
+    || source === "lore_retain"
+    || source === "onboarding"
+    || memory?.scopeSource === "manual"
+    || memory?.scope_source === "manual";
+}
+
+export function mapCheckpointRow(row) {
+  if (!row) return null;
+  return {
+    client: row.client,
+    sessionId: row.session_id,
+    sourceIdentity: row.source_identity,
+    offset: row.offset,
+    partialRecord: parseJson(row.partial_record_json),
+    adapterState: parseJson(row.adapter_state_json),
+    branchState: parseJson(row.branch_state_json),
+    revision: row.revision,
+    health: {
+      lastSuccessAt: row.last_success_at,
+      pendingBytes: row.pending_bytes,
+      failureCode: row.failure_code,
+    },
+    updatedAt: row.updated_at,
+  };
+}
+
+export function parseJson(value) {
+  if (value === null || value === undefined || value === "") return null;
+  try { return JSON.parse(value); } catch { return null; }
+}
+
+export function mapRepositoryMappingRow(row) {
+  return { legacy: row.legacy, canonical: row.canonical };
+}
+
+export function findActiveSuppression(owner, write) {
+  const canonicalFingerprint = buildSuppressionFingerprint({
+    type: write.type,
+    canonicalKey: write.canonicalKey,
+    scope: write.scope,
+    repository: write.repository,
+  });
+  return owner.db.prepare(`
+    SELECT suppression_key
+    FROM memory_suppression
+    WHERE superseded_at IS NULL
+      AND (
+        (canonical_fingerprint IS NOT NULL AND canonical_fingerprint = ? AND scope = ?
+          AND IFNULL(repository, '') = IFNULL(?, ''))
+        OR (evidence_fingerprint IS NOT NULL AND evidence_fingerprint = ?)
+      )
+    ORDER BY created_at DESC
+    LIMIT 1
+  `).get(canonicalFingerprint, write.scope, write.repository, write.evidence.key);
+}
+
+export function upsertSessionEvidence(owner, evidence, capturedAt = new Date().toISOString()) {
+  const current = owner.db.prepare("SELECT revision FROM session_evidence WHERE evidence_key = ?").get(evidence.key);
+  if (current && !acceptsRevision(evidence.revision, current.revision)) return;
+  owner.db.prepare(`
+    INSERT INTO session_evidence (
+      evidence_key, session_id, source_identity, source_record_id, source_kind,
+      revision, proposition_fingerprint, content_hash, metadata_json, captured_at, retired_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+    ON CONFLICT(evidence_key) DO UPDATE SET
+      session_id = excluded.session_id,
+      source_identity = excluded.source_identity,
+      source_record_id = excluded.source_record_id,
+      source_kind = excluded.source_kind,
+      revision = excluded.revision,
+      proposition_fingerprint = excluded.proposition_fingerprint,
+      content_hash = excluded.content_hash,
+      metadata_json = excluded.metadata_json,
+      captured_at = excluded.captured_at,
+      retired_at = NULL
+  `).run(evidence.key, evidence.sessionId, evidence.sourceIdentity, evidence.sourceRecordId,
+    evidence.sourceKind, evidence.revision, evidence.propositionFingerprint, evidence.contentHash,
+    JSON.stringify(evidence.metadata), capturedAt);
+}
+
+export function listSemanticEvidence(owner, memoryId) {
+  owner.ensureOpen();
+  return owner.db.prepare(`
+    SELECT se.evidence_key, se.session_id, se.source_identity, se.source_record_id,
+      se.source_kind, se.revision, se.proposition_fingerprint, se.content_hash,
+      se.metadata_json, se.captured_at, se.retired_at, me.linked_at,
+      me.retired_at AS link_retired_at
+    FROM memory_evidence me
+    JOIN session_evidence se ON se.evidence_key = me.evidence_key
+    WHERE me.memory_id = ?
+    ORDER BY se.captured_at ASC, se.evidence_key ASC
+  `).all(memoryId).map((row) => ({
+    key: row.evidence_key,
+    sessionId: row.session_id,
+    sourceIdentity: row.source_identity,
+    sourceRecordId: row.source_record_id,
+    sourceKind: row.source_kind,
+    revision: row.revision,
+    propositionFingerprint: row.proposition_fingerprint,
+    contentHash: row.content_hash,
+    metadata: parseJson(row.metadata_json),
+    capturedAt: row.captured_at,
+    retiredAt: row.retired_at,
+    linkedAt: row.linked_at,
+    linkRetiredAt: row.link_retired_at,
+  }));
+}
+
+export function reconcileGeneratedMemories(owner, { sessionId, repository, memories = [], retiredEvidenceKeys = [] }) {
+  owner.ensureOpen();
+  const timestamp = new Date().toISOString();
+  const linked = [];
+  for (const memory of Array.isArray(memories) ? memories : []) {
+    const evidence = normalizeEvidence({ sessionId, memory, repository });
+    upsertSessionEvidence(owner, evidence, timestamp);
+    const existingEvidence = owner.db.prepare(`
+      SELECT sm.id FROM memory_evidence me
+      JOIN semantic_memory sm ON sm.id = me.memory_id
+      WHERE me.evidence_key = ? AND me.retired_at IS NULL AND sm.superseded_by IS NULL
+      ORDER BY sm.updated_at DESC LIMIT 1
+    `).get(evidence.key);
+    let memoryId = existingEvidence?.id ?? null;
+    if (!memoryId) {
+      memoryId = owner.insertSemanticMemory({
+        ...memory,
+        sourceSessionId: memory.sourceSessionId ?? sessionId,
+        repository: memory.repository ?? repository,
+        evidence: {
+          ...memory.evidence,
+          key: evidence.key,
+          contentHash: evidence.contentHash,
+          sourceRecordId: evidence.sourceRecordId,
+          sourceKind: evidence.sourceKind,
+          revision: evidence.revision,
+        },
+      });
+    }
+    if (!memoryId) {
+      linked.push(null);
+      continue;
+    }
+    owner.db.prepare(`
+      INSERT INTO memory_evidence (memory_id, evidence_key, linked_at, retired_at)
+      VALUES (?, ?, ?, NULL)
+      ON CONFLICT(memory_id, evidence_key) DO UPDATE SET linked_at = excluded.linked_at, retired_at = NULL
+    `).run(memoryId, evidence.key, timestamp);
+    linked.push(memoryId);
+  }
+  for (const key of Array.isArray(retiredEvidenceKeys) ? retiredEvidenceKeys : []) {
+    if (typeof key !== "string" || !key.trim()) continue;
+    owner.db.prepare("UPDATE session_evidence SET retired_at = ? WHERE evidence_key = ?").run(timestamp, key);
+    owner.db.prepare("UPDATE memory_evidence SET retired_at = ? WHERE evidence_key = ?").run(timestamp, key);
+  }
+  return linked;
+}
+
+export function getIngestionCheckpoint(owner, client, sessionId) {
+  owner.ensureOpen();
+  const row = owner.db.prepare(`
+    SELECT client, session_id, source_identity, offset, partial_record_json,
+      adapter_state_json, branch_state_json, revision, last_success_at,
+      pending_bytes, failure_code, updated_at
+    FROM ingestion_checkpoint WHERE client = ? AND session_id = ?
+  `).get(String(client), String(sessionId));
+  return mapCheckpointRow(row);
+}
+
+export function saveIngestionCheckpoint(owner, client, sessionId, state = {}) {
+  owner.ensureOpen();
+  const normalizedClient = String(client ?? "").trim();
+  const normalizedSessionId = String(sessionId ?? "").trim();
+  if (!normalizedClient || !normalizedSessionId) throw new Error("client and sessionId are required for an ingestion checkpoint");
+  const health = state.health && typeof state.health === "object" ? state.health : {};
+  const now = new Date().toISOString();
+  const existing = owner.db.prepare("SELECT revision FROM ingestion_checkpoint WHERE client = ? AND session_id = ?")
+    .get(normalizedClient, normalizedSessionId);
+  const revision = state.revision == null ? null : String(state.revision);
+  if (existing && !acceptsRevision(revision, existing.revision)) {
+    return getIngestionCheckpoint(owner, normalizedClient, normalizedSessionId);
+  }
+  owner.db.prepare(`
+    INSERT INTO ingestion_checkpoint (
+      client, session_id, source_identity, offset, partial_record_json,
+      adapter_state_json, branch_state_json, revision, last_success_at,
+      pending_bytes, failure_code, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(client, session_id) DO UPDATE SET
+      source_identity = excluded.source_identity, offset = excluded.offset,
+      partial_record_json = excluded.partial_record_json, adapter_state_json = excluded.adapter_state_json,
+      branch_state_json = excluded.branch_state_json, revision = excluded.revision,
+      last_success_at = excluded.last_success_at, pending_bytes = excluded.pending_bytes,
+      failure_code = excluded.failure_code, updated_at = excluded.updated_at
+  `).run(normalizedClient, normalizedSessionId,
+    typeof state.sourceIdentity === "string" ? state.sourceIdentity : null,
+    Number.isFinite(state.offset) ? Math.max(0, Math.trunc(state.offset)) : 0,
+    state.partialRecord == null ? null : JSON.stringify(state.partialRecord),
+    JSON.stringify(state.adapterState && typeof state.adapterState === "object" ? state.adapterState : {}),
+    JSON.stringify(state.branchState && typeof state.branchState === "object" ? state.branchState : {}),
+    revision,
+    typeof health.lastSuccessAt === "string" ? health.lastSuccessAt : null,
+    Number.isFinite(health.pendingBytes) ? Math.max(0, Math.trunc(health.pendingBytes)) : 0,
+    typeof health.failureCode === "string" ? health.failureCode : null, now);
+  return getIngestionCheckpoint(owner, normalizedClient, normalizedSessionId);
+}
+
+export function listCaptureHealth(owner, { repository = null } = {}) {
+  owner.ensureOpen();
+  const params = [];
+  let sql = `SELECT client, session_id, source_identity, offset, partial_record_json,
+    adapter_state_json, branch_state_json, revision, last_success_at,
+    pending_bytes, failure_code, updated_at FROM ingestion_checkpoint`;
+  if (repository !== null && repository !== undefined) { sql += " WHERE source_identity = ?"; params.push(String(repository)); }
+  sql += " ORDER BY updated_at DESC, client ASC, session_id ASC";
+  return owner.db.prepare(sql).all(...params).map(mapCheckpointRow);
+}
+
+export function getRepositoryMappings(owner) {
+  owner.ensureOpen();
+  return owner.db.prepare("SELECT legacy, canonical FROM repository_identity_mapping ORDER BY legacy ASC").all().map(mapRepositoryMappingRow);
+}
+
+export function setRepositoryMapping(owner, { legacy, canonical }) {
+  owner.ensureOpen();
+  const normalizedLegacy = String(legacy ?? "").trim();
+  const normalizedCanonical = String(canonical ?? "").trim();
+  if (!normalizedLegacy || !normalizedCanonical) throw new Error("legacy and canonical repository identities are required");
+  const now = new Date().toISOString();
+  owner.db.prepare(`
+    INSERT INTO repository_identity_mapping (legacy, canonical, created_at, updated_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT(legacy) DO UPDATE SET canonical = excluded.canonical, updated_at = excluded.updated_at
+  `).run(normalizedLegacy, normalizedCanonical, now, now);
+  return { legacy: normalizedLegacy, canonical: normalizedCanonical };
+}
+
+export function forgetMemory(owner, { id, supersededBy, actor = "user", reason = "manual_forget" }) {
+  owner.ensureOpen();
+  if (!owner.pendingSemanticDurability) return owner.withSemanticMemoryTransaction(() => forgetMemory(owner, { id, supersededBy, actor, reason }));
+  const existing = owner.db.prepare("SELECT id, type, canonical_key, scope, repository FROM semantic_memory WHERE id = ?").get(id);
+  if (!existing) throw new Error(`semantic memory not found: ${id}`);
+  const marker = supersededBy ?? `manual:${new Date().toISOString()}`;
+  const timestamp = new Date().toISOString();
+  owner.db.prepare("UPDATE semantic_memory SET superseded_by = ?, updated_at = ? WHERE id = ?").run(marker, timestamp, id);
+  const evidenceRows = owner.db.prepare(`
+    SELECT COALESCE(se.content_hash, se.proposition_fingerprint, se.evidence_key) AS fingerprint
+    FROM memory_evidence me JOIN session_evidence se ON se.evidence_key = me.evidence_key
+    WHERE me.memory_id = ?
+  `).all(id);
+  const fingerprints = evidenceRows.length > 0 ? evidenceRows.map((row) => row.fingerprint) : [existing.canonical_key ?? id];
+  const canonicalFingerprint = buildSuppressionFingerprint({
+    type: existing.type,
+    canonicalKey: existing.canonical_key,
+    scope: existing.scope,
+    repository: existing.repository,
+  });
+  const insert = owner.db.prepare(`
+    INSERT OR IGNORE INTO memory_suppression (
+      suppression_key, memory_id, canonical_fingerprint, scope, repository,
+      evidence_fingerprint, actor, reason, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  for (const fingerprint of fingerprints) insert.run(`memory:${id}:${fingerprint}`, id, canonicalFingerprint,
+    existing.scope ?? "repo", existing.repository ?? null, fingerprint, String(actor), String(reason), timestamp);
+  return { id, supersededBy: marker };
+}

--- a/lib/db/db-memory-lifecycle.mjs
+++ b/lib/db/db-memory-lifecycle.mjs
@@ -5,9 +5,9 @@ export function normalizeLifecycleText(value) {
   return text || null;
 }
 
-export function buildSuppressionFingerprint({ type, canonicalKey, scope, repository }) {
+export function buildSuppressionFingerprint({ type, canonicalKey }) {
   return crypto.createHash("sha256")
-    .update([type ?? "", canonicalKey ?? "", scope ?? "repo", repository ?? ""].join("\0"))
+    .update([type ?? "", canonicalKey ?? ""].join("\0"))
     .digest("hex");
 }
 
@@ -17,7 +17,22 @@ function acceptsRevision(incoming, current) {
   const nextNumber = Number(incoming);
   const currentNumber = Number(current);
   if (Number.isFinite(nextNumber) && Number.isFinite(currentNumber)) return nextNumber >= currentNumber;
-  return String(incoming) === String(current);
+  // Opaque revisions have no meaningful ordering. The ingestion checkpoint
+  // uses expectedRevision CAS to reject stale writers before evidence writes.
+  return true;
+}
+
+function hashLifecycleValue(value) {
+  return crypto.createHash("sha256").update(String(value ?? "")).digest("hex");
+}
+
+export function buildContentEvidenceFingerprint({ type, content }) {
+  return hashLifecycleValue([type ?? "", content ?? ""].join("\0"));
+}
+
+function safeEvidenceFingerprint(value) {
+  const normalized = normalizeLifecycleText(value);
+  return normalized && /^[0-9a-f]{64}$/iu.test(normalized) ? normalized : hashLifecycleValue(normalized);
 }
 
 export function buildFallbackEvidenceKey({ sessionId, memory, proposition }) {
@@ -38,14 +53,19 @@ export function normalizeEvidence({ sessionId, memory, repository }) {
   return {
     key,
     sessionId: normalizeLifecycleText(sessionId),
-    sourceIdentity: normalizeLifecycleText(evidence.sourceIdentity) ?? normalizeLifecycleText(repository),
+    repository: normalizeLifecycleText(repository),
+    sourceIdentity: normalizeLifecycleText(evidence.sourceIdentity),
     sourceRecordId: normalizeLifecycleText(evidence.sourceRecordId)
       ?? (Number.isInteger(memory?.sourceTurnIndex) ? String(memory.sourceTurnIndex) : null),
     sourceKind: normalizeLifecycleText(evidence.sourceKind) ?? normalizeLifecycleText(memory?.type) ?? "semantic",
     revision: normalizeLifecycleText(evidence.revision) ?? contentHash,
     propositionFingerprint: normalizeLifecycleText(evidence.propositionFingerprint) ?? contentHash,
     contentHash,
-    metadata: evidence.metadata && typeof evidence.metadata === "object" ? evidence.metadata : {},
+    metadata: {
+      ...(memory?.metadata?.sourceAttribution ? { sourceAttribution: memory.metadata.sourceAttribution } : {}),
+      ...(memory?.metadata?.confidenceBasis ? { confidenceBasis: memory.metadata.confidenceBasis } : {}),
+      ...(evidence.metadata && typeof evidence.metadata === "object" ? evidence.metadata : {}),
+    },
   };
 }
 
@@ -63,12 +83,14 @@ export function mapCheckpointRow(row) {
   return {
     client: row.client,
     sessionId: row.session_id,
+    repository: row.repository ?? null,
     sourceIdentity: row.source_identity,
     offset: row.offset,
     partialRecord: parseJson(row.partial_record_json),
     adapterState: parseJson(row.adapter_state_json),
     branchState: parseJson(row.branch_state_json),
     revision: row.revision,
+    checkpointRevision: Number(row.checkpoint_revision ?? 0),
     health: {
       lastSuccessAt: row.last_success_at,
       pendingBytes: row.pending_bytes,
@@ -88,36 +110,57 @@ export function mapRepositoryMappingRow(row) {
 }
 
 export function findActiveSuppression(owner, write) {
-  const canonicalFingerprint = buildSuppressionFingerprint({
-    type: write.type,
-    canonicalKey: write.canonicalKey,
-    scope: write.scope,
-    repository: write.repository,
-  });
+  const canonicalFingerprint = write.canonicalKey
+    ? buildSuppressionFingerprint({
+      type: write.type,
+      canonicalKey: write.canonicalKey,
+      scope: write.scope,
+      repository: write.repository,
+    })
+    : null;
+  const evidenceFingerprints = [
+    write.evidence?.key,
+    write.evidence?.contentHash,
+    write.evidence?.propositionFingerprint,
+    !write.canonicalKey ? buildContentEvidenceFingerprint({
+      type: write.type,
+      content: write.content,
+      scope: write.scope,
+      repository: write.repository,
+    }) : null,
+  ].filter((value, index, all) => typeof value === "string" && value && all.indexOf(value) === index)
+    .flatMap((value) => [value, safeEvidenceFingerprint(value)])
+    .filter((value, index, all) => all.indexOf(value) === index);
   return owner.db.prepare(`
     SELECT suppression_key
     FROM memory_suppression
     WHERE superseded_at IS NULL
+      AND COALESCE(repair_candidate, 0) = 0
       AND (
-        (canonical_fingerprint IS NOT NULL AND canonical_fingerprint = ? AND scope = ?
+        (? IS NOT NULL AND canonical_fingerprint = ? AND scope = ?
           AND IFNULL(repository, '') = IFNULL(?, ''))
-        OR (evidence_fingerprint IS NOT NULL AND evidence_fingerprint = ?)
+        OR (evidence_fingerprint IN (${evidenceFingerprints.map(() => "?").join(", ")})
+          AND scope = ? AND IFNULL(repository, '') = IFNULL(?, ''))
       )
     ORDER BY created_at DESC
     LIMIT 1
-  `).get(canonicalFingerprint, write.scope, write.repository, write.evidence.key);
+  `).get(canonicalFingerprint, canonicalFingerprint, write.scope, write.repository,
+    ...evidenceFingerprints, write.scope, write.repository);
 }
 
 export function upsertSessionEvidence(owner, evidence, capturedAt = new Date().toISOString()) {
-  const current = owner.db.prepare("SELECT revision FROM session_evidence WHERE evidence_key = ?").get(evidence.key);
-  if (current && !acceptsRevision(evidence.revision, current.revision)) return;
+  const current = owner.db.prepare("SELECT revision, content_hash, retired_at FROM session_evidence WHERE evidence_key = ?").get(evidence.key);
+  if (current && !acceptsRevision(evidence.revision, current.revision)) {
+    return { accepted: false, active: current.retired_at === null };
+  }
   owner.db.prepare(`
     INSERT INTO session_evidence (
-      evidence_key, session_id, source_identity, source_record_id, source_kind,
+      evidence_key, session_id, repository, source_identity, source_record_id, source_kind,
       revision, proposition_fingerprint, content_hash, metadata_json, captured_at, retired_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
     ON CONFLICT(evidence_key) DO UPDATE SET
       session_id = excluded.session_id,
+      repository = excluded.repository,
       source_identity = excluded.source_identity,
       source_record_id = excluded.source_record_id,
       source_kind = excluded.source_kind,
@@ -126,16 +169,23 @@ export function upsertSessionEvidence(owner, evidence, capturedAt = new Date().t
       content_hash = excluded.content_hash,
       metadata_json = excluded.metadata_json,
       captured_at = excluded.captured_at,
-      retired_at = NULL
-  `).run(evidence.key, evidence.sessionId, evidence.sourceIdentity, evidence.sourceRecordId,
+      retired_at = CASE
+        WHEN session_evidence.retired_at IS NULL THEN NULL
+        WHEN session_evidence.revision != excluded.revision
+          OR session_evidence.content_hash != excluded.content_hash THEN NULL
+        ELSE session_evidence.retired_at
+      END
+  `).run(evidence.key, evidence.sessionId, evidence.repository, evidence.sourceIdentity, evidence.sourceRecordId,
     evidence.sourceKind, evidence.revision, evidence.propositionFingerprint, evidence.contentHash,
     JSON.stringify(evidence.metadata), capturedAt);
+  const updated = owner.db.prepare("SELECT retired_at FROM session_evidence WHERE evidence_key = ?").get(evidence.key);
+  return { accepted: true, active: updated?.retired_at == null };
 }
 
 export function listSemanticEvidence(owner, memoryId) {
   owner.ensureOpen();
   return owner.db.prepare(`
-    SELECT se.evidence_key, se.session_id, se.source_identity, se.source_record_id,
+    SELECT se.evidence_key, se.session_id, se.repository, se.source_identity, se.source_record_id,
       se.source_kind, se.revision, se.proposition_fingerprint, se.content_hash,
       se.metadata_json, se.captured_at, se.retired_at, me.linked_at,
       me.retired_at AS link_retired_at
@@ -146,6 +196,7 @@ export function listSemanticEvidence(owner, memoryId) {
   `).all(memoryId).map((row) => ({
     key: row.evidence_key,
     sessionId: row.session_id,
+    repository: row.repository ?? null,
     sourceIdentity: row.source_identity,
     sourceRecordId: row.source_record_id,
     sourceKind: row.source_kind,
@@ -166,7 +217,11 @@ export function reconcileGeneratedMemories(owner, { sessionId, repository, memor
   const linked = [];
   for (const memory of Array.isArray(memories) ? memories : []) {
     const evidence = normalizeEvidence({ sessionId, memory, repository });
-    upsertSessionEvidence(owner, evidence, timestamp);
+    const evidenceState = upsertSessionEvidence(owner, evidence, timestamp);
+    if (!evidenceState?.accepted || !evidenceState.active) {
+      linked.push(null);
+      continue;
+    }
     const existingEvidence = owner.db.prepare(`
       SELECT sm.id FROM memory_evidence me
       JOIN semantic_memory sm ON sm.id = me.memory_id
@@ -196,7 +251,8 @@ export function reconcileGeneratedMemories(owner, { sessionId, repository, memor
     owner.db.prepare(`
       INSERT INTO memory_evidence (memory_id, evidence_key, linked_at, retired_at)
       VALUES (?, ?, ?, NULL)
-      ON CONFLICT(memory_id, evidence_key) DO UPDATE SET linked_at = excluded.linked_at, retired_at = NULL
+      ON CONFLICT(memory_id, evidence_key) DO UPDATE SET linked_at = excluded.linked_at,
+        retired_at = NULL
     `).run(memoryId, evidence.key, timestamp);
     linked.push(memoryId);
   }
@@ -211,8 +267,8 @@ export function reconcileGeneratedMemories(owner, { sessionId, repository, memor
 export function getIngestionCheckpoint(owner, client, sessionId) {
   owner.ensureOpen();
   const row = owner.db.prepare(`
-    SELECT client, session_id, source_identity, offset, partial_record_json,
-      adapter_state_json, branch_state_json, revision, last_success_at,
+    SELECT client, session_id, repository, source_identity, offset, partial_record_json,
+      adapter_state_json, branch_state_json, revision, checkpoint_revision, last_success_at,
       pending_bytes, failure_code, updated_at
     FROM ingestion_checkpoint WHERE client = ? AND session_id = ?
   `).get(String(client), String(sessionId));
@@ -221,36 +277,78 @@ export function getIngestionCheckpoint(owner, client, sessionId) {
 
 export function saveIngestionCheckpoint(owner, client, sessionId, state = {}) {
   owner.ensureOpen();
+  if (!owner.pendingSemanticDurability && !owner._checkpointTransaction) {
+    owner.db.exec("BEGIN IMMEDIATE TRANSACTION");
+    owner._checkpointTransaction = true;
+    try {
+      const result = saveIngestionCheckpoint(owner, client, sessionId, state);
+      owner.db.exec("COMMIT");
+      return result;
+    } catch (error) {
+      owner.db.exec("ROLLBACK");
+      throw error;
+    } finally {
+      owner._checkpointTransaction = false;
+    }
+  }
   const normalizedClient = String(client ?? "").trim();
   const normalizedSessionId = String(sessionId ?? "").trim();
   if (!normalizedClient || !normalizedSessionId) throw new Error("client and sessionId are required for an ingestion checkpoint");
   const health = state.health && typeof state.health === "object" ? state.health : {};
   const now = new Date().toISOString();
-  const existing = owner.db.prepare("SELECT revision FROM ingestion_checkpoint WHERE client = ? AND session_id = ?")
+  const existing = owner.db.prepare("SELECT repository, source_identity, revision, checkpoint_revision FROM ingestion_checkpoint WHERE client = ? AND session_id = ?")
     .get(normalizedClient, normalizedSessionId);
   const revision = state.revision == null ? null : String(state.revision);
-  if (existing && !acceptsRevision(revision, existing.revision)) {
-    return getIngestionCheckpoint(owner, normalizedClient, normalizedSessionId);
+  const repository = typeof state.repository === "string"
+    ? (state.repository.trim() || null)
+    : existing?.repository ?? null;
+  const sourceIdentity = typeof state.sourceIdentity === "string"
+    ? (state.sourceIdentity.trim() || null)
+    : existing?.source_identity ?? null;
+  const expectedCheckpointRevision = state.expectedCheckpointRevision
+    ?? (Object.hasOwn(state, "expectedRevision") && /^\d+$/.test(String(state.expectedRevision))
+      ? Number(state.expectedRevision) : null);
+  const expectedSourceRevision = expectedCheckpointRevision === null && Object.hasOwn(state, "expectedRevision")
+    ? String(state.expectedRevision ?? "") : null;
+  if ((!existing && expectedCheckpointRevision !== null && Number(expectedCheckpointRevision) !== 0)
+    || (existing && expectedCheckpointRevision !== null
+    && Number(expectedCheckpointRevision) !== Number(existing.checkpoint_revision ?? 0))) {
+    const conflict = new Error("ingestion checkpoint revision conflict");
+    conflict.code = "CHECKPOINT_REVISION_CONFLICT";
+    conflict.currentRevision = Number(existing.checkpoint_revision ?? 0);
+    conflict.currentSourceRevision = existing.revision;
+    throw conflict;
+  }
+  if (existing && expectedSourceRevision !== null
+    && expectedSourceRevision !== String(existing.revision ?? "")) {
+    const conflict = new Error("ingestion checkpoint source revision conflict");
+    conflict.code = "CHECKPOINT_REVISION_CONFLICT";
+    conflict.currentRevision = Number(existing.checkpoint_revision ?? 0);
+    conflict.currentSourceRevision = existing.revision;
+    throw conflict;
   }
   owner.db.prepare(`
     INSERT INTO ingestion_checkpoint (
-      client, session_id, source_identity, offset, partial_record_json,
-      adapter_state_json, branch_state_json, revision, last_success_at,
+      client, session_id, repository, source_identity, offset, partial_record_json,
+      adapter_state_json, branch_state_json, revision, checkpoint_revision, last_success_at,
       pending_bytes, failure_code, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(client, session_id) DO UPDATE SET
-      source_identity = excluded.source_identity, offset = excluded.offset,
+      repository = excluded.repository, source_identity = excluded.source_identity, offset = excluded.offset,
       partial_record_json = excluded.partial_record_json, adapter_state_json = excluded.adapter_state_json,
       branch_state_json = excluded.branch_state_json, revision = excluded.revision,
+      checkpoint_revision = ingestion_checkpoint.checkpoint_revision + 1,
       last_success_at = excluded.last_success_at, pending_bytes = excluded.pending_bytes,
       failure_code = excluded.failure_code, updated_at = excluded.updated_at
   `).run(normalizedClient, normalizedSessionId,
-    typeof state.sourceIdentity === "string" ? state.sourceIdentity : null,
+    repository,
+    sourceIdentity,
     Number.isFinite(state.offset) ? Math.max(0, Math.trunc(state.offset)) : 0,
     state.partialRecord == null ? null : JSON.stringify(state.partialRecord),
     JSON.stringify(state.adapterState && typeof state.adapterState === "object" ? state.adapterState : {}),
     JSON.stringify(state.branchState && typeof state.branchState === "object" ? state.branchState : {}),
     revision,
+    existing ? Number(existing.checkpoint_revision ?? 0) + 1 : 1,
     typeof health.lastSuccessAt === "string" ? health.lastSuccessAt : null,
     Number.isFinite(health.pendingBytes) ? Math.max(0, Math.trunc(health.pendingBytes)) : 0,
     typeof health.failureCode === "string" ? health.failureCode : null, now);
@@ -260,10 +358,10 @@ export function saveIngestionCheckpoint(owner, client, sessionId, state = {}) {
 export function listCaptureHealth(owner, { repository = null } = {}) {
   owner.ensureOpen();
   const params = [];
-  let sql = `SELECT client, session_id, source_identity, offset, partial_record_json,
-    adapter_state_json, branch_state_json, revision, last_success_at,
+  let sql = `SELECT client, session_id, repository, source_identity, offset, partial_record_json,
+    adapter_state_json, branch_state_json, revision, checkpoint_revision, last_success_at,
     pending_bytes, failure_code, updated_at FROM ingestion_checkpoint`;
-  if (repository !== null && repository !== undefined) { sql += " WHERE source_identity = ?"; params.push(String(repository)); }
+  if (repository !== null && repository !== undefined) { sql += " WHERE repository = ?"; params.push(String(repository)); }
   sql += " ORDER BY updated_at DESC, client ASC, session_id ASC";
   return owner.db.prepare(sql).all(...params).map(mapCheckpointRow);
 }
@@ -290,7 +388,7 @@ export function setRepositoryMapping(owner, { legacy, canonical }) {
 export function forgetMemory(owner, { id, supersededBy, actor = "user", reason = "manual_forget" }) {
   owner.ensureOpen();
   if (!owner.pendingSemanticDurability) return owner.withSemanticMemoryTransaction(() => forgetMemory(owner, { id, supersededBy, actor, reason }));
-  const existing = owner.db.prepare("SELECT id, type, canonical_key, scope, repository FROM semantic_memory WHERE id = ?").get(id);
+  const existing = owner.db.prepare("SELECT id, type, content, canonical_key, scope, repository FROM semantic_memory WHERE id = ?").get(id);
   if (!existing) throw new Error(`semantic memory not found: ${id}`);
   const marker = supersededBy ?? `manual:${new Date().toISOString()}`;
   const timestamp = new Date().toISOString();
@@ -300,13 +398,15 @@ export function forgetMemory(owner, { id, supersededBy, actor = "user", reason =
     FROM memory_evidence me JOIN session_evidence se ON se.evidence_key = me.evidence_key
     WHERE me.memory_id = ?
   `).all(id);
-  const fingerprints = evidenceRows.length > 0 ? evidenceRows.map((row) => row.fingerprint) : [existing.canonical_key ?? id];
-  const canonicalFingerprint = buildSuppressionFingerprint({
+  const fingerprints = evidenceRows.length > 0
+    ? evidenceRows.map((row) => safeEvidenceFingerprint(row.fingerprint))
+    : [buildContentEvidenceFingerprint(existing)];
+  const canonicalFingerprint = existing.canonical_key ? buildSuppressionFingerprint({
     type: existing.type,
     canonicalKey: existing.canonical_key,
     scope: existing.scope,
     repository: existing.repository,
-  });
+  }) : null;
   const insert = owner.db.prepare(`
     INSERT OR IGNORE INTO memory_suppression (
       suppression_key, memory_id, canonical_fingerprint, scope, repository,

--- a/lib/db/db-migration-runner.mjs
+++ b/lib/db/db-migration-runner.mjs
@@ -930,7 +930,7 @@ export class MigrationRunner {
         SELECT id, type, content, canonical_key, scope, repository, superseded_by, metadata_json,
                source_session_id, source_turn_index, updated_at
         FROM semantic_memory
-        WHERE superseded_by LIKE 'manual:%' OR superseded_by LIKE 'manual-%'
+        WHERE superseded_by LIKE 'manual%'
       `).all();
       for (const row of rows) {
         const key = `legacy:${row.id}`;

--- a/lib/db/db-migration-runner.mjs
+++ b/lib/db/db-migration-runner.mjs
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import {
   buildSemanticCanonicalKey,
   classifyEpisodeDigest,
@@ -6,7 +7,7 @@ import {
 import { parseJsonArray } from "../utils/json-array-utils.mjs";
 import { parseJsonObject } from "../utils/json-object-utils.mjs";
 import { SCHEMA_STATEMENTS, SCHEMA_VERSION } from "./schema.mjs";
-import { buildSuppressionFingerprint } from "./db-memory-lifecycle.mjs";
+import { buildContentEvidenceFingerprint, buildSuppressionFingerprint } from "./db-memory-lifecycle.mjs";
 
 const PRIMARY_SCHEMA_VERSION_TABLE = "lore_schema_version";
 const LEGACY_SCHEMA_VERSION_TABLES = Object.freeze(["coherence_schema_version"]);
@@ -884,6 +885,11 @@ export class MigrationRunner {
    * @returns {void}
    */
   applyLifecycleFoundationMigration(api = this) {
+    api.ensureColumn("session_evidence", "repository", "TEXT");
+    api.ensureColumn("ingestion_checkpoint", "repository", "TEXT");
+    api.ensureColumn("ingestion_checkpoint", "checkpoint_revision", "INTEGER NOT NULL DEFAULT 0");
+    api.ensureColumn("memory_suppression", "repair_candidate", "INTEGER NOT NULL DEFAULT 0");
+    api.ensureColumn("memory_suppression", "legacy_marker_fingerprint", "TEXT");
     api.ensureColumn("improvement_backlog", "repository", "TEXT");
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_improvement_backlog_repository_status
@@ -917,17 +923,19 @@ export class MigrationRunner {
       const insert = this.db.prepare(`
         INSERT OR IGNORE INTO memory_suppression (
           suppression_key, memory_id, canonical_fingerprint, scope, repository,
-          evidence_fingerprint, actor, reason, created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          evidence_fingerprint, actor, reason, created_at, repair_candidate, legacy_marker_fingerprint
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `);
       const rows = this.db.prepare(`
-        SELECT id, type, canonical_key, scope, repository, superseded_by, metadata_json,
+        SELECT id, type, content, canonical_key, scope, repository, superseded_by, metadata_json,
                source_session_id, source_turn_index, updated_at
         FROM semantic_memory
-        WHERE superseded_by LIKE 'manual:%'
+        WHERE superseded_by LIKE 'manual:%' OR superseded_by LIKE 'manual-%'
       `).all();
       for (const row of rows) {
         const key = `legacy:${row.id}`;
+        const ambiguous = !row.superseded_by.startsWith("manual:");
+        const markerFingerprint = crypto.createHash("sha256").update(row.superseded_by).digest("hex");
         insert.run(
           key,
           row.id,
@@ -938,7 +946,7 @@ export class MigrationRunner {
               scope: row.scope,
               repository: row.repository,
             })
-            : null,
+            : buildContentEvidenceFingerprint({ type: row.type, content: row.content }),
           row.scope ?? "repo",
           row.repository ?? null,
           row.canonical_key
@@ -948,10 +956,12 @@ export class MigrationRunner {
               scope: row.scope,
               repository: row.repository,
             })
-            : null,
+            : buildContentEvidenceFingerprint({ type: row.type, content: row.content }),
           "legacy-migration",
           "legacy_manual_forget",
           row.updated_at ?? nowIso(),
+          ambiguous ? 1 : 0,
+          markerFingerprint,
         );
       }
     }

--- a/lib/db/db-migration-runner.mjs
+++ b/lib/db/db-migration-runner.mjs
@@ -885,6 +885,11 @@ export class MigrationRunner {
    * @returns {void}
    */
   applyLifecycleFoundationMigration(api = this) {
+    if (api.tableExists("memory_embedding")) {
+      for (const [column, type] of [["content_hash", "TEXT"], ["provider", "TEXT"], ["model", "TEXT"], ["dimensions", "INTEGER"]]) {
+        api.ensureColumn("memory_embedding", column, type);
+      }
+    }
     api.ensureColumn("session_evidence", "repository", "TEXT");
     api.ensureColumn("ingestion_checkpoint", "repository", "TEXT");
     api.ensureColumn("ingestion_checkpoint", "checkpoint_revision", "INTEGER NOT NULL DEFAULT 0");

--- a/lib/db/db-migration-runner.mjs
+++ b/lib/db/db-migration-runner.mjs
@@ -6,6 +6,7 @@ import {
 import { parseJsonArray } from "../utils/json-array-utils.mjs";
 import { parseJsonObject } from "../utils/json-object-utils.mjs";
 import { SCHEMA_STATEMENTS, SCHEMA_VERSION } from "./schema.mjs";
+import { buildSuppressionFingerprint } from "./db-memory-lifecycle.mjs";
 
 const PRIMARY_SCHEMA_VERSION_TABLE = "lore_schema_version";
 const LEGACY_SCHEMA_VERSION_TABLES = Object.freeze(["coherence_schema_version"]);
@@ -237,6 +238,11 @@ export class MigrationRunner {
         label: "memory-domain-observation",
         shouldRun: (currentVersion) => currentVersion < 14,
         run: () => api.applyMemoryDomainObservationMigration(),
+      },
+      {
+        label: "lifecycle-foundation",
+        shouldRun: (currentVersion) => currentVersion < 19,
+        run: () => api.applyLifecycleFoundationMigration(),
       },
     ];
   }
@@ -865,6 +871,89 @@ export class MigrationRunner {
         CREATE INDEX IF NOT EXISTS idx_semantic_memory_domain_key
           ON semantic_memory(domain_key);
       `);
+    }
+  }
+
+  /**
+   * Adds the evidence, suppression, checkpoint, and repository mapping
+   * substrate. Existing semantic rows are left untouched; only an
+   * unambiguous repository already present in an improvement artifact is
+   * copied into the new backlog column.
+   *
+   * @param {MigrationApi} [api=this]
+   * @returns {void}
+   */
+  applyLifecycleFoundationMigration(api = this) {
+    api.ensureColumn("improvement_backlog", "repository", "TEXT");
+    this.db.exec(`
+      CREATE INDEX IF NOT EXISTS idx_improvement_backlog_repository_status
+        ON improvement_backlog(repository, status, updated_at DESC);
+    `);
+
+    if (api.tableExists("improvement_backlog")) {
+      const update = this.db.prepare(`
+        UPDATE improvement_backlog SET repository = ?
+        WHERE id = ? AND repository IS NULL
+      `);
+      const rows = this.db.prepare(`
+        SELECT id, evidence_json, trace_json
+        FROM improvement_backlog
+        WHERE repository IS NULL
+      `).all();
+      for (const row of rows) {
+        const evidence = parseJsonObject(row.evidence_json);
+        const trace = parseJsonObject(row.trace_json);
+        const candidates = [evidence.repository, trace.repository]
+          .filter((value) => typeof value === "string" && value.trim())
+          .map((value) => value.trim());
+        if (candidates.length > 0 && new Set(candidates).size === 1) {
+          update.run(candidates[0], row.id);
+        }
+      }
+    }
+
+    const hasSuppression = api.tableExists("memory_suppression");
+    if (hasSuppression && api.tableExists("semantic_memory")) {
+      const insert = this.db.prepare(`
+        INSERT OR IGNORE INTO memory_suppression (
+          suppression_key, memory_id, canonical_fingerprint, scope, repository,
+          evidence_fingerprint, actor, reason, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+      const rows = this.db.prepare(`
+        SELECT id, type, canonical_key, scope, repository, superseded_by, metadata_json,
+               source_session_id, source_turn_index, updated_at
+        FROM semantic_memory
+        WHERE superseded_by LIKE 'manual:%'
+      `).all();
+      for (const row of rows) {
+        const key = `legacy:${row.id}`;
+        insert.run(
+          key,
+          row.id,
+          row.canonical_key
+            ? buildSuppressionFingerprint({
+              type: row.type,
+              canonicalKey: row.canonical_key,
+              scope: row.scope,
+              repository: row.repository,
+            })
+            : null,
+          row.scope ?? "repo",
+          row.repository ?? null,
+          row.canonical_key
+            ? buildSuppressionFingerprint({
+              type: row.type,
+              canonicalKey: row.canonical_key,
+              scope: row.scope,
+              repository: row.repository,
+            })
+            : null,
+          "legacy-migration",
+          "legacy_manual_forget",
+          row.updated_at ?? nowIso(),
+        );
+      }
     }
   }
 

--- a/lib/db/db-snapshot-lifecycle.mjs
+++ b/lib/db/db-snapshot-lifecycle.mjs
@@ -1,0 +1,149 @@
+import { DatabaseSync } from "node:sqlite";
+import { existsSync, chmodSync } from "node:fs";
+import path from "node:path";
+import { SCHEMA_STATEMENTS, SCHEMA_VERSION } from "./schema.mjs";
+
+const VERSION_TABLES = ["lore_schema_version", "coherence_schema_version"];
+
+function sqlQuote(value) {
+  return String(value).replaceAll("'", "''");
+}
+
+function schemaInfo(db, dbPath) {
+  const found = [];
+  for (const table of VERSION_TABLES) {
+    if (!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table)) continue;
+    const rows = db.prepare(`SELECT version FROM ${table}`).all();
+    if (rows.some((row) => typeof row.version !== "number" || !Number.isInteger(row.version) || row.version < 0)) {
+      throw new Error(`malformed Lore schema version in ${table} at ${path.resolve(dbPath)}`);
+    }
+    const version = rows.length > 0 ? Math.max(...rows.map((row) => row.version)) : 0;
+    if (version > SCHEMA_VERSION) {
+      throw new Error(`unsupported future Lore schema version ${version} (supported through ${SCHEMA_VERSION}) at ${path.resolve(dbPath)}`);
+    }
+    found.push({
+      tableName: table,
+      version,
+    });
+  }
+  const selected = found[0];
+  const requiredColumns = {
+    semantic_memory: ["id", "type", "content", "created_at", "updated_at"],
+    episode_digest: ["id", "session_id", "summary", "date_key", "created_at", "updated_at"],
+  };
+  const requiredTables = Object.entries(requiredColumns).every(([table, columns]) => {
+    const actual = new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((column) => column.name));
+    return columns.every((column) => actual.has(column));
+  });
+  return { ...(selected ?? { tableName: null, version: 0 }), requiredTables };
+}
+
+export function inspectDatabase(dbPath) {
+  const normalized = path.resolve(String(dbPath));
+  if (!existsSync(normalized)) return { path: normalized, exists: false, integrity: "missing", schemaVersion: null };
+  const db = new DatabaseSync(normalized, { readOnly: true });
+  try {
+    const integrity = db.prepare("PRAGMA integrity_check").get()?.integrity_check;
+    const info = schemaInfo(db, normalized);
+    return { path: normalized, exists: true, integrity: integrity === "ok" ? "ok" : integrity, schemaVersion: info.version, schemaTable: info.tableName, requiredTables: info.requiredTables };
+  } finally { db.close(); }
+}
+
+function schemaShape(db) {
+  return new Map(
+    db.prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'").all()
+      .map(({ name }) => [name, new Set(db.prepare(`PRAGMA table_info("${name.replaceAll('"', '""')}")`).all().map((column) => column.name))]),
+  );
+}
+
+export function validateCanonicalShape(db) {
+  const canonical = new DatabaseSync(":memory:");
+  try {
+    for (const statement of SCHEMA_STATEMENTS) canonical.exec(statement);
+    const expected = schemaShape(canonical);
+    const actual = schemaShape(db);
+    for (const [table, columns] of expected) {
+      const actualColumns = actual.get(table);
+      if (!actualColumns || [...columns].some((column) => !actualColumns.has(column))) {
+        throw new Error(`snapshot is not a complete Lore database (missing table or columns in ${table})`);
+      }
+    }
+  } finally { canonical.close(); }
+}
+
+export function readCurrentSuppressions(dbPath) {
+  if (!existsSync(dbPath)) return [];
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+  } catch {
+    return [];
+  }
+  try {
+    const table = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_suppression'").get();
+    if (!table) return [];
+    return db.prepare(`
+      SELECT suppression_key, memory_id, canonical_fingerprint, scope, repository,
+        evidence_fingerprint, actor, reason, created_at, superseded_at,
+        repair_candidate, legacy_marker_fingerprint
+      FROM memory_suppression
+    `).all();
+  } catch {
+    return [];
+  } finally { db.close(); }
+}
+
+function mergeCurrentSuppressions(stagePath, suppressions) {
+  if (suppressions.length === 0) return;
+  const db = new DatabaseSync(stagePath);
+  try {
+    const insert = db.prepare(`
+      INSERT OR REPLACE INTO memory_suppression (
+        suppression_key, memory_id, canonical_fingerprint, scope, repository,
+        evidence_fingerprint, actor, reason, created_at, superseded_at,
+        repair_candidate, legacy_marker_fingerprint
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      for (const row of suppressions) insert.run(
+        row.suppression_key,
+        row.memory_id,
+        row.canonical_fingerprint,
+        row.scope,
+        row.repository,
+        row.evidence_fingerprint,
+        row.actor,
+        row.reason,
+        row.created_at,
+        row.superseded_at,
+        row.repair_candidate ?? 0,
+        row.legacy_marker_fingerprint ?? null,
+      );
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw error;
+    }
+  } finally { db.close(); }
+}
+
+export function prepareSnapshotStage({ snapshotPath, stagePath, suppressions = [], upgrade }) {
+  const original = inspectDatabase(snapshotPath);
+  if (!original.exists || original.integrity !== "ok") throw new Error("snapshot integrity check failed");
+  if (!original.schemaTable || original.schemaVersion < 1 || !original.requiredTables) {
+    throw new Error("snapshot is not a recognized Lore database");
+  }
+  const source = new DatabaseSync(snapshotPath, { readOnly: true });
+  try { source.exec(`VACUUM INTO '${sqlQuote(stagePath)}'`); } finally { source.close(); }
+  chmodSync(stagePath, 0o600);
+  upgrade(stagePath);
+  mergeCurrentSuppressions(stagePath, suppressions);
+  const staged = new DatabaseSync(stagePath);
+  try {
+    validateCanonicalShape(staged);
+    if (staged.prepare("PRAGMA integrity_check").get()?.integrity_check !== "ok") throw new Error("staged snapshot integrity check failed");
+    staged.exec("PRAGMA wal_checkpoint(TRUNCATE); PRAGMA journal_mode=DELETE;");
+  } finally { staged.close(); }
+  return inspectDatabase(stagePath);
+}

--- a/lib/db/db.mjs
+++ b/lib/db/db.mjs
@@ -3254,6 +3254,7 @@ export class LoreDb {
     return {
       id: memory.id ?? crypto.randomUUID(),
       type: memory.type,
+      content: memory.content,
       classification,
       repository: normalizeRepository(classification.repository),
       scope: classification.scope,
@@ -3334,11 +3335,20 @@ export class LoreDb {
     );
   }
 
-  buildSemanticMemoryMetadata(existingMetadata, domainKey, classificationMetadata) {
+  buildSemanticMemoryMetadata(existingMetadata, domainKey, classificationMetadata, evidence = null) {
     return {
       ...existingMetadata,
       ...(domainKey ? { domainKey } : {}),
       ...classificationMetadata,
+      ...(evidence ? {
+        evidence: {
+          key: evidence.key,
+          sourceRecordId: evidence.sourceRecordId,
+          sourceKind: evidence.sourceKind,
+          revision: evidence.revision,
+          contentHash: evidence.contentHash,
+        },
+      } : {}),
     };
   }
 
@@ -3347,6 +3357,7 @@ export class LoreDb {
       parseJsonObject(match.metadata_json),
       write.domainKey,
       write.classification.metadata,
+      write.explicitWrite ? null : write.evidence,
     );
     this.db.prepare(`
       UPDATE semantic_memory
@@ -3377,27 +3388,9 @@ export class LoreDb {
     return match.id;
   }
 
-  updateProtectedSemanticMemoryMatch(existing, write, timestamp) {
-    this.db.prepare(`
-      UPDATE semantic_memory
-      SET updated_at = ?,
-          confidence = MAX(confidence, ?),
-          domain_key = COALESCE(?, domain_key),
-          tags = ?,
-          canonical_key = COALESCE(canonical_key, ?),
-          reinforcement_count = MAX(1, COALESCE(reinforcement_count, 1) + ?),
-          ${LAST_SEEN_AT_CASE_SQL}
-      WHERE id = ?
-    `).run(
-      timestamp,
-      write.incomingConfidence,
-      write.domainKey,
-      mergeTagText(existing.tags, write.tagsText),
-      write.canonicalKey,
-      write.incomingReinforcement,
-      ...lastSeenAtParams(write.incomingLastSeenAt),
-      existing.id,
-    );
+  updateProtectedSemanticMemoryMatch(existing) {
+    // Inferred evidence can share an explicit proposition, but it must not
+    // rewrite the explicit row's provenance, confidence, or reinforcement.
     return existing.id;
   }
 
@@ -3406,6 +3399,7 @@ export class LoreDb {
       parseJsonObject(existing.metadata_json),
       write.domainKey,
       write.classification.metadata,
+      write.explicitWrite ? null : write.evidence,
     );
     this.db.prepare(`
       UPDATE semantic_memory
@@ -3461,7 +3455,8 @@ export class LoreDb {
       write.incomingReinforcement,
       write.incomingLastSeenAt,
       memory.expiresAt ?? null,
-      JSON.stringify(this.buildSemanticMemoryMetadata({}, write.domainKey, write.classification.metadata)),
+      JSON.stringify(this.buildSemanticMemoryMetadata({}, write.domainKey, write.classification.metadata,
+        write.explicitWrite ? null : write.evidence)),
     );
     return write.id;
   }
@@ -3484,8 +3479,8 @@ export class LoreDb {
       return null;
     }
     const existingMetadata = parseJsonObject(existing.metadata_json);
-    const manualExisting = existingMetadata.source === "memory_save";
-    const manualIncoming = write.sourceText === "memory_save";
+    const manualExisting = ["memory_save", "lore_retain", "onboarding"].includes(existingMetadata.source);
+    const manualIncoming = write.explicitWrite;
     const lockedScope = normalizeScopeSource(existing.scope_source) === SCOPE_SOURCE.MANUAL;
     return (manualExisting || lockedScope) && !manualIncoming
       ? this.updateProtectedSemanticMemoryMatch(existing, write, timestamp)
@@ -4329,7 +4324,18 @@ export class LoreDb {
         sql += ` JOIN semantic_fts ON semantic_fts.rowid = sm.rowid `;
       }
 
-      sql += ` WHERE sm.superseded_by IS NULL `;
+      sql += ` WHERE sm.superseded_by IS NULL
+        AND (
+          NOT EXISTS (SELECT 1 FROM memory_evidence active_me WHERE active_me.memory_id = sm.id)
+          OR EXISTS (
+            SELECT 1
+            FROM memory_evidence active_me
+            JOIN session_evidence active_se ON active_se.evidence_key = active_me.evidence_key
+            WHERE active_me.memory_id = sm.id
+              AND active_me.retired_at IS NULL
+              AND active_se.retired_at IS NULL
+          )
+        ) `;
       sql = applyScopeFilter(sql, params, repo, includeOtherRepositories, "sm");
 
       if (types.length > 0) {

--- a/lib/db/db.mjs
+++ b/lib/db/db.mjs
@@ -3281,7 +3281,7 @@ export class LoreDb {
     return findLifecycleSuppression(this, write);
   }
 
-  findManualSemanticMemoryMatch(memory, canonicalKey) {
+  findManualSemanticMemoryMatch(memory, canonicalKey, scope, repository) {
     return this.db.prepare(`
       SELECT
         id, tags, metadata_json, scope, repository, scope_source, confidence,
@@ -3294,6 +3294,8 @@ export class LoreDb {
           OR (? IS NULL AND content = ?)
         )
         AND scope_source = 'manual'
+        AND scope = ?
+        AND IFNULL(repository, '') = IFNULL(?, '')
       ORDER BY updated_at DESC
       LIMIT 1
     `).get(
@@ -3302,6 +3304,8 @@ export class LoreDb {
       canonicalKey,
       canonicalKey,
       memory.content,
+      scope,
+      repository,
     );
   }
 
@@ -3463,7 +3467,7 @@ export class LoreDb {
   }
 
   upsertManualSemanticMemory(memory, write, timestamp) {
-    const manualScopeMatch = this.findManualSemanticMemoryMatch(memory, write.canonicalKey);
+    const manualScopeMatch = this.findManualSemanticMemoryMatch(memory, write.canonicalKey, write.scope, write.repository);
     return manualScopeMatch?.id
       ? this.updateManualSemanticMemoryMatch(memory, write, timestamp, manualScopeMatch)
       : null;

--- a/lib/db/db.mjs
+++ b/lib/db/db.mjs
@@ -16,6 +16,20 @@ import {
 import { buildMemoryDomain } from "../memory/memory-domains.mjs";
 import { buildRefreshableObservation } from "../sessions/observations.mjs";
 import { SCHEMA_VERSION } from "./schema.mjs";
+import {
+  findActiveSuppression as findLifecycleSuppression,
+  forgetMemory as forgetLifecycleMemory,
+  getIngestionCheckpoint as getLifecycleCheckpoint,
+  getRepositoryMappings as getLifecycleRepositoryMappings,
+  isExplicitLifecycleWrite,
+  listCaptureHealth as listLifecycleCaptureHealth,
+  listSemanticEvidence as listLifecycleSemanticEvidence,
+  normalizeEvidence,
+  reconcileGeneratedMemories as reconcileLifecycleMemories,
+  saveIngestionCheckpoint as saveLifecycleCheckpoint,
+  setRepositoryMapping as setLifecycleRepositoryMapping,
+  upsertSessionEvidence as upsertLifecycleEvidence,
+} from "./db-memory-lifecycle.mjs";
 import { resolveLorePaths } from "../core/lore-paths.mjs";
 import { MigrationRunner } from "./db-migration-runner.mjs";
 import {
@@ -1363,6 +1377,13 @@ export class LoreDb {
     const dbPath = this.config.paths.derivedStorePath;
     const walPath = `${dbPath}-wal`;
     const shmPath = `${dbPath}-shm`;
+    const currentSuppressions = this.db?.tableExists("memory_suppression")
+      ? this.db.prepare(`
+        SELECT suppression_key, memory_id, canonical_fingerprint, scope, repository,
+          evidence_fingerprint, actor, reason, created_at, superseded_at
+        FROM memory_suppression
+      `).all()
+      : [];
     this.close();
     rmSync(walPath, { force: true });
     rmSync(shmPath, { force: true });
@@ -1371,6 +1392,26 @@ export class LoreDb {
     const currentVersion = this.getCurrentVersion();
     if (currentVersion < SCHEMA_VERSION) {
       this.runMigrations(currentVersion);
+    }
+    if (currentSuppressions.length > 0) {
+      this.db.exec("BEGIN IMMEDIATE");
+      try {
+        const insert = this.db.prepare(`
+          INSERT OR REPLACE INTO memory_suppression (
+            suppression_key, memory_id, canonical_fingerprint, scope, repository,
+            evidence_fingerprint, actor, reason, created_at, superseded_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        for (const row of currentSuppressions) insert.run(
+          row.suppression_key, row.memory_id, row.canonical_fingerprint, row.scope,
+          row.repository, row.evidence_fingerprint, row.actor, row.reason,
+          row.created_at, row.superseded_at,
+        );
+        this.db.exec("COMMIT");
+      } catch (error) {
+        this.db.exec("ROLLBACK");
+        throw error;
+      }
     }
     return {
       restoredFrom: normalizedPath,
@@ -1501,6 +1542,10 @@ export class LoreDb {
 
   applyMemoryDomainObservationMigration() {
     return this.migrations.applyMemoryDomainObservationMigration(this);
+  }
+
+  applyLifecycleFoundationMigration() {
+    return this.migrations.applyLifecycleFoundationMigration(this);
   }
 
   applyDeferredExtractionLeaseMigration() {
@@ -3201,8 +3246,14 @@ export class LoreDb {
 
   buildSemanticMemoryWriteContext(memory, timestamp) {
     const classification = classifySemanticMemory(memory);
+    const evidence = normalizeEvidence({
+      sessionId: memory.sourceSessionId,
+      memory,
+      repository: classification.repository,
+    });
     return {
       id: memory.id ?? crypto.randomUUID(),
+      type: memory.type,
       classification,
       repository: normalizeRepository(classification.repository),
       scope: classification.scope,
@@ -3221,7 +3272,13 @@ export class LoreDb {
       incomingLastSeenAt: memory.lastSeenAt ?? timestamp,
       incomingConfidence: typeof memory.confidence === "number" ? memory.confidence : 1.0,
       insertedUpdatedAt: resolveTimestamp(memory.updatedAt, timestamp),
+      evidence,
+      explicitWrite: isExplicitLifecycleWrite(memory, classification.metadata),
     };
+  }
+
+  findActiveSuppression(write) {
+    return findLifecycleSuppression(this, write);
   }
 
   findManualSemanticMemoryMatch(memory, canonicalKey) {
@@ -3435,12 +3492,47 @@ export class LoreDb {
     this.ensureOpen();
     const timestamp = nowIso();
     const write = this.buildSemanticMemoryWriteContext(memory, timestamp);
+    if (!write.explicitWrite && this.findActiveSuppression(write)) {
+      return null;
+    }
     const id = this.upsertManualSemanticMemory(memory, write, timestamp)
       ?? this.upsertScopedSemanticMemory(memory, write, timestamp)
       ?? this.insertNewSemanticMemory(memory, write, timestamp);
     if (this.pendingSemanticDurability) this.pendingSemanticDurability.add(id);
     else this.verifySemanticMemoryDurability(id);
     return id;
+  }
+
+  upsertSessionEvidence(evidence, capturedAt = nowIso()) {
+    return upsertLifecycleEvidence(this, evidence, capturedAt);
+  }
+
+  listSemanticEvidence(memoryId) {
+    return listLifecycleSemanticEvidence(this, memoryId);
+  }
+
+  reconcileGeneratedMemories(options) {
+    return reconcileLifecycleMemories(this, options);
+  }
+
+  getIngestionCheckpoint(client, sessionId) {
+    return getLifecycleCheckpoint(this, client, sessionId);
+  }
+
+  saveIngestionCheckpoint(client, sessionId, state = {}) {
+    return saveLifecycleCheckpoint(this, client, sessionId, state);
+  }
+
+  listCaptureHealth(options = {}) {
+    return listLifecycleCaptureHealth(this, options);
+  }
+
+  getRepositoryMappings() {
+    return getLifecycleRepositoryMappings(this);
+  }
+
+  setRepositoryMapping(options) {
+    return setLifecycleRepositoryMapping(this, options);
   }
 
   // Capture hooks can race at turn/session end. Commit the complete refresh
@@ -3963,13 +4055,8 @@ export class LoreDb {
     }
   }
 
-  forgetMemory({ id, supersededBy }) {
-    this.ensureOpen();
-    this.db.prepare(`
-      UPDATE semantic_memory
-      SET superseded_by = ?, updated_at = ?
-      WHERE id = ?
-    `).run(supersededBy ?? `manual:${nowIso()}`, nowIso(), id);
+  forgetMemory({ id, supersededBy, actor = "user", reason = "manual_forget" }) {
+    return forgetLifecycleMemory(this, { id, supersededBy, actor, reason });
   }
 
   listActiveStabilisationMemories({

--- a/lib/db/db.mjs
+++ b/lib/db/db.mjs
@@ -1,6 +1,6 @@
 import { promptSearchQuery } from "../context/prompt-search-query.mjs";
 import crypto from "node:crypto";
-import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, rmSync, renameSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, rmSync, renameSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
@@ -32,6 +32,7 @@ import {
 } from "./db-memory-lifecycle.mjs";
 import { resolveLorePaths } from "../core/lore-paths.mjs";
 import { MigrationRunner } from "./db-migration-runner.mjs";
+import { readCurrentSuppressions, prepareSnapshotStage } from "./db-snapshot-lifecycle.mjs";
 import {
   buildStyleAddressingSection,
   isStyleAddressingMemory,
@@ -1375,23 +1376,16 @@ export class LoreDb {
       throw new Error(`backup path does not exist: ${normalizedPath}`);
     }
     const dbPath = this.config.paths.derivedStorePath;
-    const currentSuppressions = this.db && this.tableExists("memory_suppression")
-      ? this.db.prepare(`
-        SELECT suppression_key, memory_id, canonical_fingerprint, scope, repository,
-          evidence_fingerprint, actor, reason, created_at, superseded_at,
-          repair_candidate, legacy_marker_fingerprint
-        FROM memory_suppression
-      `).all()
-      : [];
+    const currentSuppressions = readCurrentSuppressions(dbPath);
     const stage = `${dbPath}.restore-${crypto.randomUUID()}.tmp`;
     const rescue = `${dbPath}.rescue-${crypto.randomUUID()}`;
-    copyFileSync(normalizedPath, stage);
     try {
-      const staged = new DatabaseSync(stage, { readOnly: true });
-      try {
-        const integrity = staged.prepare("PRAGMA integrity_check").get()?.integrity_check;
-        if (integrity !== "ok") throw new Error(`backup integrity check failed: ${integrity}`);
-      } finally { staged.close(); }
+      prepareSnapshotStage({ snapshotPath: normalizedPath, stagePath: stage, suppressions: currentSuppressions,
+        upgrade: (stagePath) => {
+          const staged = new LoreDb({ ...this.config, paths: { ...this.config.paths, derivedStorePath: stagePath, backupDir: `${stagePath}.backups` } });
+          try { staged.initialize(); } finally { staged.close(); rmSync(`${stagePath}.backups`, { recursive: true, force: true }); }
+        },
+      });
 
       this.close();
       let movedTarget = false;
@@ -1411,34 +1405,12 @@ export class LoreDb {
         renameSync(stage, dbPath);
         installedTarget = true;
         this.openDatabase();
-        const currentVersion = this.getCurrentVersion();
-        if (currentVersion < SCHEMA_VERSION) this.runMigrations(currentVersion);
-        if (currentSuppressions.length > 0) {
-          this.db.exec("BEGIN IMMEDIATE");
-          try {
-            const insert = this.db.prepare(`
-              INSERT OR REPLACE INTO memory_suppression (
-                suppression_key, memory_id, canonical_fingerprint, scope, repository,
-                evidence_fingerprint, actor, reason, created_at, superseded_at,
-                repair_candidate, legacy_marker_fingerprint
-              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            `);
-            for (const row of currentSuppressions) insert.run(
-              row.suppression_key, row.memory_id, row.canonical_fingerprint, row.scope,
-              row.repository, row.evidence_fingerprint, row.actor, row.reason,
-              row.created_at, row.superseded_at, row.repair_candidate ?? 0,
-              row.legacy_marker_fingerprint ?? null,
-            );
-            this.db.exec("COMMIT");
-          } catch (error) {
-            this.db.exec("ROLLBACK");
-            throw error;
-          }
-        }
         return { restoredFrom: normalizedPath, rescuePath: movedTarget || movedSidecars.length > 0 ? rescue : null, schemaVersion: this.getCurrentVersion() };
       } catch (error) {
         try { this.close(); } catch { /* best effort before rescue restore */ }
-        if (installedTarget) rmSync(dbPath, { force: true });
+        if (installedTarget) {
+          for (const suffix of ["", "-wal", "-shm"]) rmSync(`${dbPath}${suffix}`, { force: true });
+        }
         if (movedTarget && existsSync(rescue)) renameSync(rescue, dbPath);
         for (const suffix of movedSidecars) {
           if (existsSync(`${rescue}${suffix}`)) renameSync(`${rescue}${suffix}`, `${dbPath}${suffix}`);
@@ -1447,7 +1419,7 @@ export class LoreDb {
         throw error;
       }
     } finally {
-      rmSync(stage, { force: true });
+      for (const suffix of ["", "-wal", "-shm"]) rmSync(`${stage}${suffix}`, { force: true });
     }
   }
 
@@ -3344,7 +3316,7 @@ export class LoreDb {
 
   findScopedSemanticMemoryMatch(memory, canonicalKey, scope, repository) {
     return this.db.prepare(`
-      SELECT id, tags, metadata_json, scope_source, reinforcement_count, last_seen_at
+      SELECT id, content, tags, metadata_json, scope_source, reinforcement_count, last_seen_at
       FROM semantic_memory
       WHERE superseded_by IS NULL
         AND type = ?
@@ -3495,9 +3467,10 @@ export class LoreDb {
 
   upsertManualSemanticMemory(memory, write, timestamp) {
     const manualScopeMatch = this.findManualSemanticMemoryMatch(memory, write.canonicalKey, write.scope, write.repository);
-    return manualScopeMatch?.id
+    if (!manualScopeMatch?.id) return null;
+    return write.explicitWrite
       ? this.updateManualSemanticMemoryMatch(memory, write, timestamp, manualScopeMatch)
-      : null;
+      : this.updateProtectedSemanticMemoryMatch(manualScopeMatch, write, timestamp);
   }
 
   upsertScopedSemanticMemory(memory, write, timestamp) {
@@ -3514,15 +3487,16 @@ export class LoreDb {
     const manualExisting = ["memory_save", "lore_retain", "onboarding"].includes(existingMetadata.source);
     const manualIncoming = write.explicitWrite;
     const lockedScope = normalizeScopeSource(existing.scope_source) === SCOPE_SOURCE.MANUAL;
-    return (manualExisting || lockedScope) && !manualIncoming
-      ? this.updateProtectedSemanticMemoryMatch(existing, write, timestamp)
-      : this.updateScopedSemanticMemoryMatch(memory, existing, write, timestamp);
+    if ((manualExisting || lockedScope) && !manualIncoming) return this.updateProtectedSemanticMemoryMatch(existing, write, timestamp);
+    if (write.preserveProposition && existing.content !== memory.content) return null;
+    return this.updateScopedSemanticMemoryMatch(memory, existing, write, timestamp);
   }
 
-  insertSemanticMemory(memory) {
+  insertSemanticMemory(memory, { preserveProposition = false } = {}) {
     this.ensureOpen();
     const timestamp = nowIso();
     const write = this.buildSemanticMemoryWriteContext(memory, timestamp);
+    write.preserveProposition = preserveProposition;
     if (!write.explicitWrite && this.findActiveSuppression(write)) {
       return null;
     }
@@ -4358,7 +4332,9 @@ export class LoreDb {
 
       sql += ` WHERE sm.superseded_by IS NULL
         AND (
-          NOT EXISTS (SELECT 1 FROM memory_evidence active_me WHERE active_me.memory_id = sm.id)
+          sm.scope_source = 'manual'
+          OR COALESCE(json_extract(sm.metadata_json, '$.source'), '') IN ('memory_save', 'lore_retain', 'onboarding')
+          OR NOT EXISTS (SELECT 1 FROM memory_evidence active_me WHERE active_me.memory_id = sm.id)
           OR EXISTS (
             SELECT 1
             FROM memory_evidence active_me

--- a/lib/db/db.mjs
+++ b/lib/db/db.mjs
@@ -1,6 +1,6 @@
 import { promptSearchQuery } from "../context/prompt-search-query.mjs";
 import crypto from "node:crypto";
-import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, rmSync } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, lstatSync, mkdirSync, rmSync, renameSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
@@ -1375,48 +1375,80 @@ export class LoreDb {
       throw new Error(`backup path does not exist: ${normalizedPath}`);
     }
     const dbPath = this.config.paths.derivedStorePath;
-    const walPath = `${dbPath}-wal`;
-    const shmPath = `${dbPath}-shm`;
-    const currentSuppressions = this.db?.tableExists("memory_suppression")
+    const currentSuppressions = this.db && this.tableExists("memory_suppression")
       ? this.db.prepare(`
         SELECT suppression_key, memory_id, canonical_fingerprint, scope, repository,
-          evidence_fingerprint, actor, reason, created_at, superseded_at
+          evidence_fingerprint, actor, reason, created_at, superseded_at,
+          repair_candidate, legacy_marker_fingerprint
         FROM memory_suppression
       `).all()
       : [];
-    this.close();
-    rmSync(walPath, { force: true });
-    rmSync(shmPath, { force: true });
-    copyFileSync(normalizedPath, dbPath);
-    this.openDatabase();
-    const currentVersion = this.getCurrentVersion();
-    if (currentVersion < SCHEMA_VERSION) {
-      this.runMigrations(currentVersion);
-    }
-    if (currentSuppressions.length > 0) {
-      this.db.exec("BEGIN IMMEDIATE");
+    const stage = `${dbPath}.restore-${crypto.randomUUID()}.tmp`;
+    const rescue = `${dbPath}.rescue-${crypto.randomUUID()}`;
+    copyFileSync(normalizedPath, stage);
+    try {
+      const staged = new DatabaseSync(stage, { readOnly: true });
       try {
-        const insert = this.db.prepare(`
-          INSERT OR REPLACE INTO memory_suppression (
-            suppression_key, memory_id, canonical_fingerprint, scope, repository,
-            evidence_fingerprint, actor, reason, created_at, superseded_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `);
-        for (const row of currentSuppressions) insert.run(
-          row.suppression_key, row.memory_id, row.canonical_fingerprint, row.scope,
-          row.repository, row.evidence_fingerprint, row.actor, row.reason,
-          row.created_at, row.superseded_at,
-        );
-        this.db.exec("COMMIT");
+        const integrity = staged.prepare("PRAGMA integrity_check").get()?.integrity_check;
+        if (integrity !== "ok") throw new Error(`backup integrity check failed: ${integrity}`);
+      } finally { staged.close(); }
+
+      this.close();
+      let movedTarget = false;
+      let installedTarget = false;
+      const movedSidecars = [];
+      try {
+        if (existsSync(dbPath)) {
+          renameSync(dbPath, rescue);
+          movedTarget = true;
+        }
+        for (const suffix of ["-wal", "-shm"]) {
+          if (existsSync(`${dbPath}${suffix}`)) {
+            renameSync(`${dbPath}${suffix}`, `${rescue}${suffix}`);
+            movedSidecars.push(suffix);
+          }
+        }
+        renameSync(stage, dbPath);
+        installedTarget = true;
+        this.openDatabase();
+        const currentVersion = this.getCurrentVersion();
+        if (currentVersion < SCHEMA_VERSION) this.runMigrations(currentVersion);
+        if (currentSuppressions.length > 0) {
+          this.db.exec("BEGIN IMMEDIATE");
+          try {
+            const insert = this.db.prepare(`
+              INSERT OR REPLACE INTO memory_suppression (
+                suppression_key, memory_id, canonical_fingerprint, scope, repository,
+                evidence_fingerprint, actor, reason, created_at, superseded_at,
+                repair_candidate, legacy_marker_fingerprint
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `);
+            for (const row of currentSuppressions) insert.run(
+              row.suppression_key, row.memory_id, row.canonical_fingerprint, row.scope,
+              row.repository, row.evidence_fingerprint, row.actor, row.reason,
+              row.created_at, row.superseded_at, row.repair_candidate ?? 0,
+              row.legacy_marker_fingerprint ?? null,
+            );
+            this.db.exec("COMMIT");
+          } catch (error) {
+            this.db.exec("ROLLBACK");
+            throw error;
+          }
+        }
+        return { restoredFrom: normalizedPath, rescuePath: movedTarget || movedSidecars.length > 0 ? rescue : null, schemaVersion: this.getCurrentVersion() };
       } catch (error) {
-        this.db.exec("ROLLBACK");
+        try { this.close(); } catch { /* best effort before rescue restore */ }
+        if (installedTarget) rmSync(dbPath, { force: true });
+        if (movedTarget && existsSync(rescue)) renameSync(rescue, dbPath);
+        for (const suffix of movedSidecars) {
+          if (existsSync(`${rescue}${suffix}`)) renameSync(`${rescue}${suffix}`, `${dbPath}${suffix}`);
+        }
+        if (!this.db && existsSync(dbPath)) this.openDatabase();
         throw error;
       }
+    } finally {
+      rmSync(stage, { force: true });
     }
-    return {
-      restoredFrom: normalizedPath,
-      schemaVersion: this.getCurrentVersion(),
-    };
   }
 
   runIndexUpkeep() {

--- a/lib/db/schema.mjs
+++ b/lib/db/schema.mjs
@@ -1,4 +1,4 @@
-export const SCHEMA_VERSION = 18;
+export const SCHEMA_VERSION = 19;
 
 export const SCHEMA_STATEMENTS = [
   `
@@ -285,6 +285,7 @@ export const SCHEMA_STATEMENTS = [
       trace_json TEXT NOT NULL DEFAULT '{}',
       status TEXT NOT NULL DEFAULT 'active',
       linked_memory_id TEXT,
+      repository TEXT,
       superseded_by TEXT,
       proposal_type TEXT,
       proposal_path TEXT,
@@ -552,5 +553,102 @@ export const SCHEMA_STATEMENTS = [
   `
     CREATE INDEX IF NOT EXISTS idx_memory_embedding_updated
       ON memory_embedding(updated_at DESC);
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS session_evidence (
+      evidence_key TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      source_identity TEXT,
+      source_record_id TEXT,
+      source_kind TEXT NOT NULL,
+      revision TEXT NOT NULL,
+      proposition_fingerprint TEXT,
+      content_hash TEXT,
+      metadata_json TEXT NOT NULL DEFAULT '{}',
+      captured_at TEXT NOT NULL,
+      retired_at TEXT
+    );
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_session_evidence_session
+      ON session_evidence(session_id, captured_at DESC);
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_session_evidence_proposition
+      ON session_evidence(proposition_fingerprint, retired_at);
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS memory_evidence (
+      memory_id TEXT NOT NULL,
+      evidence_key TEXT NOT NULL,
+      linked_at TEXT NOT NULL,
+      retired_at TEXT,
+      PRIMARY KEY (memory_id, evidence_key),
+      FOREIGN KEY (memory_id) REFERENCES semantic_memory(id) ON DELETE CASCADE,
+      FOREIGN KEY (evidence_key) REFERENCES session_evidence(evidence_key) ON DELETE CASCADE
+    );
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_memory_evidence_evidence
+      ON memory_evidence(evidence_key, retired_at);
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_memory_evidence_memory
+      ON memory_evidence(memory_id, retired_at);
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS memory_suppression (
+      suppression_key TEXT PRIMARY KEY,
+      memory_id TEXT,
+      canonical_fingerprint TEXT,
+      scope TEXT NOT NULL DEFAULT 'repo',
+      repository TEXT,
+      evidence_fingerprint TEXT,
+      actor TEXT NOT NULL,
+      reason TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      superseded_at TEXT
+    );
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_memory_suppression_canonical
+      ON memory_suppression(canonical_fingerprint, scope, repository, superseded_at);
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_memory_suppression_evidence
+      ON memory_suppression(evidence_fingerprint, superseded_at);
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS ingestion_checkpoint (
+      client TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      source_identity TEXT,
+      offset INTEGER NOT NULL DEFAULT 0,
+      partial_record_json TEXT,
+      adapter_state_json TEXT NOT NULL DEFAULT '{}',
+      branch_state_json TEXT NOT NULL DEFAULT '{}',
+      revision TEXT,
+      last_success_at TEXT,
+      pending_bytes INTEGER NOT NULL DEFAULT 0,
+      failure_code TEXT,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY (client, session_id)
+    );
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_ingestion_checkpoint_health
+      ON ingestion_checkpoint(failure_code, updated_at DESC);
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS repository_identity_mapping (
+      legacy TEXT PRIMARY KEY,
+      canonical TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_repository_identity_mapping_canonical
+      ON repository_identity_mapping(canonical);
   `,
 ];

--- a/lib/db/schema.mjs
+++ b/lib/db/schema.mjs
@@ -558,6 +558,7 @@ export const SCHEMA_STATEMENTS = [
     CREATE TABLE IF NOT EXISTS session_evidence (
       evidence_key TEXT PRIMARY KEY,
       session_id TEXT NOT NULL,
+      repository TEXT,
       source_identity TEXT,
       source_record_id TEXT,
       source_kind TEXT NOT NULL,
@@ -607,7 +608,9 @@ export const SCHEMA_STATEMENTS = [
       actor TEXT NOT NULL,
       reason TEXT NOT NULL,
       created_at TEXT NOT NULL,
-      superseded_at TEXT
+      superseded_at TEXT,
+      repair_candidate INTEGER NOT NULL DEFAULT 0,
+      legacy_marker_fingerprint TEXT
     );
   `,
   `
@@ -622,12 +625,14 @@ export const SCHEMA_STATEMENTS = [
     CREATE TABLE IF NOT EXISTS ingestion_checkpoint (
       client TEXT NOT NULL,
       session_id TEXT NOT NULL,
+      repository TEXT,
       source_identity TEXT,
       offset INTEGER NOT NULL DEFAULT 0,
       partial_record_json TEXT,
       adapter_state_json TEXT NOT NULL DEFAULT '{}',
       branch_state_json TEXT NOT NULL DEFAULT '{}',
       revision TEXT,
+      checkpoint_revision INTEGER NOT NULL DEFAULT 0,
       last_success_at TEXT,
       pending_bytes INTEGER NOT NULL DEFAULT 0,
       failure_code TEXT,

--- a/lib/db/schema.mjs
+++ b/lib/db/schema.mjs
@@ -579,6 +579,14 @@ export const SCHEMA_STATEMENTS = [
       ON session_evidence(proposition_fingerprint, retired_at);
   `,
   `
+    CREATE INDEX IF NOT EXISTS idx_session_evidence_record
+      ON session_evidence(session_id, source_record_id);
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_session_evidence_key
+      ON session_evidence(session_id, evidence_key);
+  `,
+  `
     CREATE TABLE IF NOT EXISTS memory_evidence (
       memory_id TEXT NOT NULL,
       evidence_key TEXT NOT NULL,
@@ -612,6 +620,10 @@ export const SCHEMA_STATEMENTS = [
       repair_candidate INTEGER NOT NULL DEFAULT 0,
       legacy_marker_fingerprint TEXT
     );
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS idx_memory_suppression_memory
+      ON memory_suppression(memory_id, scope, repository, superseded_at);
   `,
   `
     CREATE INDEX IF NOT EXISTS idx_memory_suppression_canonical

--- a/lib/inference/local-inference-extraction.mjs
+++ b/lib/inference/local-inference-extraction.mjs
@@ -202,6 +202,7 @@ export async function enhanceSessionExtractionWithLocalInference({
   };
   return {
     episodeDigest,
+    retiredEvidenceKeys: extraction.retiredEvidenceKeys ?? [],
     semanticMemories: [
       ...extraction.semanticMemories,
       ...buildInferredSemanticMemories({

--- a/lib/maintenance/recovery.mjs
+++ b/lib/maintenance/recovery.mjs
@@ -7,54 +7,10 @@ import path from "node:path";
 
 import { loadFileConfigSync, mergeDeep, USER_CONFIG_DEFAULTS, isPlainObject } from "../core/config.mjs";
 import { resolveLorePaths } from "../core/lore-paths.mjs";
-import { SCHEMA_STATEMENTS, SCHEMA_VERSION } from "../db/schema.mjs";
+import { inspectDatabase, validateCanonicalShape, readCurrentSuppressions, prepareSnapshotStage } from "../db/db-snapshot-lifecycle.mjs";
 import { LoreDb } from "../db/db.mjs";
 
-const VERSION_TABLES = ["lore_schema_version", "coherence_schema_version"];
-
-function sqlQuote(value) {
-  return String(value).replaceAll("'", "''");
-}
-
-function schemaInfo(db, dbPath) {
-  const found = [];
-  for (const table of VERSION_TABLES) {
-    if (!db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name=?").get(table)) continue;
-    const rows = db.prepare(`SELECT version FROM ${table}`).all();
-    if (rows.some((row) => typeof row.version !== "number" || !Number.isInteger(row.version) || row.version < 0)) {
-      throw new Error(`malformed Lore schema version in ${table} at ${path.resolve(dbPath)}`);
-    }
-    const version = rows.length > 0 ? Math.max(...rows.map((row) => row.version)) : 0;
-    if (version > SCHEMA_VERSION) {
-      throw new Error(`unsupported future Lore schema version ${version} (supported through ${SCHEMA_VERSION}) at ${path.resolve(dbPath)}`);
-    }
-    found.push({
-      tableName: table,
-      version,
-    });
-  }
-  const selected = found[0];
-  const requiredColumns = {
-    semantic_memory: ["id", "type", "content", "created_at", "updated_at"],
-    episode_digest: ["id", "session_id", "summary", "date_key", "created_at", "updated_at"],
-  };
-  const requiredTables = Object.entries(requiredColumns).every(([table, columns]) => {
-    const actual = new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((column) => column.name));
-    return columns.every((column) => actual.has(column));
-  });
-  return { ...(selected ?? { tableName: null, version: 0 }), requiredTables };
-}
-
-function inspectDatabase(dbPath) {
-  const normalized = path.resolve(String(dbPath));
-  if (!existsSync(normalized)) return { path: normalized, exists: false, integrity: "missing", schemaVersion: null };
-  const db = new DatabaseSync(normalized, { readOnly: true });
-  try {
-    const integrity = db.prepare("PRAGMA integrity_check").get()?.integrity_check;
-    const info = schemaInfo(db, normalized);
-    return { path: normalized, exists: true, integrity: integrity === "ok" ? "ok" : integrity, schemaVersion: info.version, schemaTable: info.tableName, requiredTables: info.requiredTables };
-  } finally { db.close(); }
-}
+function sqlQuote(value) { return String(value).replaceAll("'", "''"); }
 
 export function inspectRecoveryTarget({ derivedStorePath }) {
   return inspectDatabase(derivedStorePath);
@@ -136,28 +92,6 @@ function preflightWriterLock(dbPath) {
   } finally { db.close(); }
 }
 
-function schemaShape(db) {
-  return new Map(
-    db.prepare("SELECT name FROM sqlite_master WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'").all()
-      .map(({ name }) => [name, new Set(db.prepare(`PRAGMA table_info("${name.replaceAll('"', '""')}")`).all().map((column) => column.name))]),
-  );
-}
-
-function validateCanonicalShape(db) {
-  const canonical = new DatabaseSync(":memory:");
-  try {
-    for (const statement of SCHEMA_STATEMENTS) canonical.exec(statement);
-    const expected = schemaShape(canonical);
-    const actual = schemaShape(db);
-    for (const [table, columns] of expected) {
-      const actualColumns = actual.get(table);
-      if (!actualColumns || [...columns].some((column) => !actualColumns.has(column))) {
-        throw new Error(`snapshot is not a complete Lore database (missing table or columns in ${table})`);
-      }
-    }
-  } finally { canonical.close(); }
-}
-
 function validateSnapshot(snapshotPath) {
   const result = inspectDatabase(snapshotPath);
   if (!result.exists) throw new Error(`snapshot path does not exist: ${result.path}`);
@@ -178,64 +112,6 @@ function validateSnapshot(snapshotPath) {
     } finally { db.close(); }
     return result;
   } finally { rmSync(tempDir, { recursive: true, force: true }); }
-}
-
-function readCurrentSuppressions(dbPath) {
-  if (!existsSync(dbPath)) return [];
-  let db;
-  try {
-    db = new DatabaseSync(dbPath, { readOnly: true });
-  } catch {
-    return [];
-  }
-  try {
-    const table = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_suppression'").get();
-    if (!table) return [];
-    return db.prepare(`
-      SELECT suppression_key, memory_id, canonical_fingerprint, scope, repository,
-        evidence_fingerprint, actor, reason, created_at, superseded_at,
-        repair_candidate, legacy_marker_fingerprint
-      FROM memory_suppression
-    `).all();
-  } catch {
-    return [];
-  } finally { db.close(); }
-}
-
-function mergeCurrentSuppressions(stagePath, suppressions) {
-  if (suppressions.length === 0) return;
-  const db = new DatabaseSync(stagePath);
-  try {
-    for (const statement of SCHEMA_STATEMENTS) db.exec(statement);
-    const insert = db.prepare(`
-      INSERT OR REPLACE INTO memory_suppression (
-        suppression_key, memory_id, canonical_fingerprint, scope, repository,
-        evidence_fingerprint, actor, reason, created_at, superseded_at,
-        repair_candidate, legacy_marker_fingerprint
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-    db.exec("BEGIN IMMEDIATE");
-    try {
-      for (const row of suppressions) insert.run(
-        row.suppression_key,
-        row.memory_id,
-        row.canonical_fingerprint,
-        row.scope,
-        row.repository,
-        row.evidence_fingerprint,
-        row.actor,
-        row.reason,
-        row.created_at,
-        row.superseded_at,
-        row.repair_candidate ?? 0,
-        row.legacy_marker_fingerprint ?? null,
-      );
-      db.exec("COMMIT");
-    } catch (error) {
-      db.exec("ROLLBACK");
-      throw error;
-    }
-  } finally { db.close(); }
 }
 
 export function restoreRecoverySnapshot({ derivedStorePath, snapshotPath, write = false, clientsStopped = false, preserveCurrentSuppressions = true, detectActiveUsers = defaultActiveDetector, fsOps = {} } = {}) {
@@ -262,11 +138,13 @@ export function restoreRecoverySnapshot({ derivedStorePath, snapshotPath, write 
   let installedTarget = false;
   const movedSidecars = [];
   try {
-    const stageDb = new DatabaseSync(source, { readOnly: true });
-    try { stageDb.exec(`VACUUM INTO '${sqlQuote(stage)}'`); } finally { stageDb.close(); }
-    chmodSync(stage, 0o600);
+    prepareSnapshotStage({ snapshotPath: source, stagePath: stage, suppressions: currentSuppressions,
+      upgrade: (stagePath) => {
+        const staged = new LoreDb({ paths: { derivedStorePath: stagePath, backupDir: `${stagePath}.backups` } });
+        try { staged.initialize(); } finally { staged.close(); rmSync(`${stagePath}.backups`, { recursive: true, force: true }); }
+      },
+    });
     flushFile(stage);
-    mergeCurrentSuppressions(stage, currentSuppressions);
     const stagedValidation = validateSnapshot(stage);
     if (existsSync(target)) {
       ops.renameSync(target, rescue);

--- a/lib/maintenance/recovery.mjs
+++ b/lib/maintenance/recovery.mjs
@@ -193,7 +193,8 @@ function readCurrentSuppressions(dbPath) {
     if (!table) return [];
     return db.prepare(`
       SELECT suppression_key, memory_id, canonical_fingerprint, scope, repository,
-        evidence_fingerprint, actor, reason, created_at, superseded_at
+        evidence_fingerprint, actor, reason, created_at, superseded_at,
+        repair_candidate, legacy_marker_fingerprint
       FROM memory_suppression
     `).all();
   } catch {
@@ -209,8 +210,9 @@ function mergeCurrentSuppressions(stagePath, suppressions) {
     const insert = db.prepare(`
       INSERT OR REPLACE INTO memory_suppression (
         suppression_key, memory_id, canonical_fingerprint, scope, repository,
-        evidence_fingerprint, actor, reason, created_at, superseded_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        evidence_fingerprint, actor, reason, created_at, superseded_at,
+        repair_candidate, legacy_marker_fingerprint
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `);
     db.exec("BEGIN IMMEDIATE");
     try {
@@ -225,6 +227,8 @@ function mergeCurrentSuppressions(stagePath, suppressions) {
         row.reason,
         row.created_at,
         row.superseded_at,
+        row.repair_candidate ?? 0,
+        row.legacy_marker_fingerprint ?? null,
       );
       db.exec("COMMIT");
     } catch (error) {

--- a/lib/maintenance/recovery.mjs
+++ b/lib/maintenance/recovery.mjs
@@ -180,12 +180,67 @@ function validateSnapshot(snapshotPath) {
   } finally { rmSync(tempDir, { recursive: true, force: true }); }
 }
 
-export function restoreRecoverySnapshot({ derivedStorePath, snapshotPath, write = false, clientsStopped = false, detectActiveUsers = defaultActiveDetector, fsOps = {} } = {}) {
+function readCurrentSuppressions(dbPath) {
+  if (!existsSync(dbPath)) return [];
+  let db;
+  try {
+    db = new DatabaseSync(dbPath, { readOnly: true });
+  } catch {
+    return [];
+  }
+  try {
+    const table = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'memory_suppression'").get();
+    if (!table) return [];
+    return db.prepare(`
+      SELECT suppression_key, memory_id, canonical_fingerprint, scope, repository,
+        evidence_fingerprint, actor, reason, created_at, superseded_at
+      FROM memory_suppression
+    `).all();
+  } catch {
+    return [];
+  } finally { db.close(); }
+}
+
+function mergeCurrentSuppressions(stagePath, suppressions) {
+  if (suppressions.length === 0) return;
+  const db = new DatabaseSync(stagePath);
+  try {
+    for (const statement of SCHEMA_STATEMENTS) db.exec(statement);
+    const insert = db.prepare(`
+      INSERT OR REPLACE INTO memory_suppression (
+        suppression_key, memory_id, canonical_fingerprint, scope, repository,
+        evidence_fingerprint, actor, reason, created_at, superseded_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    db.exec("BEGIN IMMEDIATE");
+    try {
+      for (const row of suppressions) insert.run(
+        row.suppression_key,
+        row.memory_id,
+        row.canonical_fingerprint,
+        row.scope,
+        row.repository,
+        row.evidence_fingerprint,
+        row.actor,
+        row.reason,
+        row.created_at,
+        row.superseded_at,
+      );
+      db.exec("COMMIT");
+    } catch (error) {
+      db.exec("ROLLBACK");
+      throw error;
+    }
+  } finally { db.close(); }
+}
+
+export function restoreRecoverySnapshot({ derivedStorePath, snapshotPath, write = false, clientsStopped = false, preserveCurrentSuppressions = true, detectActiveUsers = defaultActiveDetector, fsOps = {} } = {}) {
   const target = path.resolve(expandUserPath(derivedStorePath));
   const source = path.resolve(expandUserPath(snapshotPath));
   const validation = validateSnapshot(source);
   if (!write) return { written: false, target, snapshotPath: source, validation };
   if (!clientsStopped) throw new Error("restore --write requires explicit --clients-stopped acknowledgement");
+  const currentSuppressions = preserveCurrentSuppressions ? readCurrentSuppressions(target) : [];
   const warnings = [];
   const active = detectActiveUsers(target);
   if (active === null) warnings.push("lsof active-client detection unavailable");
@@ -207,6 +262,7 @@ export function restoreRecoverySnapshot({ derivedStorePath, snapshotPath, write 
     try { stageDb.exec(`VACUUM INTO '${sqlQuote(stage)}'`); } finally { stageDb.close(); }
     chmodSync(stage, 0o600);
     flushFile(stage);
+    mergeCurrentSuppressions(stage, currentSuppressions);
     const stagedValidation = validateSnapshot(stage);
     if (existsSync(target)) {
       ops.renameSync(target, rescue);

--- a/lib/memory/memory-scope.mjs
+++ b/lib/memory/memory-scope.mjs
@@ -62,6 +62,8 @@ const GLOBAL_PREFERENCE_PATTERNS = [
   /\bjokes?\b/i,
 ];
 
+const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:globally|across\s+(?:all\s+)?(?:projects|repositories|repos)|for\s+(?:every|all)\s+(?:project|repository|repo)|regardless\s+of\s+(?:the\s+)?repo(?:sitory)?|in\s+all\s+(?:projects|repositories|repos))\b/i;
+
 // Explicit naming vocabulary ("call you X", "your name is X", ...). Used both
 // as part of the general-purpose patterns below and, on their own, as the
 // strict set for persisting new assistant_identity memories (see
@@ -409,7 +411,13 @@ function classifyPreferenceSemanticMemory({
   if (transferable && !globalPreference) {
     return buildScopedClassification(MEMORY_SCOPE.TRANSFERABLE, repository, metadata);
   }
-  return buildScopedClassification(MEMORY_SCOPE.GLOBAL, repository, metadata);
+  if (globalPreference) {
+    return buildScopedClassification(MEMORY_SCOPE.GLOBAL, repository, metadata);
+  }
+  // An unqualified preference with no known origin is not evidence that the
+  // preference applies to every project. Keep it repository-scoped until an
+  // explicit cross-project declaration or a later repair supplies scope.
+  return buildScopedClassification(MEMORY_SCOPE.REPO, repository, metadata);
 }
 
 function classifyAssistantGoalMemory({
@@ -424,7 +432,7 @@ function classifyAssistantGoalMemory({
   if (transferable) {
     return buildScopedClassification(MEMORY_SCOPE.TRANSFERABLE, repository, metadata);
   }
-  return buildScopedClassification(MEMORY_SCOPE.GLOBAL, repository, metadata);
+  return buildScopedClassification(MEMORY_SCOPE.REPO, repository, metadata);
 }
 
 export function classifySemanticMemory(memory) {
@@ -433,6 +441,12 @@ export function classifySemanticMemory(memory) {
   const metadata = normalizeMetadata(memory.metadata);
   if (explicitScope) {
     return buildScopedClassification(explicitScope, repository, metadata);
+  }
+  // A direct memory_save is an explicit operator action. It may intentionally
+  // create a global memory without a repository; the conservative default
+  // below applies only to inferred rows.
+  if (metadata.source === "memory_save" && !repository) {
+    return buildScopedClassification(MEMORY_SCOPE.GLOBAL, repository, metadata);
   }
 
   const text = textFromParts([
@@ -456,7 +470,10 @@ export function classifySemanticMemory(memory) {
 
   const repoSpecific = hasPattern(text, REPO_SPECIFIC_PATTERNS);
   const transferable = hasPattern(text, TRANSFERABLE_PATTERNS);
-  const globalPreference = hasPattern(text, GLOBAL_PREFERENCE_PATTERNS);
+  const globalPreference = hasPattern(text, [
+    ...GLOBAL_PREFERENCE_PATTERNS,
+    EXPLICIT_GLOBAL_SCOPE_PATTERN,
+  ]);
 
   const preferenceClassification = classifyPreferenceSemanticMemory({
     type,
@@ -484,7 +501,7 @@ export function classifySemanticMemory(memory) {
   }
 
   if (!repository) {
-    return buildScopedClassification(MEMORY_SCOPE.GLOBAL, repository, metadata);
+    return buildScopedClassification(MEMORY_SCOPE.REPO, repository, metadata);
   }
 
   return buildScopedClassification(MEMORY_SCOPE.REPO, repository, metadata);

--- a/lib/memory/memory-scope.mjs
+++ b/lib/memory/memory-scope.mjs
@@ -99,18 +99,12 @@ const ASSISTANT_IDENTITY_PATTERNS = [
 // "Error:", "Review:", "Hey dude,", etc. - any sentence-initial word followed
 // by punctuation matches that shape, not just a name).
 export function detectAssistantIdentityDeclaration(text) {
-  const normalized = normalizeText(text);
-  if (!normalized) {
-    return null;
-  }
-  for (const pattern of ASSISTANT_IDENTITY_DECLARATION_PATTERNS) {
-    const match = normalized.match(pattern);
-    const candidate = toAssistantDisplayName(match?.[1]);
-    if (candidate) {
-      return candidate;
-    }
-  }
-  return null;
+  const normalized = normalizeText(text).replace(/^(?:ok|okay)[,:]\s*/i, "");
+  // Persistence requires a direct declaration; the loose prompt-time detector
+  // below can still recognize names mentioned in a question or greeting.
+  if (!normalized || /[?"“”`]/u.test(normalized)) return null;
+  const match = normalized.match(/^(?:please\s+)?(?:call (?:you|yourself)|your name is|use (?:the )?name|i(?:'ll| will) call you)\s+([a-z][a-z0-9_-]{1,31})(?:\b|$)/i);
+  return toAssistantDisplayName(match?.[1]);
 }
 
 const ASSISTANT_IDENTITY_STOPWORDS = new Set([
@@ -369,8 +363,14 @@ function classifyFixedSemanticMemory({ type, text, repository, metadata }) {
     "interaction_style",
     "user_identity",
     "directive",
-    "recurring_mistake",
   ]);
+  if (type === "recurring_mistake") {
+    return buildScopedClassification(
+      EXPLICIT_GLOBAL_SCOPE_PATTERN.test(text) ? MEMORY_SCOPE.GLOBAL : MEMORY_SCOPE.REPO,
+      repository,
+      metadata,
+    );
+  }
   if (globalTypes.has(type)) {
     return buildScopedClassification(MEMORY_SCOPE.GLOBAL, repository, metadata);
   }

--- a/lib/memory/memory-scope.mjs
+++ b/lib/memory/memory-scope.mjs
@@ -62,7 +62,7 @@ const GLOBAL_PREFERENCE_PATTERNS = [
   /\bjokes?\b/i,
 ];
 
-const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:globally|across\s+(?:all\s+)?(?:projects|repositories|repos)|for\s+(?:every|all)\s+(?:project|repository|repo)|regardless\s+of\s+(?:the\s+)?repo(?:sitory)?|in\s+all\s+(?:projects|repositories|repos))\b/i;
+const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:globally|across\s+(?:all\s+)?(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|for\s+(?:every|all)\s+(?:my\s+)?(?:project|repository|repo)|regardless\s+of\s+(?:the\s+)?repo(?:sitory)?|in\s+all\s+(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos))\b/i;
 
 // Explicit naming vocabulary ("call you X", "your name is X", ...). Used both
 // as part of the general-purpose patterns below and, on their own, as the

--- a/lib/sessions/backfill.mjs
+++ b/lib/sessions/backfill.mjs
@@ -121,6 +121,16 @@ export function applySessionExtraction({
   workspace,
   extraction: suppliedExtraction = null,
 }) {
+  if (!db.pendingSemanticDurability) {
+    return db.withSemanticMemoryTransaction(() => applySessionExtraction({
+      db,
+      sessionId,
+      repository,
+      sessionArtifacts,
+      workspace,
+      extraction: suppliedExtraction,
+    }));
+  }
   const extraction = suppliedExtraction ?? extractSessionMemories({
     sessionId,
     repository,

--- a/lib/sessions/backfill.mjs
+++ b/lib/sessions/backfill.mjs
@@ -1,5 +1,4 @@
 import { buildSemanticCanonicalKey } from "../memory/memory-scope.mjs";
-import { retainMemory } from "../memory/memory-operations.mjs";
 import { extractSessionMemories } from "./rule-extractor.mjs";
 import { enhanceSessionExtractionWithLocalInference } from "../inference/local-inference-extraction.mjs";
 import { setTimeout as delay } from "node:timers/promises";
@@ -129,19 +128,18 @@ export function applySessionExtraction({
     workspace,
     config: db.config,
   });
-  db.deleteGeneratedSemanticMemories(sessionId);
   db.upsertEpisodeDigest(extraction.episodeDigest);
   db.refreshDaySummary({
     date: extraction.episodeDigest.dateKey,
     repository: extraction.episodeDigest.repository,
   });
-  for (const memory of extraction.semanticMemories) {
-    const retained = retainMemory({
-      db,
-      kind: "semantic",
-      memory,
-    });
-    const linkedMemoryId = retained.id;
+  const linkedMemoryIds = db.reconcileGeneratedMemories({
+    sessionId,
+    repository,
+    memories: extraction.semanticMemories,
+  });
+  for (const [index, memory] of extraction.semanticMemories.entries()) {
+    const linkedMemoryId = linkedMemoryIds[index] ?? null;
     if (!linkedMemoryId) {
       continue;
     }

--- a/lib/sessions/backfill.mjs
+++ b/lib/sessions/backfill.mjs
@@ -137,6 +137,7 @@ export function applySessionExtraction({
     sessionId,
     repository,
     memories: extraction.semanticMemories,
+    retiredEvidenceKeys: extraction.retiredEvidenceKeys ?? [],
   });
   for (const [index, memory] of extraction.semanticMemories.entries()) {
     const linkedMemoryId = linkedMemoryIds[index] ?? null;

--- a/lib/sessions/decision-subject.mjs
+++ b/lib/sessions/decision-subject.mjs
@@ -12,14 +12,16 @@ function normalizeSubject(value) {
 }
 
 function decisionParts(memory) {
-  const [choice, ...rationale] = memory.content.replace(/^Decision:\s*/i, "").split(/\s+because\s+/i);
+  const [contentChoice, ...contentRationale] = memory.content.replace(/^Decision:\s*/i, "").split(/\s+because\s+/i);
+  const choice = memory.metadata?.decisionChoice ?? contentChoice;
+  const rationale = memory.metadata?.decisionRationale ?? contentRationale.join(" because ");
   // Purpose/subject belongs to the choice. Reasons such as reliability and
   // performance describe why it was chosen, and cannot establish its subject.
   const topic = choice.match(/\b(?:for|about|regarding)\s+(.+)$/i)?.[1];
   return {
     choice: normalizeSubject(choice),
     topic: topic ? normalizeSubject(topic) : null,
-    rationale: rationale.join(" because "),
+    rationale,
   };
 }
 

--- a/lib/sessions/decision-subject.mjs
+++ b/lib/sessions/decision-subject.mjs
@@ -67,6 +67,7 @@ export function collectRetiredDecisionEvidenceKeys(memories) {
     for (let priorIndex = 0; priorIndex < index; priorIndex += 1) {
       const prior = decisions[priorIndex];
       if (prior.scope === current.scope && prior.repository === current.repository
+        && parts[priorIndex].choice !== parts[index].choice
         && referencedSubject(parts[priorIndex], parts[index], references)) {
         candidates.push(priorIndex);
       }
@@ -75,7 +76,9 @@ export function collectRetiredDecisionEvidenceKeys(memories) {
     // invalidation from inventory invalidation. Preserve both until clarified.
     const subjects = new Set(candidates.map((priorIndex) => parts[priorIndex].topic));
     if (subjects.size === 1) {
-      retired.add(decisions[candidates.at(-1)].evidence.key);
+      for (const priorIndex of candidates) {
+        retired.add(decisions[priorIndex].evidence.key);
+      }
     }
   }
   return [...retired];

--- a/lib/sessions/decision-subject.mjs
+++ b/lib/sessions/decision-subject.mjs
@@ -1,0 +1,82 @@
+import { normalizeText } from "../utils/text-normalizer.mjs";
+
+function normalizeSubject(value) {
+  return normalizeText(value).toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .trim()
+    .replace(/\s+(?:instead|rather)$/, "")
+    .replace(/^(?:a|an|the|this|our)\s+/, "")
+    .split(/\s+/)
+    .map((word) => word.replace(/ies$/, "y").replace(/(?<![siu])s$/, ""))
+    .join(" ");
+}
+
+function decisionParts(memory) {
+  const [choice, ...rationale] = memory.content.replace(/^Decision:\s*/i, "").split(/\s+because\s+/i);
+  // Purpose/subject belongs to the choice. Reasons such as reliability and
+  // performance describe why it was chosen, and cannot establish its subject.
+  const topic = choice.match(/\b(?:for|about|regarding)\s+(.+)$/i)?.[1];
+  return {
+    choice: normalizeSubject(choice),
+    topic: topic ? normalizeSubject(topic) : null,
+    rationale: rationale.join(" because "),
+  };
+}
+
+function affectedObjects(rationale) {
+  // An explicitly affected object can refer back to a known subject: e.g.
+  // "for catalog invalidation" / "because losing invalidations is unacceptable".
+  // This is deliberately narrower than matching arbitrary rationale words.
+  return [...rationale.matchAll(/\b(?:losing|dropping|duplicating|corrupting|loss\s+of)\s+(.+?)(?=\s+(?:is|are|was|were|would|will)\b|[.,;]|$)/gi)]
+    .map((match) => normalizeSubject(match[1]));
+}
+
+function containsSubject(phrase, subject) {
+  return ` ${phrase} `.includes(` ${subject} `);
+}
+
+function referencedSubject(prior, current, objects) {
+  if (!prior.topic) {
+    return false;
+  }
+  if (current.topic) {
+    // Distinct explicit subjects are never joined by a shared head noun,
+    // selected technology, or rationale.
+    return prior.topic === current.topic;
+  }
+  if (containsSubject(current.choice, prior.topic)) {
+    return true;
+  }
+  return objects.some((object) => object === prior.topic
+    || (object.split(" ").length === 1 && prior.topic.split(" ").at(-1) === object));
+}
+
+export function collectRetiredDecisionEvidenceKeys(memories) {
+  const decisions = memories
+    .filter((memory) => memory.type === "decision" && memory.evidence?.key)
+    .sort((left, right) => (left.sourceTurnIndex ?? 0) - (right.sourceTurnIndex ?? 0));
+  const parts = decisions.map(decisionParts);
+  const retired = new Set();
+  for (let index = 0; index < decisions.length; index += 1) {
+    const current = decisions[index];
+    if (current.metadata?.decisionStatus !== "reversal") {
+      continue;
+    }
+    const references = affectedObjects(parts[index].rationale);
+    const candidates = [];
+    for (let priorIndex = 0; priorIndex < index; priorIndex += 1) {
+      const prior = decisions[priorIndex];
+      if (prior.scope === current.scope && prior.repository === current.repository
+        && referencedSubject(parts[priorIndex], parts[index], references)) {
+        candidates.push(priorIndex);
+      }
+    }
+    // A partial reference such as "invalidations" cannot disambiguate catalog
+    // invalidation from inventory invalidation. Preserve both until clarified.
+    const subjects = new Set(candidates.map((priorIndex) => parts[priorIndex].topic));
+    if (subjects.size === 1) {
+      retired.add(decisions[candidates.at(-1)].evidence.key);
+    }
+  }
+  return [...retired];
+}

--- a/lib/sessions/directive-corrections.mjs
+++ b/lib/sessions/directive-corrections.mjs
@@ -1,0 +1,30 @@
+import { normalizeText } from "../utils/text-normalizer.mjs";
+
+export function collectRetiredDirectiveEvidenceKeys(memories, turns) {
+  const retired = new Set();
+  let previousUserTurn = null;
+  for (const turn of turns) {
+    const message = normalizeText(turn.user_message);
+    if (!message) continue;
+    // "No, I meant ..." explicitly replaces the immediately addressed request.
+    // Resolve only a single prior preference; multiple topics or an intervening
+    // user question require clarification rather than guessing the antecedent.
+    if (/^(?:no,?\s+i\s+meant\b|actually,?\s+that(?:'s| is)\s+wrong\s*:)/i.test(message) && previousUserTurn) {
+      const replacements = memories.filter((memory) => memory.type === "user_preference" && memory.sourceTurnIndex === turn.turn_index);
+      const previous = memories.filter((memory) => memory.type === "user_preference" && memory.sourceTurnIndex === previousUserTurn.turn_index);
+      if (replacements.length === 1 && previous.length === 1
+        && replacements[0].scope === previous[0].scope && replacements[0].repository === previous[0].repository
+        && replacements[0].content !== previous[0].content) {
+        for (const memory of memories) {
+          if (memory.type === previous[0].type && memory.scope === previous[0].scope
+            && memory.repository === previous[0].repository && memory.sourceTurnIndex < turn.turn_index
+            && normalizeText(memory.content).toLowerCase() === normalizeText(previous[0].content).toLowerCase()) {
+            retired.add(memory.evidence.key);
+          }
+        }
+      }
+    }
+    previousUserTurn = turn;
+  }
+  return [...retired];
+}

--- a/lib/sessions/extraction-grammar.mjs
+++ b/lib/sessions/extraction-grammar.mjs
@@ -88,8 +88,8 @@ export function isHypotheticalDirectiveSentence(text) {
 export function isOneOffDirectiveRequest(text) {
   const body = directiveBody(text);
   const scopedText = text.replace(EXPLICIT_SCOPE_PREAMBLE_PATTERN, "");
-  if (/\b(?:just\s+this\s+once|this\s+time|for\s+(?:now|today)|(?:for|during)\s+this\s+(?:incident|run|request|attempt|reproduction|session|task)|(?:right\s+)?now|today)\b/i.test(body)
-    || /^(?:for|during)\s+this\s+(?:incident|run|request|attempt|reproduction|session|task)\b/i.test(text)) {
+  if (/\b(?:just\s+this\s+once|this\s+time|for\s+(?:now|today)|(?:for|during)\s+this\s+(?:incident|run|request|response|reply|answer|attempt|reproduction|session|task)|(?:right\s+)?now|today)\b/i.test(body)
+    || /^(?:for|during)\s+this\s+(?:incident|run|request|response|reply|answer|attempt|reproduction|session|task)\b/i.test(text)) {
     return true;
   }
   if (/^(?:as\s+(?:a\s+)?policy|in\s+(?:the\s+)?future|going\s+forward|from\s+now\s+on)\b/i.test(scopedText)

--- a/lib/sessions/extraction-grammar.mjs
+++ b/lib/sessions/extraction-grammar.mjs
@@ -1,6 +1,6 @@
 import { normalizeText } from "../utils/text-normalizer.mjs";
 
-export function splitSentences(value) {
+export function splitSentences(value, { splitSemicolons = true } = {}) {
   const sentences = [];
   let current = "";
   let quote = null;
@@ -30,7 +30,7 @@ export function splitSentences(value) {
       current = "";
       continue;
     }
-    if (!quote && /[.!?;]/.test(character) && (index === text.length - 1 || /\s/.test(text[index + 1]))) {
+    if (!quote && (splitSemicolons ? /[.!?;]/ : /[.!?]/).test(character) && (index === text.length - 1 || /\s/.test(text[index + 1]))) {
       const sentence = normalizeText(current);
       if (sentence) {
         sentences.push(sentence);
@@ -47,7 +47,7 @@ export function splitSentences(value) {
 
 export function splitDirectiveClauses(sentence) {
   return sentence
-    .split(/\s+(?:and|but)\s+(?=(?:never|do\s+not|don't|avoid|please)\b)|\s+so\s+(?=please\s+(?:use|prefer|keep|include)\b)/i)
+    .split(/;\s*|\s+(?:and|but)\s+(?=(?:never|do\s+not|don't|avoid|please)\b)|\s+so\s+(?=please\s+(?:use|prefer|keep|include)\b)/i)
     .map((clause) => clause.replace(/;+$/, "").trim())
     .filter(Boolean);
 }
@@ -56,28 +56,30 @@ function isQuotedSentence(text) {
   return /["“”‘`]|(?:^|[\s:(])'/.test(text);
 }
 
-export function isNonDirectiveSentence(text) {
+export function isNonDirectiveSentence(text, { allowConditions = false } = {}) {
   return !text
     || text.endsWith("?")
     || isQuotedSentence(text)
-    || /^(?:if|unless|when|suppose|imagine|assuming|should we|could we|would you|could you|can you|what if)\b/i.test(text)
+    || /^(?:suppose|imagine|assuming|should we|could we|would you|could you|can you|what if)\b/i.test(text)
+    || (!allowConditions && /^(?:if|unless|when)\b/i.test(text))
     || /\b(?:don't|do not|never|not)\s+(?:really\s+)?prefer\b/i.test(text)
     || /\bprefer\s+not\s+to\b/i.test(text)
     || /\bi\s+meant\s+to\s+(?:ask|know|understand)\b/i.test(text)
     || /\b(?:would|could|might|may)\s+(?:prefer|use|choose|avoid)\b/i.test(text);
 }
 
-const EXPLICIT_SCOPE_PREAMBLE_PATTERN = /^(?:(?:for|in)\s+(?:this|the current)(?:\s+[a-z][a-z0-9_-]*){0,2}\s+(?:repo(?:sitory)?|project|app)|for\s+[a-z][a-z0-9_-]*(?:\s+[a-z][a-z0-9_-]*){0,4}|(?:across|in|for)\s+all\s+(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|make\s+(?:this\s+)?rule\s+global\s+across\s+(?:all\s+)?(?:projects|repositories|repos)|globally)\s*(?:,|:)\s*/i;
+const EXPLICIT_SCOPE_PREAMBLE_PATTERN = /^(?:(?:for|in)\s+(?:this|the current)(?:\s+[a-z][a-z0-9_-]*){0,2}\s+(?:repo(?:sitory)?|project|app)|for\s+[a-z][a-z0-9_-]*(?:\s+[a-z][a-z0-9_-]*){0,4}|(?:across|in|for)\s+(?:all\s+)?(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|make\s+(?:this\s+)?rule\s+global\s+across\s+(?:all\s+)?(?:projects|repositories|repos)|globally)\s*(?:,|:)\s*/i;
 
 export function directiveBody(text) {
   return String(text || "")
     .replace(EXPLICIT_SCOPE_PREAMBLE_PATTERN, "")
     .replace(/^(?:as\s+(?:a\s+)?policy|in\s+(?:the\s+)?future|going\s+forward|from\s+now\s+on)\s*(?:,|:)\s*/i, "")
+    .replace(/^(?:if|when|whenever|unless)\s+[^,]+,\s*/i, "")
     .replace(/^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i, "");
 }
 
-export function isConditionalDirectiveSentence(text) {
-  return /\b(?:if|unless|when)\b/i.test(text);
+export function isHypotheticalDirectiveSentence(text) {
+  return /\b(?:if|when|unless)\b[^.!?;]*\b(?:ever|were\s+to)\b|\b(?:might|could|would|may)\s+(?:prefer|use|choose|avoid)|\b(?:hypothetical|only\s+a\s+scenario|not\s+current\s+guidance)\b/i.test(text);
 }
 
 // A topic (payments, failures, logging) does not make a request temporary.
@@ -96,8 +98,31 @@ export function isOneOffDirectiveRequest(text) {
     || /\b(?:each|every)\s+[a-z]|\b(?:all|future)\s+(?:requests|responses|reports|incidents|mutations|reviews|commits|runs|projects)\b/i.test(body)) {
     return false;
   }
-  return /\b(?:a|an|this|that|the)\s+(?:[a-z-]+\s+){0,2}(?:attachment|report|reproduction|request|response|incident|issue)\b(?=\s+(?:to|for|in|into|from|open|closed|updated|and|but)\b|[.,;]|$)/i.test(body)
-    || /\b(?:this|that|the)\s+(?:(?:currently|failing|failed|captured|broken|payment|bug)\s+){1,3}(?:request|response|endpoint|logs?|report|issue|reproduction)\b/i.test(body)
-    || /\b(?:this|that|the)\s+(?:bug|incident|issue|reproduction)\b/i.test(body)
-    || /^(?:please\s+)?(?:run|check|inspect|reproduce|attach|report)\b/i.test(body);
+  const target = body.split(/\s+(?:before|after|when|because|so)\s+/i)[0];
+  return /\b(?:a|an|this|that|the)\s+(?:[a-z-]+\s+){0,2}(?:attachment|report|reproduction|request|response|incident|issue)\b(?=\s+(?:to|for|in|into|from|open|closed|updated|and|but)\b|[.,;]|$)/i.test(target)
+    || /\b(?:this|that|the)\s+(?:(?:currently|failing|failed|captured|broken|payment|bug)\s+){1,3}(?:request|response|endpoint|logs?|report|issue|reproduction)\b/i.test(target)
+    || /\b(?:this|that|the)\s+(?:bug|incident|issue|reproduction)\b/i.test(target)
+    || /^(?:please\s+)?(?:run|check|inspect|reproduce|attach|report)\s+(?:(?:the|this|that|a|an)\s+|tests?[.!]?\s*$)/i.test(target);
+}
+
+// Anchored imperative verbs describe a requested rule, rather than a keyword
+// occurring inside an observation. Conditions and temporary targets are checked
+// separately, before this syntactic classification.
+const POLICY_VERBS = "use|keep|require|preserve|redact|validate|run|schedule|key|read|sample|expose|represent|chain|store|fall back|send|write|version|name|classify|fail|return|rotate|encrypt|publish|renew|cap|inject|index|move|pause|distinguish|set|propagate|invalidate|limit|process|record|infer|retain|restore|parse|tell|link|label|acknowledge|explain|put|format|include|split|ask|check|make";
+const IMPERATIVE_RULE = new RegExp(`^(?:please\\s+)?(?:always\\s+)?(?:${POLICY_VERBS})\\s+.+$`, "i");
+const PROHIBITION_VERBS = `${POLICY_VERBS}|retry|commit|push|delete|merge|overwrite|ignore|assume|rely|start|choose|concatenate|cast|truncate|emit|print|drop|remove`;
+const PROHIBITION = new RegExp(`^(?:please\\s+)?(?:do not|don't|never)\\s+(?:[a-z]+ly\\s+|ever\\s+)?(?:${PROHIBITION_VERBS})\\s+.+$`, "i");
+const SUBJECT_REQUIREMENT = /^[a-z][a-z0-9 ,'-]{1,90}?\s+(?:must|should)\s+(?:(?:not|never)\s+)?[a-z]+\b/i;
+
+export function standingDirectiveType(text) {
+  const body = directiveBody(text);
+  if (PROHIBITION.test(body) || /^(?:please\s+)?(?:reject|avoid|stop)\s+.+/i.test(body)) return "rejected_approach";
+  const mainClause = body.split(/\s+(?:because|so|before|after|when)\s+/i)[0];
+  if (/\b(?:says|said|asked|whether|claims|claimed|suggests|suggested|proposes|proposed)\b/i.test(mainClause)) return null;
+  if (SUBJECT_REQUIREMENT.test(mainClause)) {
+    return /\b(?:must|should)\s+(?:not|never)\b/i.test(mainClause) ? "rejected_approach" : "user_preference";
+  }
+  if (/^[a-z][a-z0-9 ,'-]{1,90}?\s+is\s+not\s+acceptable\b/i.test(body)) return "rejected_approach";
+  if (/^[a-z][a-z0-9 ,'-]{1,90}?\s+(?:is|are)\s+mandatory\b/i.test(body)) return "user_preference";
+  return IMPERATIVE_RULE.test(body) ? "user_preference" : null;
 }

--- a/lib/sessions/extraction-grammar.mjs
+++ b/lib/sessions/extraction-grammar.mjs
@@ -1,0 +1,103 @@
+import { normalizeText } from "../utils/text-normalizer.mjs";
+
+export function splitSentences(value) {
+  const sentences = [];
+  let current = "";
+  let quote = null;
+  const text = String(value || "");
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    current += character;
+    if (character === "`" || (character === "'" && (quote === "'" || !/[a-z0-9]/i.test(text[index - 1] ?? "")))) {
+      quote = quote === character ? null : (quote ?? character);
+    } else if (character === '"') {
+      quote = quote === '"' ? null : (quote ?? '"');
+    } else if (character === "“") {
+      quote = "”";
+    } else if (character === "”" && quote === "”") {
+      quote = null;
+    } else if (character === "‘") {
+      quote = "’";
+    } else if (character === "’" && quote === "’") {
+      quote = null;
+    }
+    if (!quote && /["”’\x27`]/.test(character) && /[.!?;]/.test(text[index - 1] ?? "")
+      && (index === text.length - 1 || /\s/.test(text[index + 1]))) {
+      const sentence = normalizeText(current);
+      if (sentence) {
+        sentences.push(sentence);
+      }
+      current = "";
+      continue;
+    }
+    if (!quote && /[.!?;]/.test(character) && (index === text.length - 1 || /\s/.test(text[index + 1]))) {
+      const sentence = normalizeText(current);
+      if (sentence) {
+        sentences.push(sentence);
+      }
+      current = "";
+    }
+  }
+  const remainder = normalizeText(current);
+  if (remainder) {
+    sentences.push(remainder);
+  }
+  return sentences;
+}
+
+export function splitDirectiveClauses(sentence) {
+  return sentence
+    .split(/\s+(?:and|but)\s+(?=(?:never|do\s+not|don't|avoid|please)\b)|\s+so\s+(?=please\s+(?:use|prefer|keep|include)\b)/i)
+    .map((clause) => clause.replace(/;+$/, "").trim())
+    .filter(Boolean);
+}
+
+function isQuotedSentence(text) {
+  return /["“”‘`]|(?:^|[\s:(])'/.test(text);
+}
+
+export function isNonDirectiveSentence(text) {
+  return !text
+    || text.endsWith("?")
+    || isQuotedSentence(text)
+    || /^(?:if|unless|when|suppose|imagine|assuming|should we|could we|would you|could you|can you|what if)\b/i.test(text)
+    || /\b(?:don't|do not|never|not)\s+(?:really\s+)?prefer\b/i.test(text)
+    || /\bprefer\s+not\s+to\b/i.test(text)
+    || /\bi\s+meant\s+to\s+(?:ask|know|understand)\b/i.test(text)
+    || /\b(?:would|could|might|may)\s+(?:prefer|use|choose|avoid)\b/i.test(text);
+}
+
+const EXPLICIT_SCOPE_PREAMBLE_PATTERN = /^(?:(?:for|in)\s+(?:this|the current)(?:\s+[a-z][a-z0-9_-]*){0,2}\s+(?:repo(?:sitory)?|project|app)|for\s+[a-z][a-z0-9_-]*(?:\s+[a-z][a-z0-9_-]*){0,4}|(?:across|in|for)\s+all\s+(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|make\s+(?:this\s+)?rule\s+global\s+across\s+(?:all\s+)?(?:projects|repositories|repos)|globally)\s*(?:,|:)\s*/i;
+
+export function directiveBody(text) {
+  return String(text || "")
+    .replace(EXPLICIT_SCOPE_PREAMBLE_PATTERN, "")
+    .replace(/^(?:as\s+(?:a\s+)?policy|in\s+(?:the\s+)?future|going\s+forward|from\s+now\s+on)\s*(?:,|:)\s*/i, "")
+    .replace(/^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i, "");
+}
+
+export function isConditionalDirectiveSentence(text) {
+  return /\b(?:if|unless|when)\b/i.test(text);
+}
+
+// A topic (payments, failures, logging) does not make a request temporary.
+// Explicit duration wins; otherwise distinguish a particular incident artifact
+// from a standing rule about a class of work.
+export function isOneOffDirectiveRequest(text) {
+  const body = directiveBody(text);
+  const scopedText = text.replace(EXPLICIT_SCOPE_PREAMBLE_PATTERN, "");
+  if (/\b(?:just\s+this\s+once|this\s+time|for\s+(?:now|today)|(?:for|during)\s+this\s+(?:incident|run|request|attempt|reproduction|session|task)|(?:right\s+)?now|today)\b/i.test(body)
+    || /^(?:for|during)\s+this\s+(?:incident|run|request|attempt|reproduction|session|task)\b/i.test(text)) {
+    return true;
+  }
+  if (/^(?:as\s+(?:a\s+)?policy|in\s+(?:the\s+)?future|going\s+forward|from\s+now\s+on)\b/i.test(scopedText)
+    || /^(?:please\s+)?(?:(?:i|we)\s+)?(?:always|never|prefer)\b/i.test(body)
+    || /^(?:i|we)\s+(?:really\s+)?prefer\b|^my\s+preference\s+is\b|^remember\b/i.test(body)
+    || /\b(?:each|every)\s+[a-z]|\b(?:all|future)\s+(?:requests|responses|reports|incidents|mutations|reviews|commits|runs|projects)\b/i.test(body)) {
+    return false;
+  }
+  return /\b(?:a|an|this|that|the)\s+(?:[a-z-]+\s+){0,2}(?:attachment|report|reproduction|request|response|incident|issue)\b(?=\s+(?:to|for|in|into|from|open|closed|updated|and|but)\b|[.,;]|$)/i.test(body)
+    || /\b(?:this|that|the)\s+(?:(?:currently|failing|failed|captured|broken|payment|bug)\s+){1,3}(?:request|response|endpoint|logs?|report|issue|reproduction)\b/i.test(body)
+    || /\b(?:this|that|the)\s+(?:bug|incident|issue|reproduction)\b/i.test(body)
+    || /^(?:please\s+)?(?:run|check|inspect|reproduce|attach|report)\b/i.test(body);
+}

--- a/lib/sessions/extraction-grammar.mjs
+++ b/lib/sessions/extraction-grammar.mjs
@@ -110,7 +110,7 @@ export function isOneOffDirectiveRequest(text) {
 // separately, before this syntactic classification.
 const POLICY_VERBS = "use|keep|require|preserve|redact|validate|run|schedule|key|read|sample|expose|represent|chain|store|fall back|send|write|version|name|classify|fail|return|rotate|encrypt|publish|renew|cap|inject|index|move|pause|distinguish|set|propagate|invalidate|limit|process|record|infer|retain|restore|parse|tell|link|label|acknowledge|explain|put|format|include|split|ask|check|make";
 const IMPERATIVE_RULE = new RegExp(`^(?:please\\s+)?(?:always\\s+)?(?:${POLICY_VERBS})\\s+.+$`, "i");
-const PROHIBITION_VERBS = `${POLICY_VERBS}|retry|commit|push|delete|merge|overwrite|ignore|assume|rely|start|choose|concatenate|cast|truncate|emit|print|drop|remove`;
+const PROHIBITION_VERBS = `${POLICY_VERBS}|retry|commit|push|delete|merge|overwrite|ignore|assume|rely|start|choose|concatenate|cast|truncate|emit|print|drop|remove|disable`;
 const PROHIBITION = new RegExp(`^(?:please\\s+)?(?:do not|don't|never)\\s+(?:[a-z]+ly\\s+|ever\\s+)?(?:${PROHIBITION_VERBS})\\s+.+$`, "i");
 const SUBJECT_REQUIREMENT = /^[a-z][a-z0-9 ,'-]{1,90}?\s+(?:must|should)\s+(?:(?:not|never)\s+)?[a-z]+\b/i;
 

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -6,7 +6,16 @@ import {
 import { createHash } from "node:crypto";
 import { normalizeText } from "../utils/text-normalizer.mjs";
 import { readRetentionSanitizationEnabled } from "../rollout/rollout-flags.mjs";
+import { collectRetiredDecisionEvidenceKeys } from "./decision-subject.mjs";
 import { stripInjectedContext } from "../memory/retention-sanitizer.mjs";
+import {
+  directiveBody,
+  isConditionalDirectiveSentence,
+  isNonDirectiveSentence,
+  isOneOffDirectiveRequest,
+  splitDirectiveClauses,
+  splitSentences,
+} from "./extraction-grammar.mjs";
 
 function normalizeTurnText(value, config = null) {
   const text = readRetentionSanitizationEnabled(config)
@@ -26,114 +35,6 @@ function normalizeEvidenceText(value) {
     .replace(/[^a-z0-9\s-]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-}
-
-function splitSentences(value) {
-  const sentences = [];
-  let current = "";
-  let quote = null;
-  const text = String(value || "");
-  for (let index = 0; index < text.length; index += 1) {
-    const character = text[index];
-    current += character;
-    if (character === '"') {
-      quote = quote === '"' ? null : (quote ?? '"');
-    } else if (character === "“") {
-      quote = "”";
-    } else if (character === "”" && quote === "”") {
-      quote = null;
-    } else if (character === "‘") {
-      quote = "’";
-    } else if (character === "’" && quote === "’") {
-      quote = null;
-    }
-    if (!quote && /["”’]/.test(character) && /[.!?;]/.test(text[index - 1] ?? "")
-      && (index === text.length - 1 || /\s/.test(text[index + 1]))) {
-      const sentence = normalizeText(current);
-      if (sentence) {
-        sentences.push(sentence);
-      }
-      current = "";
-      continue;
-    }
-    if (!quote && /[.!?;]/.test(character) && (index === text.length - 1 || /\s/.test(text[index + 1]))) {
-      const sentence = normalizeText(current);
-      if (sentence) {
-        sentences.push(sentence);
-      }
-      current = "";
-    }
-  }
-  const remainder = normalizeText(current);
-  if (remainder) {
-    sentences.push(remainder);
-  }
-  return sentences;
-}
-
-function splitDirectiveClauses(sentence) {
-  return sentence
-    .split(/\s+(?:and|but)\s+(?=(?:never|do\s+not|don't|avoid|please)\b)|\s+so\s+(?=please\s+(?:use|prefer|keep|include)\b)/i)
-    .map((clause) => clause.replace(/;+$/, "").trim())
-    .filter(Boolean);
-}
-
-function isQuotedSentence(text) {
-  const quoteRanges = [];
-  const quotePattern = /["“”‘’]/g;
-  let openQuote = null;
-  for (const match of text.matchAll(quotePattern)) {
-    const quote = match[0];
-    if (quote === "“" || quote === "‘" || (quote === '"' && openQuote === null)) {
-      openQuote = match.index;
-      continue;
-    }
-    if (openQuote !== null) {
-      quoteRanges.push([openQuote, match.index + 1]);
-      openQuote = null;
-    }
-  }
-  if (openQuote !== null) {
-    quoteRanges.push([openQuote, text.length]);
-  }
-  return quoteRanges.length > 0;
-}
-
-function isNonDirectiveSentence(text) {
-  return !text
-    || text.endsWith("?")
-    || isQuotedSentence(text)
-    || /^(?:if|unless|when|suppose|imagine|assuming|should we|could we|would you|could you|can you|what if)\b/i.test(text)
-    || /\b(?:don't|do not|never|not)\s+(?:really\s+)?prefer\b/i.test(text)
-    || /\bprefer\s+not\s+to\b/i.test(text)
-    || /\bi\s+meant\s+to\s+(?:ask|know|understand)\b/i.test(text)
-    || /\b(?:would|could|might|may)\s+(?:prefer|use|choose|avoid)\b/i.test(text);
-}
-
-const EXPLICIT_SCOPE_PREAMBLE_PATTERN = /^(?:(?:for|in)\s+(?:this|the current)(?:\s+[a-z][a-z0-9_-]*){0,2}\s+(?:repo(?:sitory)?|project|app)|for\s+[a-z][a-z0-9_-]*(?:\s+[a-z][a-z0-9_-]*){0,4}|(?:across|in|for)\s+all\s+(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|make\s+(?:this\s+)?rule\s+global\s+across\s+(?:all\s+)?(?:projects|repositories|repos)|globally)\s*(?:,|:)\s*/i;
-
-function directiveBody(text) {
-  return String(text || "")
-    .replace(EXPLICIT_SCOPE_PREAMBLE_PATTERN, "")
-    .replace(/^(?:as\s+(?:a\s+)?policy|in\s+(?:the\s+)?future|going\s+forward)\s*(?:,|:)\s*/i, "")
-    .replace(/^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i, "");
-}
-
-function isConditionalDirectiveSentence(text) {
-  return /\b(?:if|unless|when)\b/i.test(text);
-}
-
-function isOneOffIncidentRequest(text) {
-  const body = directiveBody(text);
-  const incidentContext = /\b(?:failing|failure|bug|incident|captured|endpoint|issue|reproduction|debugg(?:e|ing)|payment)\b/i.test(body);
-  const incidentAction = /^(?:please\s+)?(?:(?:always\s+)?(?:use|keep|write|make|ask|include|check|run|preserve|attach|inspect|reproduce|report|show)|(?:do not|don't|never|avoid|stop))\b/i.test(body);
-  if (!incidentContext || !incidentAction) {
-    return false;
-  }
-  if (/^(?:please\s+)?never\s+(?:expose|share|store|log|print|reveal)\s+(?:any\s+)?(?:credentials?|secrets?|tokens?|passwords?|api\s+keys?)\s+in\s+logs?\.?$/i.test(body)) {
-    return false;
-  }
-  return true;
 }
 
 const EXPLICIT_PREFERENCE_PATTERNS = [
@@ -166,7 +67,7 @@ function hasExplicitDirective(text, patterns) {
   const correctionLead = /^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i.test(text);
   return !isNonDirectiveSentence(text)
     && !isConditionalDirectiveSentence(text)
-    && !isOneOffIncidentRequest(text)
+    && !isOneOffDirectiveRequest(text)
     && (patterns.some((pattern) => pattern.test(body))
       || (patterns === EXPLICIT_PREFERENCE_PATTERNS
         && correctionLead
@@ -211,6 +112,12 @@ function buildDirectiveMemory({ sentence, type, repository, sessionId, turn, sou
 export function extractDirectiveMemoriesFromTurn({ turn, text, repository, sessionId, sourceRole }) {
   const memories = [];
   for (const rawSentence of splitSentences(text)) {
+    // Qualifiers govern the whole coordinated sentence, not just its last
+    // clause. A rationale followed by an explicit request is handled below.
+    if (isNonDirectiveSentence(rawSentence)
+      || (isConditionalDirectiveSentence(rawSentence) && !/\bso\s+please\b/i.test(rawSentence))) {
+      continue;
+    }
     for (const sentence of splitDirectiveClauses(rawSentence)) {
       const contentSentence = /^please\s/i.test(sentence) && /\bso\b/i.test(rawSentence)
         ? rawSentence
@@ -244,13 +151,13 @@ const DECISION_PATTERNS = [
   /^(?:we|i)\s+(?:have\s+)?decided\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^(?:we|i)\s+(?:(?:initially|ultimately|finally)\s+)?(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^(?:we|i)\s+(?:changed|switched|moved)\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
-  /^.*\b(?:we|i)\s+(?:(?:initially|ultimately|finally)\s+)?(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^(?:after|following)\s+[^,]+,\s*(?:we|i)\s+(?:(?:initially|ultimately|finally)\s+)?(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^the\s+decision\s+changed\b.*?:\s*(?:use|choose)\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^the\s+decision\s+is\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
 ];
 
 function isNonCompletedDecisionSentence(text) {
-  return /\b(?:asked|whether|unclear|not\s+decided|still\s+open|hypothetical|scenario|example|i\s+think|i\s+believe|not\s+verified|have\s+not\s+verified)\b/i.test(text);
+  return /\b(?:asked|whether|unclear|not\s+decided|still\s+open|hypothetical|scenario|example|i\s+think|i\s+believe|not\s+verified|have\s+not\s+verified|perhaps|maybe|possibly|probably|did\s+not|didn't)\b/i.test(text);
 }
 
 export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionId, sourceRole }) {
@@ -363,52 +270,6 @@ export function attachEvidenceToSemanticMemories(memories, { sessionId, turns })
     fallbackRecordId: `${memory.type}:${hashText(normalizeEvidenceText(memory.content))}`,
     evidenceIndex: index,
   }));
-}
-
-const REVERSAL_STOPWORDS = new Set([
-  "about", "app", "application", "because", "changed", "chose", "code", "concurrent", "database",
-  "decided", "decision", "deployment", "embedded", "feature", "for", "implementation", "instead",
-  "moved", "need", "needs", "on", "portable", "rather", "reconsidered", "selected", "service",
-  "settled", "simple", "switched", "system", "target", "test", "testing", "tests", "the", "this",
-  "use", "used", "using", "with", "will", "would", "writers",
-]);
-
-function decisionTopicTokens(content) {
-  const normalized = normalizeText(content).toLowerCase();
-  const explicitTopic = normalized.match(/\b(?:for|about|regarding|on)\s+(.+?)(?:\s+because\b|$)/)?.[1] ?? "";
-  const rationaleTopic = normalized.match(/\bbecause\s+(.+)$/)?.[1] ?? "";
-  return new Set(`${explicitTopic} ${rationaleTopic}`
-    .replace(/[^a-z0-9\s]/g, " ")
-    .split(/\s+/)
-    .map((token) => token.replace(/ies$/, "y").replace(/s$/, ""))
-    .filter((token) => token.length >= 4 && !REVERSAL_STOPWORDS.has(token)));
-}
-
-function decisionsShareTopic(left, right) {
-  const leftTokens = decisionTopicTokens(left.content);
-  const rightTokens = decisionTopicTokens(right.content);
-  return [...leftTokens].some((token) => rightTokens.has(token));
-}
-
-function collectRetiredEvidenceKeys(memories) {
-  const decisions = memories
-    .filter((memory) => memory.type === "decision" && memory.evidence?.key)
-    .sort((left, right) => (left.sourceTurnIndex ?? 0) - (right.sourceTurnIndex ?? 0));
-  const retired = [];
-  for (let index = 0; index < decisions.length; index += 1) {
-    const current = decisions[index];
-    if (current.metadata?.decisionStatus !== "reversal") {
-      continue;
-    }
-    for (let priorIndex = index - 1; priorIndex >= 0; priorIndex -= 1) {
-      const prior = decisions[priorIndex];
-      if (decisionsShareTopic(prior, current)) {
-        retired.push(prior.evidence.key);
-        break;
-      }
-    }
-  }
-  return [...new Set(retired)];
 }
 
 function stripListMarkers(value) {
@@ -1061,10 +922,14 @@ function collectFailureSignals({ turns, actions, decisions, openItems, config = 
     if (source.sourceRole === "assistant" && /\b(?:corrected|correction|understood)\b/i.test(source.text)) {
       continue;
     }
-    if (!firstMatchingPattern(source.text, FAILURE_SIGNAL_PATTERNS)) {
-      continue;
-    }
-    if (firstMatchingPattern(source.text, FAILURE_RESOLUTION_PATTERNS)) {
+    const observation = splitSentences(source.text).filter((sentence) =>
+      !isNonDirectiveSentence(sentence)
+      && !isNonCompletedDecisionSentence(sentence)
+      && !/^(?:please|(?:i|we)\s+will)\b/i.test(sentence)
+      && firstMatchingPattern(sentence, FAILURE_SIGNAL_PATTERNS)
+      && !firstMatchingPattern(sentence, FAILURE_RESOLUTION_PATTERNS),
+    ).join(" ");
+    if (!observation) {
       continue;
     }
     signals.push({
@@ -1072,7 +937,7 @@ function collectFailureSignals({ turns, actions, decisions, openItems, config = 
       sourceRole: source.sourceRole ?? null,
       sourceRecordId: source.sourceRecordId ?? null,
       sourceRevision: source.sourceRevision ?? null,
-      text: truncateText(source.text, 140),
+      text: truncateText(observation, 140),
     });
   }
   const uniqueSignals = [];
@@ -1279,7 +1144,7 @@ export function extractSessionMemories({ sessionId, repository, sessionArtifacts
     sessionId,
     turns,
   });
-  const retiredEvidenceKeys = collectRetiredEvidenceKeys(semanticMemories);
+  const retiredEvidenceKeys = collectRetiredDecisionEvidenceKeys(semanticMemories);
   const themes = extractThemes(
     [summary, ...actions.slice(0, 3), ...decisions.slice(0, 2), ...openItems.slice(0, 2)].join(" "),
     effectiveRepository,

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -28,6 +28,29 @@ function hashText(value) {
   return createHash("sha256").update(String(value || "")).digest("hex");
 }
 
+function sourceRevisionForTurn(turn, sourceRole) {
+  return turn.source_revision ?? hashText(JSON.stringify({
+    role: sourceRole,
+    text: normalizeText(sourceRole === "assistant" ? turn.assistant_response : turn.user_message),
+  }));
+}
+
+function assistantSourceTurns(turn) {
+  if (!Array.isArray(turn.assistant_source_records)) {
+    return [turn];
+  }
+  // The array is authoritative, including an empty array after a source was
+  // removed. The combined response exists only for older producer contracts.
+  return turn.assistant_source_records
+    .filter((record) => record?.source_record_id != null && typeof record.text === "string")
+    .map((record) => ({
+      ...turn,
+      assistant_response: record.text,
+      source_record_id: record.source_record_id,
+      source_revision: record.source_revision,
+    }));
+}
+
 function normalizeEvidenceText(value) {
   return normalizeText(value)
     .toLowerCase()
@@ -186,6 +209,8 @@ export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionI
       ...scopeFields,
       sourceSessionId: sessionId,
       sourceTurnIndex: turn.turn_index,
+      sourceRecordId: turn.source_record_id ?? turn.turn_index,
+      sourceRevision: sourceRevisionForTurn(turn, sourceRole),
       confidence: 0.82,
       tags: ["decision", sourceRole, ...(reversal ? ["reversal"] : [])],
       metadata: {
@@ -224,23 +249,17 @@ function attachExtractionEvidence(memory, {
 }) {
   const content = normalizeText(memory.content);
   const contentHash = hashText(content);
-  const sourceRecordId = turn?.source_record_id
+  const sourceRecordId = memory.sourceRecordId
+    ?? turn?.source_record_id
     ?? turn?.turn_index
-    ?? memory.sourceRecordId
     ?? fallbackRecordId
     ?? `memory:${evidenceIndex}`;
   const sourceKind = EVIDENCE_SOURCE_KINDS[memory.type] ?? memory.type ?? "semantic";
   const propositionHash = hashText(normalizeEvidenceText(content));
   const sourceRole = memory.metadata?.sourceRole
     ?? (turn?.assistant_response && !turn?.user_message ? "assistant" : "user");
-  const sourceText = sourceRole === "assistant" ? turn?.assistant_response : turn?.user_message;
-  const sourceRevision = turn
-    ? hashText(JSON.stringify({
-      role: sourceRole,
-      text: normalizeText(sourceText),
-    }))
-    : contentHash;
-  const revision = turn?.source_revision ?? memory.sourceRevision ?? sourceRevision;
+  const sourceRevision = turn ? sourceRevisionForTurn(turn, sourceRole) : contentHash;
+  const revision = memory.sourceRevision ?? sourceRevision;
   const key = `session:${sessionId}:record:${sourceRecordId}:type:${memory.type}:proposition:${propositionHash}`;
   return {
     ...memory,
@@ -483,7 +502,6 @@ function extractSemanticMemoriesFromTurns(turns, repository, sessionId, config =
 
   for (const turn of recentTurns) {
     const userMessage = normalizeTurnText(turn.user_message, config);
-    const assistantResponse = normalizeTurnText(turn.assistant_response, config);
     if (userMessage) {
       const interactionStyleMemory = extractInteractionStyleMemory({
         message: userMessage,
@@ -511,14 +529,17 @@ function extractSemanticMemoriesFromTurns(turns, repository, sessionId, config =
         sourceRole: "user",
       }));
     }
-    if (assistantResponse) {
-      memories.push(...extractDecisionMemoryFromTurn({
-        turn,
-        text: assistantResponse,
-        repository,
-        sessionId,
-        sourceRole: "assistant",
-      }));
+    for (const assistantTurn of assistantSourceTurns(turn)) {
+      const assistantResponse = normalizeTurnText(assistantTurn.assistant_response, config);
+      if (assistantResponse) {
+        memories.push(...extractDecisionMemoryFromTurn({
+          turn: assistantTurn,
+          text: assistantResponse,
+          repository,
+          sessionId,
+          sourceRole: "assistant",
+        }));
+      }
     }
   }
 
@@ -898,13 +919,13 @@ function collectFailureSignals({ turns, actions, decisions, openItems, config = 
         sourceRevision: turn.source_revision ?? null,
         text: normalizeTurnText(turn.user_message, config),
       },
-      {
+      ...assistantSourceTurns(turn).map((assistantTurn) => ({
         turnIndex: turn.turn_index,
         sourceRole: "assistant",
-        sourceRecordId: turn.source_record_id ?? null,
-        sourceRevision: turn.source_revision ?? null,
-        text: normalizeTurnText(turn.assistant_response, config),
-      },
+        sourceRecordId: assistantTurn.source_record_id ?? null,
+        sourceRevision: sourceRevisionForTurn(assistantTurn, "assistant"),
+        text: normalizeTurnText(assistantTurn.assistant_response, config),
+      })),
     ]),
     ...actions.map((text) => ({ turnIndex: null, sourceRole: null, text: normalizeText(text) })),
     ...decisions.map((text) => ({ turnIndex: null, sourceRole: null, text: normalizeText(text) })),

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -122,6 +122,12 @@ function isConditionalDirectiveSentence(text) {
   return /\b(?:if|unless|when)\b/i.test(text);
 }
 
+function isOneOffIncidentRequest(text) {
+  const body = directiveBody(text);
+  return /^please\s+(?:include|check|run|preserve|attach|inspect|reproduce|report|show)\b/i.test(body)
+    && /\b(?:failing|bug|endpoint|logs?|reproduction|result|request|response|debugg(?:e|ing))\b/i.test(body);
+}
+
 const EXPLICIT_PREFERENCE_PATTERNS = [
   /^(?:i|we)\s+(?:always\s+)?(?:really\s+)?prefer\s+.+$/i,
   /^(?:please\s+)?prefer\s+.+$/i,
@@ -152,6 +158,7 @@ function hasExplicitDirective(text, patterns) {
   const correctionLead = /^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i.test(text);
   return !isNonDirectiveSentence(text)
     && !isConditionalDirectiveSentence(text)
+    && !isOneOffIncidentRequest(text)
     && (patterns.some((pattern) => pattern.test(body))
       || (patterns === EXPLICIT_PREFERENCE_PATTERNS
         && correctionLead
@@ -227,17 +234,21 @@ export function extractDirectiveMemoriesFromTurn({ turn, text, repository, sessi
 
 const DECISION_PATTERNS = [
   /^(?:we|i)\s+(?:have\s+)?decided\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
-  /^(?:we|i)\s+(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^(?:we|i)\s+(?:(?:initially|ultimately|finally)\s+)?(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^(?:we|i)\s+(?:changed|switched|moved)\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
-  /^.*\b(?:we|i)\s+(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^.*\b(?:we|i)\s+(?:(?:initially|ultimately|finally)\s+)?(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^the\s+decision\s+changed\b.*?:\s*(?:use|choose)\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^the\s+decision\s+is\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
 ];
 
+function isNonCompletedDecisionSentence(text) {
+  return /\b(?:asked|whether|unclear|not\s+decided|still\s+open|hypothetical|scenario|example|i\s+think|i\s+believe|not\s+verified|have\s+not\s+verified)\b/i.test(text);
+}
+
 export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionId, sourceRole }) {
   const memories = [];
   for (const sentence of splitSentences(text)) {
-    if (isNonDirectiveSentence(sentence)) {
+    if (isNonDirectiveSentence(sentence) || isNonCompletedDecisionSentence(sentence)) {
       continue;
     }
     const decisionSentence = sentence.replace(/^(?:instead|rather)\b[,\s-]*/i, "");
@@ -250,7 +261,8 @@ export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionI
     if (!choice || choice.length < 3) {
       continue;
     }
-    const reversal = /^(?:instead|rather)\b|\b(?:changed|switched|moved)\s+to\b|\b(?:no longer|reconsidered)\b|\s+(?:instead|rather)[.!?]*$/i.test(sentence);
+    const reversal = /^(?:instead|rather)\b|\bdecision\s+changed\b|\b(?:changed|switched|moved)\s+to\b|\b(?:no longer|reconsidered)\b|\s+(?:instead|rather)[.!?]*$/i.test(sentence);
+    const contextualReversal = /\bdecision\s+changed\b|^(?:after|following|once)\b.*\b(?:we|i)\s+(?:chose|selected|settled\s+on)\b/i.test(sentence);
     const scope = scopeForExtractedDirective(sentence, repository);
     const { scopeMetadata, ...scopeFields } = scope;
     memories.push({
@@ -268,6 +280,7 @@ export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionI
         confidenceBasis: "explicit_completed_decision",
         verificationStatus: sourceRole === "assistant" ? "unverified_assistant_claim" : "conversation_record",
         ...(reversal ? { decisionStatus: "reversal" } : {}),
+        ...(contextualReversal ? { contextualReversal: true } : {}),
       },
     });
   }
@@ -379,7 +392,10 @@ function collectRetiredEvidenceKeys(memories) {
     }
     for (let priorIndex = index - 1; priorIndex >= 0; priorIndex -= 1) {
       const prior = decisions[priorIndex];
-      if (decisionsShareTopic(prior, current)) {
+      const isLinkedContextualReversal = current.metadata?.contextualReversal === true
+        && decisionTopicTokens(current.content).size === 0
+        && priorIndex === index - 1;
+      if (decisionsShareTopic(prior, current) || isLinkedContextualReversal) {
         retired.push(prior.evidence.key);
         break;
       }
@@ -1007,8 +1023,8 @@ function inferRecurringMistakeFromCorrections(turns, sessionId, config = null) {
 function collectFailureSignals({ turns, actions, decisions, openItems, config = null }) {
   const sources = [
     ...turns.slice(-16).flatMap((turn) => [
-      { turnIndex: turn.turn_index, text: normalizeTurnText(turn.user_message, config) },
-      { turnIndex: turn.turn_index, text: normalizeTurnText(turn.assistant_response, config) },
+      { turnIndex: turn.turn_index, sourceRole: "user", text: normalizeTurnText(turn.user_message, config) },
+      { turnIndex: turn.turn_index, sourceRole: "assistant", text: normalizeTurnText(turn.assistant_response, config) },
     ]),
     ...actions.map((text) => ({ turnIndex: null, text: normalizeText(text) })),
     ...decisions.map((text) => ({ turnIndex: null, text: normalizeText(text) })),
@@ -1018,6 +1034,12 @@ function collectFailureSignals({ turns, actions, decisions, openItems, config = 
   const signals = [];
   for (const source of sources) {
     if (!source.text || source.text.length > 280) {
+      continue;
+    }
+    if (source.sourceRole === "user" && firstMatchingPattern(source.text, IMPLICIT_CORRECTION_PATTERNS)) {
+      continue;
+    }
+    if (source.sourceRole === "assistant" && /\b(?:corrected|correction|understood)\b/i.test(source.text)) {
       continue;
     }
     if (!firstMatchingPattern(source.text, FAILURE_SIGNAL_PATTERNS)) {
@@ -1056,7 +1078,25 @@ function classifyImplicitFailureGoal(examples) {
 
 function inferAssistantGoalFromFailures({ turns, repository, sessionId, actions, decisions, openItems, config = null }) {
   const signals = collectFailureSignals({ turns, actions, decisions, openItems, config });
-  if (signals.length < 2) {
+  const distinctFailureTurns = new Set(
+    signals
+      .map((signal) => signal.turnIndex)
+      .filter((turnIndex) => Number.isInteger(turnIndex)),
+  );
+  const hasRecurrenceMarker = signals.some((signal) => /\b(?:again|repeated|recurring|keeps?|every\s+time|still)\b/i.test(signal.text));
+  const failureTopicStopwords = new Set([
+    "again", "after", "before", "debugging", "endpoint", "failed", "failing", "failure", "include",
+    "inspect", "logs", "please", "report", "reproduce", "reproduction", "request", "response", "result",
+    "the", "timeout",
+  ]);
+  const topicSets = signals.map((signal) => new Set(
+    signal.text.toLowerCase().replace(/[^a-z0-9\s]/g, " ").split(/\s+/)
+      .filter((token) => token.length >= 5 && !failureTopicStopwords.has(token)),
+  ));
+  const hasRepeatedTopic = topicSets.some((left, index) => topicSets
+    .slice(index + 1)
+    .some((right) => [...left].some((token) => right.has(token))));
+  if (signals.length < 2 || distinctFailureTurns.size < 2 || (!hasRecurrenceMarker && !hasRepeatedTopic)) {
     return null;
   }
   const examples = signals.map((signal) => signal.text);

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -115,6 +115,7 @@ const EXPLICIT_SCOPE_PREAMBLE_PATTERN = /^(?:(?:for|in)\s+(?:this|the current)(?
 function directiveBody(text) {
   return String(text || "")
     .replace(EXPLICIT_SCOPE_PREAMBLE_PATTERN, "")
+    .replace(/^(?:as\s+(?:a\s+)?policy|in\s+(?:the\s+)?future|going\s+forward)\s*(?:,|:)\s*/i, "")
     .replace(/^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i, "");
 }
 
@@ -124,8 +125,15 @@ function isConditionalDirectiveSentence(text) {
 
 function isOneOffIncidentRequest(text) {
   const body = directiveBody(text);
-  return /^please\s+(?:include|check|run|preserve|attach|inspect|reproduce|report|show)\b/i.test(body)
-    && /\b(?:failing|bug|endpoint|logs?|reproduction|result|request|response|debugg(?:e|ing))\b/i.test(body);
+  const incidentContext = /\b(?:failing|failure|bug|incident|captured|endpoint|issue|reproduction|debugg(?:e|ing)|payment)\b/i.test(body);
+  const incidentAction = /^(?:please\s+)?(?:(?:always\s+)?(?:use|keep|write|make|ask|include|check|run|preserve|attach|inspect|reproduce|report|show)|(?:do not|don't|never|avoid|stop))\b/i.test(body);
+  if (!incidentContext || !incidentAction) {
+    return false;
+  }
+  if (/^(?:please\s+)?never\s+(?:expose|share|store|log|print|reveal)\s+(?:any\s+)?(?:credentials?|secrets?|tokens?|passwords?|api\s+keys?)\s+in\s+logs?\.?$/i.test(body)) {
+    return false;
+  }
+  return true;
 }
 
 const EXPLICIT_PREFERENCE_PATTERNS = [
@@ -367,10 +375,12 @@ const REVERSAL_STOPWORDS = new Set([
 
 function decisionTopicTokens(content) {
   const normalized = normalizeText(content).toLowerCase();
-  const topic = normalized.match(/\b(?:for|about|regarding|on)\s+(.+?)(?:\s+because\b|$)/)?.[1] ?? "";
-  return new Set(topic
+  const explicitTopic = normalized.match(/\b(?:for|about|regarding|on)\s+(.+?)(?:\s+because\b|$)/)?.[1] ?? "";
+  const rationaleTopic = normalized.match(/\bbecause\s+(.+)$/)?.[1] ?? "";
+  return new Set(`${explicitTopic} ${rationaleTopic}`
     .replace(/[^a-z0-9\s]/g, " ")
     .split(/\s+/)
+    .map((token) => token.replace(/ies$/, "y").replace(/s$/, ""))
     .filter((token) => token.length >= 4 && !REVERSAL_STOPWORDS.has(token)));
 }
 
@@ -392,10 +402,7 @@ function collectRetiredEvidenceKeys(memories) {
     }
     for (let priorIndex = index - 1; priorIndex >= 0; priorIndex -= 1) {
       const prior = decisions[priorIndex];
-      const isLinkedContextualReversal = current.metadata?.contextualReversal === true
-        && decisionTopicTokens(current.content).size === 0
-        && priorIndex === index - 1;
-      if (decisionsShareTopic(prior, current) || isLinkedContextualReversal) {
+      if (decisionsShareTopic(prior, current)) {
         retired.push(prior.evidence.key);
         break;
       }
@@ -1023,12 +1030,24 @@ function inferRecurringMistakeFromCorrections(turns, sessionId, config = null) {
 function collectFailureSignals({ turns, actions, decisions, openItems, config = null }) {
   const sources = [
     ...turns.slice(-16).flatMap((turn) => [
-      { turnIndex: turn.turn_index, sourceRole: "user", text: normalizeTurnText(turn.user_message, config) },
-      { turnIndex: turn.turn_index, sourceRole: "assistant", text: normalizeTurnText(turn.assistant_response, config) },
+      {
+        turnIndex: turn.turn_index,
+        sourceRole: "user",
+        sourceRecordId: turn.source_record_id ?? null,
+        sourceRevision: turn.source_revision ?? null,
+        text: normalizeTurnText(turn.user_message, config),
+      },
+      {
+        turnIndex: turn.turn_index,
+        sourceRole: "assistant",
+        sourceRecordId: turn.source_record_id ?? null,
+        sourceRevision: turn.source_revision ?? null,
+        text: normalizeTurnText(turn.assistant_response, config),
+      },
     ]),
-    ...actions.map((text) => ({ turnIndex: null, text: normalizeText(text) })),
-    ...decisions.map((text) => ({ turnIndex: null, text: normalizeText(text) })),
-    ...openItems.map((text) => ({ turnIndex: null, text: normalizeText(text) })),
+    ...actions.map((text) => ({ turnIndex: null, sourceRole: null, text: normalizeText(text) })),
+    ...decisions.map((text) => ({ turnIndex: null, sourceRole: null, text: normalizeText(text) })),
+    ...openItems.map((text) => ({ turnIndex: null, sourceRole: null, text: normalizeText(text) })),
   ];
 
   const signals = [];
@@ -1050,13 +1069,25 @@ function collectFailureSignals({ turns, actions, decisions, openItems, config = 
     }
     signals.push({
       turnIndex: source.turnIndex,
+      sourceRole: source.sourceRole ?? null,
+      sourceRecordId: source.sourceRecordId ?? null,
+      sourceRevision: source.sourceRevision ?? null,
       text: truncateText(source.text, 140),
     });
   }
-  return uniqueStrings(signals.map((signal) => signal.text), 4).map((text) => ({
-    text,
-    turnIndex: signals.find((signal) => signal.text === text)?.turnIndex ?? null,
-  }));
+  const uniqueSignals = [];
+  const seen = new Set();
+  for (const signal of signals) {
+    if (seen.has(signal.text)) {
+      continue;
+    }
+    seen.add(signal.text);
+    uniqueSignals.push(signal);
+    if (uniqueSignals.length >= 4) {
+      break;
+    }
+  }
+  return uniqueSignals;
 }
 
 function classifyImplicitFailureGoal(examples) {
@@ -1101,12 +1132,15 @@ function inferAssistantGoalFromFailures({ turns, repository, sessionId, actions,
   }
   const examples = signals.map((signal) => signal.text);
   const goal = classifyImplicitFailureGoal(examples);
+  const selectedSignal = signals.at(-1) ?? {};
   return {
     type: "assistant_goal",
     content: `Current assistant goal: ${goal}`,
     repository,
     sourceSessionId: sessionId,
-    sourceTurnIndex: signals.at(-1)?.turnIndex ?? null,
+    sourceTurnIndex: selectedSignal.turnIndex ?? null,
+    sourceRecordId: selectedSignal.sourceRecordId ?? null,
+    sourceRevision: selectedSignal.sourceRevision ?? null,
     confidence: 0.82,
     tags: ["assistant-goal", "implicit-session", "failure-repair"],
     metadata: {
@@ -1115,6 +1149,7 @@ function inferAssistantGoalFromFailures({ turns, repository, sessionId, actions,
       goal,
       failureCount: signals.length,
       examples,
+      ...(selectedSignal.sourceRole ? { sourceRole: selectedSignal.sourceRole } : {}),
     },
   };
 }

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -3,6 +3,7 @@ import {
   detectUserIdentityName,
   MEMORY_SCOPE,
 } from "../memory/memory-scope.mjs";
+import { createHash } from "node:crypto";
 import { normalizeText } from "../utils/text-normalizer.mjs";
 import { readRetentionSanitizationEnabled } from "../rollout/rollout-flags.mjs";
 import { stripInjectedContext } from "../memory/retention-sanitizer.mjs";
@@ -12,6 +13,293 @@ function normalizeTurnText(value, config = null) {
     ? stripInjectedContext(value)
     : String(value || "");
   return normalizeText(text);
+}
+
+function hashText(value) {
+  return createHash("sha256").update(String(value || "")).digest("hex");
+}
+
+function normalizeEvidenceText(value) {
+  return normalizeText(value)
+    .toLowerCase()
+    .replace(/["'’]/g, "")
+    .replace(/[^a-z0-9\s-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function splitSentences(value) {
+  return String(value || "")
+    .match(/[^.!?]+(?:[.!?]+|$)/g)
+    ?.map((sentence) => normalizeText(sentence))
+    .filter(Boolean) ?? [];
+}
+
+function isQuotedSentence(text) {
+  const quoteRanges = [];
+  const quotePattern = /["“”‘’]/g;
+  let openQuote = null;
+  for (const match of text.matchAll(quotePattern)) {
+    const quote = match[0];
+    if (quote === "“" || quote === "‘" || (quote === '"' && openQuote === null)) {
+      openQuote = match.index;
+      continue;
+    }
+    if (openQuote !== null) {
+      quoteRanges.push([openQuote, match.index + 1]);
+      openQuote = null;
+    }
+  }
+  if (openQuote !== null) {
+    quoteRanges.push([openQuote, text.length]);
+  }
+  return quoteRanges.length > 0;
+}
+
+function isNonDirectiveSentence(text) {
+  return !text
+    || text.endsWith("?")
+    || isQuotedSentence(text)
+    || /^(?:if|unless|when|suppose|imagine|assuming|should we|could we|would you|could you|can you|what if)\b/i.test(text)
+    || /\b(?:don't|do not|never|not)\s+(?:really\s+)?prefer\b/i.test(text)
+    || /\bprefer\s+not\s+to\b/i.test(text)
+    || /\b(?:would|could|might|may)\s+(?:prefer|use|choose|avoid)\b/i.test(text);
+}
+
+const EXPLICIT_PREFERENCE_PATTERNS = [
+  /^(?:i|we)\s+(?:always\s+)?(?:really\s+)?prefer\s+.+$/i,
+  /^my\s+preference\s+is\s+.+$/i,
+  /^(?:please\s+)?always\s+(?:use|keep|include|show|run|write|ask|check|preserve|make)\s+.+$/i,
+  /^(?:i|we)\s+always\s+(?:use|keep|include|show|run|write|ask|check|preserve|make)\s+.+$/i,
+  /^(?:please\s+)?(?:use|keep|include|show|run|write|ask|check|preserve|make)\s+.+\s+(?:for|when|in)\s+(?:this|the)\s+(?:repo|repository|project)\b.*$/i,
+  /^please\s+(?:keep|make|write|format)\s+.+$/i,
+];
+
+const EXPLICIT_REJECTION_PATTERNS = [
+  /^(?:please\s+)?(?:do not|don't|never)\s+(?:ever\s+)?(?:use|store|include|show|run|write|ask|check|preserve|make|commit|push|delete|merge|overwrite|ignore|assume|send|expose|log|add|change|modify|rely|return|start)\b.+$/i,
+  /^(?:please\s+)?avoid\s+.+$/i,
+  /^(?:please\s+)?stop\s+.+$/i,
+  /^(?:i|we)\s+(?:do not|don't|never)\s+(?:want|like|use|need|store|include|see)\s+.+$/i,
+];
+
+const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:globally|across\s+(?:all\s+)?(?:projects|repositories|repos)|for\s+(?:every|all)\s+(?:project|repository|repo)|regardless\s+of\s+(?:the\s+)?repo(?:sitory)?|in\s+all\s+(?:projects|repositories|repos))\b/i;
+
+function hasExplicitDirective(text, patterns) {
+  return !isNonDirectiveSentence(text) && patterns.some((pattern) => pattern.test(text));
+}
+
+function scopeForExtractedDirective(text, repository) {
+  if (EXPLICIT_GLOBAL_SCOPE_PATTERN.test(text)) {
+    return {
+      scope: MEMORY_SCOPE.GLOBAL,
+      repository: null,
+      scopeMetadata: repository ? { originRepository: repository } : {},
+    };
+  }
+  if (repository) {
+    return { scope: MEMORY_SCOPE.REPO, repository };
+  }
+  return {};
+}
+
+function buildDirectiveMemory({ sentence, type, repository, sessionId, turn, sourceRole }) {
+  const scope = scopeForExtractedDirective(sentence, repository);
+  const rejection = type === "rejected_approach";
+  const { scopeMetadata, ...scopeFields } = scope;
+  return {
+    type,
+    content: sentence,
+    ...scopeFields,
+    sourceSessionId: sessionId,
+    sourceTurnIndex: turn.turn_index,
+    confidence: rejection ? 0.76 : 0.78,
+    tags: rejection ? ["rejected", sourceRole] : ["preference", sourceRole],
+    metadata: {
+      ...scopeMetadata,
+      source: "rule_extractor",
+      sourceRole,
+      confidenceBasis: rejection ? "explicit_rejection_sentence" : "explicit_preference_sentence",
+    },
+  };
+}
+
+export function extractDirectiveMemoriesFromTurn({ turn, text, repository, sessionId, sourceRole }) {
+  const memories = [];
+  for (const sentence of splitSentences(text)) {
+    if (hasExplicitDirective(sentence, EXPLICIT_PREFERENCE_PATTERNS)) {
+      memories.push(buildDirectiveMemory({
+        sentence,
+        type: "user_preference",
+        repository,
+        sessionId,
+        turn,
+        sourceRole,
+      }));
+      continue;
+    }
+    if (hasExplicitDirective(sentence, EXPLICIT_REJECTION_PATTERNS)) {
+      memories.push(buildDirectiveMemory({
+        sentence,
+        type: "rejected_approach",
+        repository,
+        sessionId,
+        turn,
+        sourceRole,
+      }));
+    }
+  }
+  return memories;
+}
+
+const DECISION_PATTERNS = [
+  /^(?:we|i)\s+(?:have\s+)?decided\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^(?:we|i)\s+(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^the\s+decision\s+is\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
+];
+
+export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionId, sourceRole }) {
+  const memories = [];
+  for (const sentence of splitSentences(text)) {
+    if (isNonDirectiveSentence(sentence)) {
+      continue;
+    }
+    const decisionSentence = sentence.replace(/^(?:instead|rather)\b[,\s-]*/i, "");
+    const match = DECISION_PATTERNS.map((pattern) => decisionSentence.match(pattern)).find(Boolean);
+    if (!match) {
+      continue;
+    }
+    const choice = normalizeText(match[1]);
+    const rationale = normalizeText(match[2] ?? "");
+    if (!choice || choice.length < 3) {
+      continue;
+    }
+    const reversal = /^(?:instead|rather)|\b(?:changed|no longer|reconsidered)\b/i.test(sentence);
+    const scope = scopeForExtractedDirective(sentence, repository);
+    const { scopeMetadata, ...scopeFields } = scope;
+    memories.push({
+      type: "decision",
+      content: `Decision: ${choice}${rationale ? ` because ${rationale}` : ""}`,
+      ...scopeFields,
+      sourceSessionId: sessionId,
+      sourceTurnIndex: turn.turn_index,
+      confidence: 0.82,
+      tags: ["decision", sourceRole, ...(reversal ? ["reversal"] : [])],
+      metadata: {
+        ...scopeMetadata,
+        source: "rule_extractor",
+        sourceRole,
+        confidenceBasis: "explicit_completed_decision",
+        verificationStatus: sourceRole === "assistant" ? "unverified_assistant_claim" : "conversation_record",
+        ...(reversal ? { decisionStatus: "reversal" } : {}),
+      },
+    });
+  }
+  return memories;
+}
+
+const EVIDENCE_SOURCE_KINDS = Object.freeze({
+  user_preference: "preference",
+  rejected_approach: "rejection",
+  decision: "decision",
+  assistant_identity: "identity",
+  user_identity: "identity",
+  interaction_style: "style",
+  assistant_goal: "goal",
+  recurring_mistake: "rejection",
+  open_loop: "open_loop",
+  blocker: "blocker",
+  commitment: "commitment",
+});
+
+function attachExtractionEvidence(memory, {
+  sessionId,
+  turn = null,
+  fallbackRecordId,
+  evidenceIndex,
+}) {
+  const content = normalizeText(memory.content);
+  const contentHash = hashText(content);
+  const sourceRecordId = turn?.source_record_id
+    ?? turn?.turn_index
+    ?? memory.sourceRecordId
+    ?? fallbackRecordId
+    ?? `memory:${evidenceIndex}`;
+  const revision = turn?.source_revision ?? memory.sourceRevision ?? contentHash;
+  const sourceKind = EVIDENCE_SOURCE_KINDS[memory.type] ?? memory.type ?? "semantic";
+  const propositionHash = hashText(normalizeEvidenceText(content));
+  const key = `session:${sessionId}:record:${sourceRecordId}:type:${memory.type}:proposition:${propositionHash}`;
+  const sourceRole = memory.metadata?.sourceRole
+    ?? (turn?.assistant_response && !turn?.user_message ? "assistant" : "user");
+  return {
+    ...memory,
+    metadata: {
+      ...memory.metadata,
+      sourceAttribution: {
+        sessionId,
+        sourceRecordId: String(sourceRecordId),
+        sourceRole,
+      },
+    },
+    evidence: {
+      key,
+      sourceRecordId: String(sourceRecordId),
+      sourceKind,
+      revision: String(revision),
+      contentHash,
+    },
+  };
+}
+
+export function attachEvidenceToSemanticMemories(memories, { sessionId, turns }) {
+  const turnsByIndex = new Map(turns.map((turn) => [turn.turn_index, turn]));
+  return memories.map((memory, index) => attachExtractionEvidence(memory, {
+    sessionId,
+    turn: turnsByIndex.get(memory.sourceTurnIndex) ?? null,
+    fallbackRecordId: `${memory.type}:${hashText(normalizeEvidenceText(memory.content))}`,
+    evidenceIndex: index,
+  }));
+}
+
+const REVERSAL_STOPWORDS = new Set([
+  "because", "chose", "decided", "decision", "instead", "postgresql", "sqlite", "use", "used",
+  "rather", "settled", "selected", "the", "this", "with", "will", "would",
+]);
+
+function decisionTopicTokens(content) {
+  return new Set(
+    normalizeText(content)
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, " ")
+      .split(/\s+/)
+      .filter((token) => token.length >= 5 && !REVERSAL_STOPWORDS.has(token)),
+  );
+}
+
+function decisionsShareTopic(left, right) {
+  const leftTokens = decisionTopicTokens(left.content);
+  const rightTokens = decisionTopicTokens(right.content);
+  return [...leftTokens].some((token) => rightTokens.has(token));
+}
+
+function collectRetiredEvidenceKeys(memories) {
+  const decisions = memories
+    .filter((memory) => memory.type === "decision" && memory.evidence?.key)
+    .sort((left, right) => (left.sourceTurnIndex ?? 0) - (right.sourceTurnIndex ?? 0));
+  const retired = [];
+  for (let index = 0; index < decisions.length; index += 1) {
+    const current = decisions[index];
+    if (current.metadata?.decisionStatus !== "reversal") {
+      continue;
+    }
+    for (let priorIndex = index - 1; priorIndex >= 0; priorIndex -= 1) {
+      const prior = decisions[priorIndex];
+      if (decisionsShareTopic(prior, current)) {
+        retired.push(prior.evidence.key);
+        break;
+      }
+    }
+  }
+  return [...new Set(retired)];
 }
 
 function stripListMarkers(value) {
@@ -218,48 +506,49 @@ function buildEpisodeSummary({
 
 function extractSemanticMemoriesFromTurns(turns, repository, sessionId, config = null) {
   const memories = [];
-  const recentTurns = turns.slice(-12);
+  // Directive and decision evidence is source-addressed, so an older turn is
+  // still useful on a later bounded ingestion pass. Keep the per-record work
+  // sentence-level and let the caller bound how many source records it feeds.
+  const recentTurns = turns;
 
   for (const turn of recentTurns) {
-    const message = normalizeTurnText(turn.user_message, config);
-    if (!message || message.length > 240) {
-      continue;
-    }
-
-    const interactionStyleMemory = extractInteractionStyleMemory({
-      message,
-      repository,
-      sessionId,
-      turnIndex: turn.turn_index,
-    });
-    if (interactionStyleMemory) {
-      memories.push(interactionStyleMemory);
-      continue;
-    }
-
-    if (/\b(?:always|prefer)\b/i.test(message)) {
-      memories.push({
-        type: "user_preference",
-        content: message,
+    const userMessage = normalizeTurnText(turn.user_message, config);
+    const assistantResponse = normalizeTurnText(turn.assistant_response, config);
+    if (userMessage) {
+      const interactionStyleMemory = extractInteractionStyleMemory({
+        message: userMessage,
         repository,
-        sourceSessionId: sessionId,
-        sourceTurnIndex: turn.turn_index,
-        confidence: 0.95,
-        tags: ["preference", "user"],
+        sessionId,
+        turnIndex: turn.turn_index,
       });
-      continue;
-    }
-
-    if (/\b(?:never|do not|don't)\b/i.test(message)) {
-      memories.push({
-        type: "rejected_approach",
-        content: message,
+      if (interactionStyleMemory) {
+        memories.push(interactionStyleMemory);
+      }
+      if (!interactionStyleMemory) {
+        memories.push(...extractDirectiveMemoriesFromTurn({
+          turn,
+          text: userMessage,
+          repository,
+          sessionId,
+          sourceRole: "user",
+        }));
+      }
+      memories.push(...extractDecisionMemoryFromTurn({
+        turn,
+        text: userMessage,
         repository,
-        sourceSessionId: sessionId,
-        sourceTurnIndex: turn.turn_index,
-        confidence: 0.95,
-        tags: ["rejected", "user"],
-      });
+        sessionId,
+        sourceRole: "user",
+      }));
+    }
+    if (assistantResponse) {
+      memories.push(...extractDecisionMemoryFromTurn({
+        turn,
+        text: assistantResponse,
+        repository,
+        sessionId,
+        sourceRole: "assistant",
+      }));
     }
   }
 
@@ -795,6 +1084,7 @@ function buildSessionSemanticMemories({
   };
 }
 
+
 export function extractSessionMemories({ sessionId, repository, sessionArtifacts, workspace, config = null }) {
   const { session, checkpoints, files, refs, turns } = sessionArtifacts;
   const latestCheckpoint = checkpoints[0] ?? null;
@@ -815,7 +1105,7 @@ export function extractSessionMemories({ sessionId, repository, sessionArtifacts
     openItems,
     config,
   });
-  const { learnings, semanticMemories } = buildSessionSemanticMemories({
+  const { learnings, semanticMemories: unannotatedSemanticMemories } = buildSessionSemanticMemories({
     turns,
     effectiveRepository,
     sessionId,
@@ -824,6 +1114,11 @@ export function extractSessionMemories({ sessionId, repository, sessionArtifacts
     openItems,
     config,
   });
+  const semanticMemories = attachEvidenceToSemanticMemories(unannotatedSemanticMemories, {
+    sessionId,
+    turns,
+  });
+  const retiredEvidenceKeys = collectRetiredEvidenceKeys(semanticMemories);
   const themes = extractThemes(
     [summary, ...actions.slice(0, 3), ...decisions.slice(0, 2), ...openItems.slice(0, 2)].join(" "),
     effectiveRepository,
@@ -862,5 +1157,6 @@ export function extractSessionMemories({ sessionId, repository, sessionArtifacts
       createdAt,
     },
     semanticMemories,
+    retiredEvidenceKeys,
   };
 }

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -29,10 +29,53 @@ function normalizeEvidenceText(value) {
 }
 
 function splitSentences(value) {
-  return String(value || "")
-    .match(/[^.!?]+(?:[.!?]+|$)/g)
-    ?.map((sentence) => normalizeText(sentence))
-    .filter(Boolean) ?? [];
+  const sentences = [];
+  let current = "";
+  let quote = null;
+  const text = String(value || "");
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+    current += character;
+    if (character === '"') {
+      quote = quote === '"' ? null : (quote ?? '"');
+    } else if (character === "“") {
+      quote = "”";
+    } else if (character === "”" && quote === "”") {
+      quote = null;
+    } else if (character === "‘") {
+      quote = "’";
+    } else if (character === "’" && quote === "’") {
+      quote = null;
+    }
+    if (!quote && /["”’]/.test(character) && /[.!?;]/.test(text[index - 1] ?? "")
+      && (index === text.length - 1 || /\s/.test(text[index + 1]))) {
+      const sentence = normalizeText(current);
+      if (sentence) {
+        sentences.push(sentence);
+      }
+      current = "";
+      continue;
+    }
+    if (!quote && /[.!?;]/.test(character) && (index === text.length - 1 || /\s/.test(text[index + 1]))) {
+      const sentence = normalizeText(current);
+      if (sentence) {
+        sentences.push(sentence);
+      }
+      current = "";
+    }
+  }
+  const remainder = normalizeText(current);
+  if (remainder) {
+    sentences.push(remainder);
+  }
+  return sentences;
+}
+
+function splitDirectiveClauses(sentence) {
+  return sentence
+    .split(/\s+(?:and|but)\s+(?=(?:never|do\s+not|don't|avoid|please)\b)|\s+so\s+(?=please\s+(?:use|prefer|keep|include)\b)/i)
+    .map((clause) => clause.replace(/;+$/, "").trim())
+    .filter(Boolean);
 }
 
 function isQuotedSentence(text) {
@@ -63,29 +106,56 @@ function isNonDirectiveSentence(text) {
     || /^(?:if|unless|when|suppose|imagine|assuming|should we|could we|would you|could you|can you|what if)\b/i.test(text)
     || /\b(?:don't|do not|never|not)\s+(?:really\s+)?prefer\b/i.test(text)
     || /\bprefer\s+not\s+to\b/i.test(text)
+    || /\bi\s+meant\s+to\s+(?:ask|know|understand)\b/i.test(text)
     || /\b(?:would|could|might|may)\s+(?:prefer|use|choose|avoid)\b/i.test(text);
+}
+
+const EXPLICIT_SCOPE_PREAMBLE_PATTERN = /^(?:(?:for|in)\s+(?:this|the current)(?:\s+[a-z][a-z0-9_-]*){0,2}\s+(?:repo(?:sitory)?|project|app)|for\s+[a-z][a-z0-9_-]*(?:\s+[a-z][a-z0-9_-]*){0,4}|(?:across|in|for)\s+all\s+(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|make\s+(?:this\s+)?rule\s+global\s+across\s+(?:all\s+)?(?:projects|repositories|repos)|globally)\s*(?:,|:)\s*/i;
+
+function directiveBody(text) {
+  return String(text || "")
+    .replace(EXPLICIT_SCOPE_PREAMBLE_PATTERN, "")
+    .replace(/^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i, "");
+}
+
+function isConditionalDirectiveSentence(text) {
+  return /\b(?:if|unless|when)\b/i.test(text);
 }
 
 const EXPLICIT_PREFERENCE_PATTERNS = [
   /^(?:i|we)\s+(?:always\s+)?(?:really\s+)?prefer\s+.+$/i,
+  /^(?:please\s+)?prefer\s+.+$/i,
   /^my\s+preference\s+is\s+.+$/i,
   /^(?:please\s+)?always\s+(?:use|keep|include|show|run|write|ask|check|preserve|make)\s+.+$/i,
   /^(?:i|we)\s+always\s+(?:use|keep|include|show|run|write|ask|check|preserve|make)\s+.+$/i,
+  /^please\s+(?:use|keep|include|show|run|write|ask|check|preserve|make)\s+.+$/i,
+  /^(?:i|we)\s+work\s+best\s+with\s+.+$/i,
+  /^(?:across|in)\s+(?:all\s+)?(?:of\s+)?(?:my\s+)?projects?\s+i\s+work\s+best\s+with\s+.+$/i,
+  /^(?:no\s*,?\s*)?i\s+meant\s+.+$/i,
+  /^remember\s+.+\b(?:decision|rule)\s*:\s*.+$/i,
+  /^split\s+(?:changes|commits)\b.+$/i,
   /^(?:please\s+)?(?:use|keep|include|show|run|write|ask|check|preserve|make)\s+.+\s+(?:for|when|in)\s+(?:this|the)\s+(?:repo|repository|project)\b.*$/i,
   /^please\s+(?:keep|make|write|format)\s+.+$/i,
 ];
 
 const EXPLICIT_REJECTION_PATTERNS = [
-  /^(?:please\s+)?(?:do not|don't|never)\s+(?:ever\s+)?(?:use|store|include|show|run|write|ask|check|preserve|make|commit|push|delete|merge|overwrite|ignore|assume|send|expose|log|add|change|modify|rely|return|start)\b.+$/i,
+  /^(?:please\s+)?(?:do not|don't|never)\s+(?:ever\s+)?(?:use|store|include|show|run|write|ask|check|preserve|make|put|retain|drop|remove|retry|commit|push|delete|merge|overwrite|ignore|assume|send|expose|log|add|change|modify|rely|return|start)\b.+$/i,
   /^(?:please\s+)?avoid\s+.+$/i,
   /^(?:please\s+)?stop\s+.+$/i,
   /^(?:i|we)\s+(?:do not|don't|never)\s+(?:want|like|use|need|store|include|see)\s+.+$/i,
 ];
 
-const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:globally|across\s+(?:all\s+)?(?:projects|repositories|repos)|for\s+(?:every|all)\s+(?:project|repository|repo)|regardless\s+of\s+(?:the\s+)?repo(?:sitory)?|in\s+all\s+(?:projects|repositories|repos))\b/i;
+const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:globally|across\s+(?:all\s+)?(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|for\s+(?:every|all)\s+(?:my\s+)?(?:project|repository|repo)|regardless\s+of\s+(?:the\s+)?repo(?:sitory)?|in\s+all\s+(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos))\b/i;
 
 function hasExplicitDirective(text, patterns) {
-  return !isNonDirectiveSentence(text) && patterns.some((pattern) => pattern.test(text));
+  const body = directiveBody(text);
+  const correctionLead = /^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i.test(text);
+  return !isNonDirectiveSentence(text)
+    && !isConditionalDirectiveSentence(text)
+    && (patterns.some((pattern) => pattern.test(body))
+      || (patterns === EXPLICIT_PREFERENCE_PATTERNS
+        && correctionLead
+        && /^use\s+.+$/i.test(body)));
 }
 
 function scopeForExtractedDirective(text, repository) {
@@ -125,27 +195,31 @@ function buildDirectiveMemory({ sentence, type, repository, sessionId, turn, sou
 
 export function extractDirectiveMemoriesFromTurn({ turn, text, repository, sessionId, sourceRole }) {
   const memories = [];
-  for (const sentence of splitSentences(text)) {
-    if (hasExplicitDirective(sentence, EXPLICIT_PREFERENCE_PATTERNS)) {
-      memories.push(buildDirectiveMemory({
-        sentence,
-        type: "user_preference",
-        repository,
-        sessionId,
-        turn,
-        sourceRole,
-      }));
-      continue;
-    }
-    if (hasExplicitDirective(sentence, EXPLICIT_REJECTION_PATTERNS)) {
-      memories.push(buildDirectiveMemory({
-        sentence,
-        type: "rejected_approach",
-        repository,
-        sessionId,
-        turn,
-        sourceRole,
-      }));
+  for (const rawSentence of splitSentences(text)) {
+    for (const sentence of splitDirectiveClauses(rawSentence)) {
+      const contentSentence = /^please\s/i.test(sentence) && /\bso\b/i.test(rawSentence)
+        ? rawSentence
+        : sentence;
+      if (hasExplicitDirective(sentence, EXPLICIT_PREFERENCE_PATTERNS)) {
+        memories.push(buildDirectiveMemory({
+          sentence: contentSentence,
+          type: "user_preference",
+          repository,
+          sessionId,
+          turn,
+          sourceRole,
+        }));
+      }
+      if (hasExplicitDirective(sentence, EXPLICIT_REJECTION_PATTERNS)) {
+        memories.push(buildDirectiveMemory({
+          sentence: contentSentence,
+          type: "rejected_approach",
+          repository,
+          sessionId,
+          turn,
+          sourceRole,
+        }));
+      }
     }
   }
   return memories;
@@ -154,6 +228,9 @@ export function extractDirectiveMemoriesFromTurn({ turn, text, repository, sessi
 const DECISION_PATTERNS = [
   /^(?:we|i)\s+(?:have\s+)?decided\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^(?:we|i)\s+(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^(?:we|i)\s+(?:changed|switched|moved)\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^.*\b(?:we|i)\s+(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^the\s+decision\s+changed\b.*?:\s*(?:use|choose)\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^the\s+decision\s+is\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
 ];
 
@@ -168,12 +245,12 @@ export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionI
     if (!match) {
       continue;
     }
-    const choice = normalizeText(match[1]);
+    const choice = normalizeText(match[1]).replace(/[;,]+$/, "").replace(/\s+(?:instead|rather)$/i, "").trim();
     const rationale = normalizeText(match[2] ?? "");
     if (!choice || choice.length < 3) {
       continue;
     }
-    const reversal = /^(?:instead|rather)|\b(?:changed|no longer|reconsidered)\b/i.test(sentence);
+    const reversal = /^(?:instead|rather)\b|\b(?:changed|switched|moved)\s+to\b|\b(?:no longer|reconsidered)\b|\s+(?:instead|rather)[.!?]*$/i.test(sentence);
     const scope = scopeForExtractedDirective(sentence, repository);
     const { scopeMetadata, ...scopeFields } = scope;
     memories.push({
@@ -224,12 +301,19 @@ function attachExtractionEvidence(memory, {
     ?? memory.sourceRecordId
     ?? fallbackRecordId
     ?? `memory:${evidenceIndex}`;
-  const revision = turn?.source_revision ?? memory.sourceRevision ?? contentHash;
   const sourceKind = EVIDENCE_SOURCE_KINDS[memory.type] ?? memory.type ?? "semantic";
   const propositionHash = hashText(normalizeEvidenceText(content));
-  const key = `session:${sessionId}:record:${sourceRecordId}:type:${memory.type}:proposition:${propositionHash}`;
   const sourceRole = memory.metadata?.sourceRole
     ?? (turn?.assistant_response && !turn?.user_message ? "assistant" : "user");
+  const sourceText = sourceRole === "assistant" ? turn?.assistant_response : turn?.user_message;
+  const sourceRevision = turn
+    ? hashText(JSON.stringify({
+      role: sourceRole,
+      text: normalizeText(sourceText),
+    }))
+    : contentHash;
+  const revision = turn?.source_revision ?? memory.sourceRevision ?? sourceRevision;
+  const key = `session:${sessionId}:record:${sourceRecordId}:type:${memory.type}:proposition:${propositionHash}`;
   return {
     ...memory,
     metadata: {
@@ -261,18 +345,20 @@ export function attachEvidenceToSemanticMemories(memories, { sessionId, turns })
 }
 
 const REVERSAL_STOPWORDS = new Set([
-  "because", "chose", "decided", "decision", "instead", "postgresql", "sqlite", "use", "used",
-  "rather", "settled", "selected", "the", "this", "with", "will", "would",
+  "about", "app", "application", "because", "changed", "chose", "code", "concurrent", "database",
+  "decided", "decision", "deployment", "embedded", "feature", "for", "implementation", "instead",
+  "moved", "need", "needs", "on", "portable", "rather", "reconsidered", "selected", "service",
+  "settled", "simple", "switched", "system", "target", "test", "testing", "tests", "the", "this",
+  "use", "used", "using", "with", "will", "would", "writers",
 ]);
 
 function decisionTopicTokens(content) {
-  return new Set(
-    normalizeText(content)
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, " ")
-      .split(/\s+/)
-      .filter((token) => token.length >= 5 && !REVERSAL_STOPWORDS.has(token)),
-  );
+  const normalized = normalizeText(content).toLowerCase();
+  const topic = normalized.match(/\b(?:for|about|regarding|on)\s+(.+?)(?:\s+because\b|$)/)?.[1] ?? "";
+  return new Set(topic
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length >= 4 && !REVERSAL_STOPWORDS.has(token)));
 }
 
 function decisionsShareTopic(left, right) {

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -697,9 +697,11 @@ function personaScope(message, repository) {
 }
 
 function extractInteractionStyleMemory({ message, repository, sessionId, turnIndex }) {
-  if (message.includes(";")) return null;
+  if (message.includes(";") || isOneOffDirectiveRequest(message)) return null;
   const body = directiveBody(message);
-  const direct = body.replace(/^(?:can|could|would) you\s+(?=(?:talk|speak|respond|reply|sound|be|keep|write|communicate|use|add|include)\b)/i, "please ").replace(/\?$/, ".");
+  const requestBody = body.replace(/^(?:can|could|would) you\s+(?=(?:talk|speak|respond|reply|sound|be|keep|write|communicate|use|add|include)\b)/i, "please ");
+  const direct = requestBody === body ? body : requestBody.replace(/\?$/, ".");
+  if (/^(?:i(?:'d| would)? like|i want)\s+to\s+(?:know|understand|learn|explain|discuss|document|describe)\b/i.test(direct)) return null;
   if (isNonDirectiveSentence(direct) || isHypotheticalDirectiveSentence(message)
     || !/^(?:please\s+)?(?:talk|speak|respond|reply|sound|be|keep|write|communicate|use|add|include|i(?:'d| would)? like|i prefer|i want|it helps when|feel free to|let'?s|we should)\b/i.test(direct)) return null;
   const signals = detectInteractionStyleSignals(direct);
@@ -743,7 +745,7 @@ function extractAssistantIdentityMemories(turns, repository, sessionId) {
   for (const turn of turns) {
     for (const message of splitSentences(normalizeTurnText(turn.user_message))) {
       const assistantName = detectAssistantIdentityDeclaration(directiveBody(message));
-      if (!assistantName || isNonDirectiveSentence(message) || isHypotheticalDirectiveSentence(message)) continue;
+      if (!assistantName || isNonDirectiveSentence(message) || isHypotheticalDirectiveSentence(message) || isOneOffDirectiveRequest(message)) continue;
       memories.push({
         type: "assistant_identity",
         content: `The user calls the assistant ${assistantName}.`,

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -517,19 +517,17 @@ function extractSemanticMemoriesFromTurns(turns, repository, sessionId, config =
   for (const turn of recentTurns) {
     const userMessage = normalizeTurnText(turn.user_message, config);
     if (userMessage) {
-      const interactionStyleMemory = extractInteractionStyleMemory({
-        message: userMessage,
-        repository,
-        sessionId,
-        turnIndex: turn.turn_index,
-      });
-      if (interactionStyleMemory) {
-        memories.push(interactionStyleMemory);
-      }
-      if (!interactionStyleMemory) {
-        memories.push(...extractDirectiveMemoriesFromTurn({
+      for (const sentence of splitSentences(userMessage, { splitSemicolons: false })) {
+        const interactionStyleMemory = extractInteractionStyleMemory({
+          message: sentence,
+          repository,
+          sessionId,
+          turnIndex: turn.turn_index,
+        });
+        if (interactionStyleMemory) memories.push(interactionStyleMemory);
+        else memories.push(...extractDirectiveMemoriesFromTurn({
           turn,
-          text: userMessage,
+          text: sentence,
           repository,
           sessionId,
           sourceRole: "user",
@@ -689,9 +687,22 @@ function buildInteractionStyleProfile(signals) {
   };
 }
 
+// Genuine persona declarations can be global, but an explicit repository
+// qualifier takes precedence over this type's default.
+function personaScope(message, repository) {
+  const repoSpecific = /\b(?:for|in)\s+(?:this|the current)(?:\s+[a-z][a-z0-9_-]*){0,2}\s+(?:repo(?:sitory)?|project|app)\b/i.test(message);
+  return repoSpecific
+    ? { scope: MEMORY_SCOPE.REPO, repository }
+    : { scope: MEMORY_SCOPE.GLOBAL, repository: null };
+}
+
 function extractInteractionStyleMemory({ message, repository, sessionId, turnIndex }) {
-  void repository;
-  const signals = detectInteractionStyleSignals(message);
+  if (message.includes(";")) return null;
+  const body = directiveBody(message);
+  const direct = body.replace(/^(?:can|could|would) you\s+(?=(?:talk|speak|respond|reply|sound|be|keep|write|communicate|use|add|include)\b)/i, "please ").replace(/\?$/, ".");
+  if (isNonDirectiveSentence(direct) || isHypotheticalDirectiveSentence(message)
+    || !/^(?:please\s+)?(?:talk|speak|respond|reply|sound|be|keep|write|communicate|use|add|include|i(?:'d| would)? like|i prefer|i want|it helps when|feel free to|let'?s|we should)\b/i.test(direct)) return null;
+  const signals = detectInteractionStyleSignals(direct);
   if (!signals.requestPattern) {
     return null;
   }
@@ -704,11 +715,10 @@ function extractInteractionStyleMemory({ message, repository, sessionId, turnInd
   return {
     type: "interaction_style",
     content: `Interaction style preference: ${message}`,
-    repository: null,
-    scope: MEMORY_SCOPE.GLOBAL,
+    ...personaScope(message, repository),
     sourceSessionId: sessionId,
     sourceTurnIndex: turnIndex,
-    confidence: 0.92,
+    confidence: 0.78,
     tags: uniqueStrings([
       "interaction-style",
       profile.voice,
@@ -719,6 +729,8 @@ function extractInteractionStyleMemory({ message, repository, sessionId, turnInd
     ], 6),
     metadata: {
       source: "rule_extractor",
+      sourceRole: "user",
+      confidenceBasis: "explicit_style_sentence",
       profile,
       patternType: "direct_or_soft",
       requestPattern: signals.requestPattern.toString(),
@@ -726,29 +738,28 @@ function extractInteractionStyleMemory({ message, repository, sessionId, turnInd
   };
 }
 
-function extractAssistantIdentityMemories(turns, sessionId) {
+function extractAssistantIdentityMemories(turns, repository, sessionId) {
   const memories = [];
-  const recentTurns = turns.slice(-12);
-  for (const turn of recentTurns) {
-    const message = normalizeTurnText(turn.user_message);
-    const assistantName = detectAssistantIdentityDeclaration(message);
-    if (!assistantName) {
-      continue;
+  for (const turn of turns) {
+    for (const message of splitSentences(normalizeTurnText(turn.user_message))) {
+      const assistantName = detectAssistantIdentityDeclaration(directiveBody(message));
+      if (!assistantName || isNonDirectiveSentence(message) || isHypotheticalDirectiveSentence(message)) continue;
+      memories.push({
+        type: "assistant_identity",
+        content: `The user calls the assistant ${assistantName}.`,
+        ...personaScope(message, repository),
+        sourceSessionId: sessionId,
+        sourceTurnIndex: turn.turn_index,
+        confidence: 0.85,
+        tags: ["assistant-identity", "user", assistantName.toLowerCase()],
+        metadata: {
+          source: "rule_extractor",
+          sourceRole: "user",
+          confidenceBasis: "explicit_naming_sentence",
+          assistantName,
+        },
+      });
     }
-    memories.push({
-      type: "assistant_identity",
-      content: `The user calls the assistant ${assistantName}.`,
-      repository: null,
-      scope: MEMORY_SCOPE.GLOBAL,
-      sourceSessionId: sessionId,
-      sourceTurnIndex: turn.turn_index,
-      confidence: 0.99,
-      tags: ["assistant-identity", "user", assistantName.toLowerCase()],
-      metadata: {
-        source: "rule_extractor",
-        assistantName,
-      },
-    });
   }
   return memories;
 }
@@ -821,41 +832,43 @@ function extractAssistantGoalMemories(turns, repository, sessionId, config = nul
   return memories;
 }
 
-function extractRecurringMistakeMemories(turns, sessionId, config = null) {
+function extractRecurringMistakeMemories(turns, repository, sessionId, config = null) {
   const memories = [];
   const seen = new Set();
-  const recentTurns = turns.slice(-20);
-  for (const turn of recentTurns) {
-    const message = normalizeTurnText(turn.user_message, config);
-    if (!message || message.length > 260) {
-      continue;
+  for (const turn of turns.slice(-20)) {
+    for (const sentence of splitSentences(normalizeTurnText(turn.user_message, config))) {
+      if (isNonDirectiveSentence(sentence) || isHypotheticalDirectiveSentence(sentence)) continue;
+      const body = directiveBody(sentence);
+      // Anchor feedback to the user addressing the assistant. Reported speech,
+      // incidental occurrences of "again", and praise are not corrections.
+      const match = body.match(/^(?:you keep|you are repeating|you(?:'re| are) making the same mistake)\b[:\s-]*(.+)$/i)
+        ?? (/^you always\b/i.test(body) && /\b(?:ignor(?:e|ing)|forget(?:ting)?|fail(?:ing)?|wrong|stale|incorrect|broken|mistakes?)\b/i.test(body)
+          ? body.match(/^you always\b[:\s-]*(.+)$/i) : null);
+      const mistake = normalizeText(match?.[1] ?? "");
+      if (mistake.length < 8) continue;
+      const key = mistake.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const { scopeMetadata, ...scope } = scopeForExtractedDirective(sentence, repository);
+      memories.push({
+        type: "recurring_mistake",
+        content: `Recurring mistake to avoid: ${mistake}`,
+        scope: MEMORY_SCOPE.REPO,
+        repository,
+        ...scope,
+        sourceSessionId: sessionId,
+        sourceTurnIndex: turn.turn_index,
+        confidence: 0.76,
+        tags: ["recurring-mistake", "feedback", "user"],
+        metadata: {
+          ...scopeMetadata,
+          source: "rule_extractor",
+          sourceRole: "user",
+          confidenceBasis: "direct_recurring_feedback",
+          mistake,
+        },
+      });
     }
-    const match = message.match(
-      /\b(?:you keep|you always|again(?:\s+you)?|same mistake|repeating)\b[:\s-]*(.+)$/i,
-    );
-    const mistake = normalizeText(match?.[1] ?? "");
-    if (!mistake || mistake.length < 8) {
-      continue;
-    }
-    const key = mistake.toLowerCase();
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    memories.push({
-      type: "recurring_mistake",
-      content: `Recurring mistake to avoid: ${mistake}`,
-      repository: null,
-      scope: MEMORY_SCOPE.GLOBAL,
-      sourceSessionId: sessionId,
-      sourceTurnIndex: turn.turn_index,
-      confidence: 0.9,
-      tags: ["recurring-mistake", "feedback", "user"],
-      metadata: {
-        source: "rule_extractor",
-        mistake,
-      },
-    });
   }
   return memories;
 }
@@ -879,10 +892,10 @@ function collectImplicitCorrectionSignals(turns, config = null) {
   const signals = [];
   for (const turn of turns.slice(-20)) {
     const message = normalizeTurnText(turn.user_message, config);
-    if (!message || message.length > 280) {
+    if (!message || message.length > 280 || isNonDirectiveSentence(message) || isHypotheticalDirectiveSentence(message)) {
       continue;
     }
-    if (!firstMatchingPattern(message, IMPLICIT_CORRECTION_PATTERNS)) {
+    if (!firstMatchingPattern(message, IMPLICIT_CORRECTION_PATTERNS.slice(0, -2))) {
       continue;
     }
     const cleaned = stripImplicitCorrectionLead(message);
@@ -897,7 +910,7 @@ function collectImplicitCorrectionSignals(turns, config = null) {
   return signals;
 }
 
-function inferRecurringMistakeFromCorrections(turns, sessionId, config = null) {
+function inferRecurringMistakeFromCorrections(turns, repository, sessionId, config = null) {
   const signals = collectImplicitCorrectionSignals(turns, config);
   if (signals.length < 2) {
     return null;
@@ -907,14 +920,16 @@ function inferRecurringMistakeFromCorrections(turns, sessionId, config = null) {
   return {
     type: "recurring_mistake",
     content: `Recurring mistake to avoid: ${mistake}.`,
-    repository: null,
-    scope: MEMORY_SCOPE.GLOBAL,
+    repository,
+    scope: MEMORY_SCOPE.REPO,
     sourceSessionId: sessionId,
     sourceTurnIndex: signals.at(-1)?.turnIndex ?? null,
-    confidence: 0.93,
+    confidence: 0.7,
     tags: ["recurring-mistake", "feedback", "implicit-session", "correction-pattern"],
     metadata: {
       source: "implicit_session_inference",
+      sourceRole: "user",
+      confidenceBasis: "repeated_direct_user_corrections",
       signalType: "repeated_correction",
       mistake,
       correctionCount: signals.length,
@@ -1108,7 +1123,7 @@ function buildSessionSemanticMemories({
 }) {
   const explicitMemories = extractSemanticMemoriesFromTurns(turns, effectiveRepository, sessionId, config);
   const assistantGoalMemories = extractAssistantGoalMemories(turns, effectiveRepository, sessionId, config);
-  const recurringMistakeMemories = extractRecurringMistakeMemories(turns, sessionId, config);
+  const recurringMistakeMemories = extractRecurringMistakeMemories(turns, effectiveRepository, sessionId, config);
   const implicitAssistantGoal = assistantGoalMemories.length === 0
     ? inferAssistantGoalFromFailures({
       turns,
@@ -1121,13 +1136,13 @@ function buildSessionSemanticMemories({
     })
     : null;
   const implicitRecurringMistake = recurringMistakeMemories.length === 0
-    ? inferRecurringMistakeFromCorrections(turns, sessionId, config)
+    ? inferRecurringMistakeFromCorrections(turns, effectiveRepository, sessionId, config)
     : null;
 
   return {
     learnings: explicitMemories.map((item) => item.content),
     semanticMemories: [
-      ...extractAssistantIdentityMemories(turns, sessionId),
+      ...extractAssistantIdentityMemories(turns, effectiveRepository, sessionId),
       ...extractUserIdentityMemories(turns, effectiveRepository, sessionId),
       ...assistantGoalMemories,
       ...(implicitAssistantGoal ? [implicitAssistantGoal] : []),

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -6,15 +6,17 @@ import {
 import { createHash } from "node:crypto";
 import { normalizeText } from "../utils/text-normalizer.mjs";
 import { readRetentionSanitizationEnabled } from "../rollout/rollout-flags.mjs";
+import { collectRetiredDirectiveEvidenceKeys } from "./directive-corrections.mjs";
 import { collectRetiredDecisionEvidenceKeys } from "./decision-subject.mjs";
 import { stripInjectedContext } from "../memory/retention-sanitizer.mjs";
 import {
   directiveBody,
-  isConditionalDirectiveSentence,
+  isHypotheticalDirectiveSentence,
   isNonDirectiveSentence,
   isOneOffDirectiveRequest,
   splitDirectiveClauses,
   splitSentences,
+  standingDirectiveType,
 } from "./extraction-grammar.mjs";
 
 function normalizeTurnText(value, config = null) {
@@ -83,15 +85,16 @@ const EXPLICIT_REJECTION_PATTERNS = [
   /^(?:i|we)\s+(?:do not|don't|never)\s+(?:want|like|use|need|store|include|see)\s+.+$/i,
 ];
 
-const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:globally|across\s+(?:all\s+)?(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|for\s+(?:every|all)\s+(?:my\s+)?(?:project|repository|repo)|regardless\s+of\s+(?:the\s+)?repo(?:sitory)?|in\s+all\s+(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos))\b/i;
+const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:for\s+all\s+work|(?:in|for)\s+(?:any|every)\s+(?:project|repository|repo)|reviewing\s+any\s+(?:project|repository|repo)|globally|across\s+(?:all\s+)?(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|for\s+(?:every|all)\s+(?:my\s+)?(?:project|repository|repo)|regardless\s+of\s+(?:the\s+)?repo(?:sitory)?|in\s+all\s+(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos))\b/i;
 
 function hasExplicitDirective(text, patterns) {
   const body = directiveBody(text);
   const correctionLead = /^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i.test(text);
-  return !isNonDirectiveSentence(text)
-    && !isConditionalDirectiveSentence(text)
+  return !isNonDirectiveSentence(text, { allowConditions: true })
+    && !isHypotheticalDirectiveSentence(text)
     && !isOneOffDirectiveRequest(text)
-    && (patterns.some((pattern) => pattern.test(body))
+    && (standingDirectiveType(text) === (patterns === EXPLICIT_PREFERENCE_PATTERNS ? "user_preference" : "rejected_approach")
+      || patterns.some((pattern) => pattern.test(body))
       || (patterns === EXPLICIT_PREFERENCE_PATTERNS
         && correctionLead
         && /^use\s+.+$/i.test(body)));
@@ -111,8 +114,8 @@ function scopeForExtractedDirective(text, repository) {
   return {};
 }
 
-function buildDirectiveMemory({ sentence, type, repository, sessionId, turn, sourceRole }) {
-  const scope = scopeForExtractedDirective(sentence, repository);
+function buildDirectiveMemory({ sentence, scopeText = sentence, type, repository, sessionId, turn, sourceRole }) {
+  const scope = scopeForExtractedDirective(scopeText, repository);
   const rejection = type === "rejected_approach";
   const { scopeMetadata, ...scopeFields } = scope;
   return {
@@ -134,20 +137,25 @@ function buildDirectiveMemory({ sentence, type, repository, sessionId, turn, sou
 
 export function extractDirectiveMemoriesFromTurn({ turn, text, repository, sessionId, sourceRole }) {
   const memories = [];
-  for (const rawSentence of splitSentences(text)) {
-    // Qualifiers govern the whole coordinated sentence, not just its last
-    // clause. A rationale followed by an explicit request is handled below.
-    if (isNonDirectiveSentence(rawSentence)
-      || (isConditionalDirectiveSentence(rawSentence) && !/\bso\s+please\b/i.test(rawSentence))) {
+  for (const rawSentence of splitSentences(text, { splitSemicolons: false })) {
+    if (isNonDirectiveSentence(rawSentence, { allowConditions: true })
+      || isHypotheticalDirectiveSentence(rawSentence) || isOneOffDirectiveRequest(rawSentence)) {
       continue;
     }
-    for (const sentence of splitDirectiveClauses(rawSentence)) {
-      const contentSentence = /^please\s/i.test(sentence) && /\bso\b/i.test(rawSentence)
+    const clauses = splitDirectiveClauses(rawSentence);
+    // A diagnostic observation followed by a semicolon and an action is still
+    // an incident request; the first clause must establish a standing rule.
+    if (rawSentence.includes(";") && !hasExplicitDirective(clauses[0], EXPLICIT_PREFERENCE_PATTERNS)
+      && !hasExplicitDirective(clauses[0], EXPLICIT_REJECTION_PATTERNS)) continue;
+    for (const sentence of clauses) {
+      const carriesSharedCondition = clauses.length > 1 && /\b(?:if|when|whenever|unless)\b/i.test(rawSentence);
+      const contentSentence = carriesSharedCondition || (/^please\s/i.test(sentence) && /\bso\b/i.test(rawSentence))
         ? rawSentence
         : sentence;
       if (hasExplicitDirective(sentence, EXPLICIT_PREFERENCE_PATTERNS)) {
         memories.push(buildDirectiveMemory({
           sentence: contentSentence,
+          scopeText: rawSentence,
           type: "user_preference",
           repository,
           sessionId,
@@ -158,6 +166,7 @@ export function extractDirectiveMemoriesFromTurn({ turn, text, repository, sessi
       if (hasExplicitDirective(sentence, EXPLICIT_REJECTION_PATTERNS)) {
         memories.push(buildDirectiveMemory({
           sentence: contentSentence,
+          scopeText: rawSentence,
           type: "rejected_approach",
           repository,
           sessionId,
@@ -176,7 +185,7 @@ const DECISION_PATTERNS = [
   /^(?:we|i)\s+(?:changed|switched|moved)\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^(?:after|following)\s+[^,]+,\s*(?:we|i)\s+(?:(?:initially|ultimately|finally)\s+)?(?:chose|selected|settled\s+on)\s+(.+?)(?:\s+because\s+(.+))?$/i,
   /^the\s+decision\s+changed\b.*?:\s*(?:use|choose)\s+(.+?)(?:\s+because\s+(.+))?$/i,
-  /^the\s+decision\s+is\s+to\s+(.+?)(?:\s+because\s+(.+))?$/i,
+  /^the\s+(?:[a-z][a-z0-9-]*\s+){0,4}decision\s+is\s+(?:to\s+)?(.+?)(?:\s+because\s+(.+))?$/i,
 ];
 
 function isNonCompletedDecisionSentence(text) {
@@ -196,7 +205,8 @@ export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionI
     }
     const choice = normalizeText(match[1]).replace(/[;,]+$/, "").replace(/\s+(?:instead|rather)$/i, "").trim();
     const rationale = normalizeText(match[2] ?? "");
-    if (!choice || choice.length < 3) {
+    const context = decisionSentence.match(/^((?:after|following)\s+[^,]+),/i)?.[1] ?? "";
+    if (!choice || choice.length < 3 || /^(?:recorded|documented|pending|open|undecided|unchanged|being)\b/i.test(choice)) {
       continue;
     }
     const reversal = /^(?:instead|rather)\b|\bdecision\s+changed\b|\b(?:changed|switched|moved)\s+to\b|\b(?:no longer|reconsidered)\b|\s+(?:instead|rather)[.!?]*$/i.test(sentence);
@@ -205,7 +215,7 @@ export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionI
     const { scopeMetadata, ...scopeFields } = scope;
     memories.push({
       type: "decision",
-      content: `Decision: ${choice}${rationale ? ` because ${rationale}` : ""}`,
+      content: `Decision: ${choice}${rationale ? ` because ${rationale}` : ""}${context ? ` (${context})` : ""}`,
       ...scopeFields,
       sourceSessionId: sessionId,
       sourceTurnIndex: turn.turn_index,
@@ -218,6 +228,9 @@ export function extractDecisionMemoryFromTurn({ turn, text, repository, sessionI
         source: "rule_extractor",
         sourceRole,
         confidenceBasis: "explicit_completed_decision",
+        decisionChoice: choice,
+        decisionRationale: rationale,
+        ...(context ? { decisionContext: context } : {}),
         verificationStatus: sourceRole === "assistant" ? "unverified_assistant_claim" : "conversation_record",
         ...(reversal ? { decisionStatus: "reversal" } : {}),
         ...(contextualReversal ? { contextualReversal: true } : {}),
@@ -480,8 +493,9 @@ function buildEpisodeSummary({
   decisions,
   openItems,
   config = null,
+  outcome = null,
 }) {
-  const seed = buildEpisodeSummarySeed({ latestCheckpoint, session, turns, config });
+  const seed = outcome ?? buildEpisodeSummarySeed({ latestCheckpoint, session, turns, config });
   const details = buildEpisodeSummaryDetails({ decisions, actions, openItems, files, refs });
 
   if (seed) {
@@ -946,6 +960,7 @@ function collectFailureSignals({ turns, actions, decisions, openItems, config = 
     const observation = splitSentences(source.text).filter((sentence) =>
       !isNonDirectiveSentence(sentence)
       && !isNonCompletedDecisionSentence(sentence)
+      && !standingDirectiveType(sentence)
       && !/^(?:please|(?:i|we)\s+will)\b/i.test(sentence)
       && firstMatchingPattern(sentence, FAILURE_SIGNAL_PATTERNS)
       && !firstMatchingPattern(sentence, FAILURE_RESOLUTION_PATTERNS),
@@ -1139,19 +1154,6 @@ export function extractSessionMemories({ sessionId, repository, sessionArtifacts
   const actions = extractActions({ latestCheckpoint, files });
   const decisions = extractDecisions(latestCheckpoint);
   const openItems = extractOpenItems(latestCheckpoint);
-  const summary = buildEpisodeSummary({
-    sessionId,
-    repository: effectiveRepository,
-    session,
-    latestCheckpoint,
-    turns,
-    files,
-    refs,
-    actions,
-    decisions,
-    openItems,
-    config,
-  });
   const { learnings, semanticMemories: unannotatedSemanticMemories } = buildSessionSemanticMemories({
     turns,
     effectiveRepository,
@@ -1165,7 +1167,33 @@ export function extractSessionMemories({ sessionId, repository, sessionArtifacts
     sessionId,
     turns,
   });
-  const retiredEvidenceKeys = collectRetiredDecisionEvidenceKeys(semanticMemories);
+  const retiredEvidenceKeys = [
+    ...collectRetiredDecisionEvidenceKeys(semanticMemories),
+    ...collectRetiredDirectiveEvidenceKeys(semanticMemories, turns),
+  ];
+  const retired = new Set(retiredEvidenceKeys);
+  const activeContents = new Set(semanticMemories.filter((memory) => !retired.has(memory.evidence.key)).map((memory) => memory.content));
+  const activeLearnings = learnings.filter((content) => activeContents.has(content));
+  const outcomes = semanticMemories.filter((memory) => memory.type === "decision" && !retired.has(memory.evidence.key));
+  const attributedOutcomes = uniqueStrings(outcomes.slice(-8).map((memory) =>
+    `${memory.metadata?.sourceRole === "assistant" ? "Assistant reported" : "User stated"}: ${memory.content}`,
+  ));
+  const episodeDecisions = uniqueStrings([...attributedOutcomes, ...decisions]);
+  const summary = buildEpisodeSummary({
+    sessionId,
+    repository: effectiveRepository,
+    session,
+    latestCheckpoint,
+    turns,
+    files,
+    refs,
+    actions,
+    decisions: episodeDecisions,
+    openItems,
+    config,
+    outcome: attributedOutcomes.at(-1) ?? null,
+  });
+
   const themes = extractThemes(
     [summary, ...actions.slice(0, 3), ...decisions.slice(0, 2), ...openItems.slice(0, 2)].join(" "),
     effectiveRepository,
@@ -1192,8 +1220,8 @@ export function extractSessionMemories({ sessionId, repository, sessionArtifacts
       branch: session.branch ?? workspace.workspace?.branch ?? null,
       summary,
       actions,
-      decisions,
-      learnings,
+      decisions: episodeDecisions,
+      learnings: activeLearnings,
       filesChanged: files.map((file) => file.file_path),
       refs: refs.map((ref) => `${ref.ref_type}:${ref.ref_value}`),
       significance,

--- a/lib/utils/repository-identity.mjs
+++ b/lib/utils/repository-identity.mjs
@@ -1,0 +1,58 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import path from "node:path";
+
+/** Normalize remote transports without dropping their host or nested path. */
+export function canonicalRemoteIdentity(value) {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (!text) return null;
+  let host;
+  let remotePath;
+  try {
+    if (text.includes("://")) {
+      const url = new URL(text);
+      if (!["ssh:", "https:", "http:", "git:"].includes(url.protocol)) return null;
+      host = url.host.toLowerCase();
+      remotePath = url.pathname;
+    } else {
+      const match = text.match(/^(?:[^@/:\s]+@)?(\[[^\]]+\]|[^/:\s]+):(.+)$/u);
+      if (!match || match[1].length === 1) return null;
+      host = match[1].toLowerCase();
+      remotePath = match[2];
+    }
+    remotePath = remotePath.replace(/^\/+|\/+$/gu, "").replace(/\.git$/u, "");
+    if (!host || !remotePath || /[\s?#]/u.test(remotePath)
+      || remotePath.split("/").some((part) => !part || part === "." || part === "..")) return null;
+    return `${host}/${remotePath}`;
+  } catch { return null; }
+}
+
+function mappedIdentity(legacy, mappings) {
+  if (!legacy) return null;
+  const entries = Array.isArray(mappings) ? mappings : [];
+  const matches = new Set(entries.filter((row) => row.legacy === legacy)
+    .map((row) => row.canonical).filter((value) => typeof value === "string" && value.trim()));
+  return matches.size === 1 ? [...matches][0] : null;
+}
+
+/** Resolve live Git identity, or an explicitly approved legacy association. */
+export function resolveRepositoryIdentity({ cwd, explicit, legacy, mappings = [] } = {}) {
+  if (typeof explicit === "string" && explicit.trim()) return explicit.trim();
+  if (typeof cwd === "string" && cwd.trim()) {
+    const git = (args) => execFileSync("git", args, {
+      cwd, encoding: "utf8", timeout: 1000, stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    // Resolve the Git common directory first: a missing origin must not be
+    // confused with a non-repository, and linked worktrees need one identity.
+    try {
+      const common = realpathSync(path.resolve(cwd, git(["rev-parse", "--git-common-dir"])));
+      try {
+        const remote = canonicalRemoteIdentity(git(["remote", "get-url", "origin"]));
+        if (remote) return remote;
+      } catch { /* A local-only repository still has a stable local identity. */ }
+      return `local:${createHash("sha256").update(common).digest("hex")}`;
+    } catch { /* Only explicitly mapped host-provided legacy IDs are trusted. */ }
+  }
+  return mappedIdentity(typeof legacy === "string" ? legacy.trim() : null, mappings);
+}

--- a/tests/unit/backfill-extraction.test.mjs
+++ b/tests/unit/backfill-extraction.test.mjs
@@ -323,7 +323,7 @@ describe("backfill extraction and progress reporting", () => {
       });
 
       assert.equal(artifacts.length, 1);
-      assert.equal(artifacts[0].source_case_id, "session:recurring_mistake:global:fixture-repo:recurring_mistake:missing or overriding explicit user corrections before continuing implementation");
+      assert.equal(artifacts[0].source_case_id, "session:recurring_mistake:repo:fixture-repo:recurring_mistake:missing or overriding explicit user corrections before continuing implementation");
       assert.equal(artifacts[0].title, "Session-inferred recurring mistake");
       assert.equal(artifacts[0].summary, "Mistake: missing or overriding explicit user corrections before continuing implementation");
       assert.ok(artifacts[0].linked_memory_id);

--- a/tests/unit/cli-scope-hotspots.test.mjs
+++ b/tests/unit/cli-scope-hotspots.test.mjs
@@ -69,7 +69,7 @@ describe("classifySemanticMemory", () => {
     });
   });
 
-  test("keeps recurring mistakes global even when repository text is present", () => {
+  test("keeps inferred recurring mistakes scoped to their repository", () => {
     const classification = classifySemanticMemory({
       type: "recurring_mistake",
       repository: "owner/test-repo",
@@ -77,11 +77,9 @@ describe("classifySemanticMemory", () => {
     });
 
     assert.deepEqual(classification, {
-      scope: MEMORY_SCOPE.GLOBAL,
-      repository: null,
-      metadata: {
-        originRepository: "owner/test-repo",
-      },
+      scope: MEMORY_SCOPE.REPO,
+      repository: "owner/test-repo",
+      metadata: {},
     });
   });
 });

--- a/tests/unit/db-legacy-schema-version.test.mjs
+++ b/tests/unit/db-legacy-schema-version.test.mjs
@@ -36,6 +36,7 @@ describe("LoreDb legacy schema version compatibility", () => {
         "improvement-backlog",
         "lore-visibility-substrate",
         "memory-domain-observation",
+        "lifecycle-foundation",
       ],
     );
   });

--- a/tests/unit/db-lifecycle-review-regressions.test.mjs
+++ b/tests/unit/db-lifecycle-review-regressions.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { withFixtureDb } from "../helpers/fixture-db.mjs";
+import { restoreRecoverySnapshot } from "../../lib/maintenance/recovery.mjs";
+
+const repo = "fixture/review";
+function generated(content, key = "k", revision = "a") {
+  return { type: "user_preference", content, scope: "repo", repository: repo,
+    metadata: { source: "rule_extractor" }, evidence: { key, revision, contentHash: content } };
+}
+function reconcile(db, memories, retiredEvidenceKeys = []) {
+  return db.reconcileGeneratedMemories({ sessionId: "review-session", repository: repo, memories, retiredEvidenceKeys });
+}
+
+test("accepted changed evidence updates its proposition while preserving independent support", async () => {
+  const { db, cleanup } = await withFixtureDb();
+  try {
+    const [oldId] = reconcile(db, [generated("Prefer kiwi fixtures.")]);
+    reconcile(db, [generated("Prefer kiwi fixtures.", "independent")]);
+    const [nextId] = reconcile(db, [generated("Prefer citrus fixtures.", "k", "b")]);
+    assert.notEqual(nextId, oldId);
+    assert.equal(db.searchSemantic({ query: "citrus", repository: repo }).length, 1);
+    assert.equal(db.searchSemantic({ query: "kiwi", repository: repo }).length, 1);
+    reconcile(db, [], ["independent"]);
+    assert.equal(db.searchSemantic({ query: "kiwi", repository: repo }).length, 0);
+    assert.equal(db.searchSemantic({ query: "citrus", repository: repo }).length, 1);
+  } finally { cleanup(); }
+});
+
+test("unchanged proposition revision refreshes evidence metadata without reinforcing replay", async () => {
+  const { db, cleanup } = await withFixtureDb();
+  try {
+    const [id] = reconcile(db, [generated("Prefer kiwi fixtures.")]);
+    const before = db.db.prepare("SELECT reinforcement_count FROM semantic_memory WHERE id=?").get(id);
+    reconcile(db, [generated("Prefer kiwi fixtures.", "k", "b")]);
+    const after = db.db.prepare("SELECT reinforcement_count, metadata_json FROM semantic_memory WHERE id=?").get(id);
+    assert.equal(after.reinforcement_count, before.reinforcement_count);
+    assert.equal(JSON.parse(after.metadata_json).evidence.revision, "b");
+  } finally { cleanup(); }
+});
+
+test("manual scope authority survives inferred replay and retirement", async () => {
+  const { db, cleanup } = await withFixtureDb();
+  try {
+    const id = db.insertSemanticMemory({ ...generated("Prefer kiwi fixtures."), confidence: 0.7, metadata: { source: "memory_save" } });
+    db.applyScopeChanges({ targetType: "semantic", ids: [id], scope: "repo", repository: repo, actor: "user", reason: "fixture", source: "memory_scope" });
+    const before = db.db.prepare("SELECT confidence, reinforcement_count, metadata_json FROM semantic_memory WHERE id=?").get(id);
+    reconcile(db, [{ ...generated("Prefer kiwi fixtures."), confidence: 0.95 }]);
+    assert.deepEqual(db.db.prepare("SELECT confidence, reinforcement_count, metadata_json FROM semantic_memory WHERE id=?").get(id), before);
+    reconcile(db, [], ["k"]);
+    assert.equal(db.searchSemantic({ query: "kiwi", repository: repo })[0]?.id, id);
+  } finally { cleanup(); }
+});
+
+test("missing checkpoint returns the stable CAS conflict category", async () => {
+  const { db, cleanup } = await withFixtureDb();
+  try {
+    assert.throws(() => db.saveIngestionCheckpoint("codex", "missing", { expectedCheckpointRevision: 1, revision: "opaque", offset: 1 }),
+      (error) => error.code === "CHECKPOINT_REVISION_CONFLICT" && error.currentRevision === 0);
+  } finally { cleanup(); }
+});
+
+test("direct restore rejects unrelated SQLite and preserves target", async () => {
+  const { db, cleanup, config } = await withFixtureDb();
+  try {
+    const id = db.insertSemanticMemory(generated("Prefer kiwi fixtures."));
+    const invalid = path.join(path.dirname(config.paths.derivedStorePath), "unrelated.db");
+    const source = new DatabaseSync(invalid);
+    source.exec("CREATE TABLE unrelated (id INTEGER)"); source.close();
+    assert.throws(() => db.restoreFromBackup(invalid), /recognized Lore|complete Lore/);
+    assert.equal(db.db.prepare("SELECT id FROM semantic_memory WHERE id=?").get(id)?.id, id);
+  } finally { cleanup(); }
+});
+
+test("closed-facade direct restore preserves current suppressions", async () => {
+  const { db, cleanup } = await withFixtureDb();
+  try {
+    const id = db.insertSemanticMemory(generated("Prefer kiwi fixtures."));
+    const snapshot = db.backupDatabase();
+    db.forgetMemory({ id }); db.close();
+    db.restoreFromBackup(snapshot);
+    assert.equal(db.db.prepare("SELECT count(*) AS n FROM memory_suppression").get().n, 1);
+  } finally { cleanup(); }
+});
+
+for (const version of ["v13-lore-v0.2.0", "v15-lore-v0.3.0", "v18-lore-v0.10.0"]) {
+  test(`released ${version} recovery migrates the installed stage before merging suppression`, async () => {
+    const { db, cleanup, config } = await withFixtureDb();
+    try {
+      const source = path.join(path.dirname(config.paths.derivedStorePath), "old.db");
+      const snapshot = new DatabaseSync(source);
+      snapshot.exec(readFileSync(new URL(`../fixtures/released-upgrades/${version}.sql`, import.meta.url), "utf8")); snapshot.close();
+      const id = db.insertSemanticMemory(generated("Prefer kiwi fixtures.")); db.forgetMemory({ id }); db.close();
+      restoreRecoverySnapshot({ derivedStorePath: config.paths.derivedStorePath, snapshotPath: source, write: true, clientsStopped: true, detectActiveUsers: () => [] });
+      const installed = new DatabaseSync(config.paths.derivedStorePath, { readOnly: true });
+      try {
+        assert.equal(installed.prepare("SELECT count(*) AS n FROM memory_suppression").get().n, 1);
+        const columns = installed.prepare("PRAGMA table_info(memory_embedding)").all().map((row) => row.name);
+        for (const column of ["content_hash", "provider", "model", "dimensions"]) assert.ok(columns.includes(column));
+      } finally { installed.close(); }
+    } finally { cleanup(); }
+  });
+}
+
+test("revised canonical goals preserve independently supported prior wording", async () => {
+  const { db, cleanup } = await withFixtureDb();
+  const goal = (content, key, revision = "a") => ({ ...generated(content, key, revision), type: "assistant_goal", metadata: { source: "rule_extractor", goal: "fixture-goal" } });
+  try {
+    const [oldId] = reconcile(db, [goal("Keep kiwi work bounded.", "goal")]);
+    reconcile(db, [goal("Keep kiwi work bounded.", "goal-independent")]);
+    const [newId] = reconcile(db, [goal("Keep citrus work bounded.", "goal", "b")]);
+    assert.notEqual(oldId, newId);
+    assert.equal(db.db.prepare("SELECT content FROM semantic_memory WHERE id=?").get(oldId).content, "Keep kiwi work bounded.");
+    assert.equal(db.db.prepare("SELECT content FROM semantic_memory WHERE id=?").get(newId).content, "Keep citrus work bounded.");
+  } finally { cleanup(); }
+});

--- a/tests/unit/db-lifecycle-review-regressions.test.mjs
+++ b/tests/unit/db-lifecycle-review-regressions.test.mjs
@@ -117,3 +117,28 @@ test("revised canonical goals preserve independently supported prior wording", a
     assert.equal(db.db.prepare("SELECT content FROM semantic_memory WHERE id=?").get(newId).content, "Keep citrus work bounded.");
   } finally { cleanup(); }
 });
+
+test("forgetting prior evidence does not suppress its revised replacement", async () => {
+  const { db, cleanup } = await withFixtureDb();
+  try {
+    const [old] = reconcile(db, [generated("Prefer kiwi fixtures.", "k"), generated("Prefer kiwi fixtures.", "independent")]);
+    reconcile(db, [generated("Prefer citrus fixtures.", "k", "b")]);
+    db.forgetMemory({ id: old });
+    const [replacement] = reconcile(db, [generated("Prefer citrus fixtures.", "new-citrus")]);
+    assert.ok(replacement);
+    assert.equal(reconcile(db, [generated("Prefer kiwi fixtures.", "new-kiwi")])[0], null);
+  } finally { cleanup(); }
+});
+
+test("revising retired canonical evidence restores the revised wording", async () => {
+  const { db, cleanup } = await withFixtureDb();
+  const goal = (content, revision) => ({ ...generated(content, "goal", revision), type: "assistant_goal", metadata: { source: "rule_extractor", goal: "fixture-goal" } });
+  try {
+    const [old] = reconcile(db, [goal("Keep kiwi work bounded.", "a")]);
+    reconcile(db, [], ["goal"]);
+    const [current] = reconcile(db, [goal("Keep citrus work bounded.", "b")]);
+    assert.notEqual(current, old);
+    assert.equal(db.searchSemantic({ query: "kiwi", repository: repo }).length, 0);
+    assert.equal(db.searchSemantic({ query: "citrus", repository: repo })[0]?.id, current);
+  } finally { cleanup(); }
+});

--- a/tests/unit/db-reliability-foundation.test.mjs
+++ b/tests/unit/db-reliability-foundation.test.mjs
@@ -284,6 +284,27 @@ describe("database reliability foundation", () => {
     }
   });
 
+  test("LoreDb.restoreFromBackup atomically restores and preserves current suppressions", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const id = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Preserve direct restore suppression.",
+        repository: "fixture-repo",
+        scope: "repo",
+        metadata: { source: "rule_extractor" },
+      });
+      const backupPath = db.backupDatabase();
+      db.forgetMemory({ id });
+      const restored = db.restoreFromBackup(backupPath);
+      assert.equal(restored.schemaVersion, SCHEMA_VERSION);
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM memory_suppression WHERE memory_id = ?").get(id).count, 1);
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM semantic_memory WHERE id = ?").get(id).count, 1);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("mapping APIs preserve explicit legacy to canonical associations", { skip: SKIP_NO_FTS5 }, async () => {
     const { db, cleanup } = await withFixtureDb();
     try {

--- a/tests/unit/db-reliability-foundation.test.mjs
+++ b/tests/unit/db-reliability-foundation.test.mjs
@@ -161,6 +161,33 @@ describe("database reliability foundation", () => {
     }
   });
 
+  test("manual canonical matches remain isolated to their scope and repository", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const manualId = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Use the repository local convention.",
+        repository: "repo-a",
+        scope: "repo",
+        metadata: { source: "memory_save" },
+      });
+      const inferredId = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Use the repository local convention.",
+        repository: "repo-b",
+        scope: "repo",
+        sourceSessionId: "session-repo-b",
+        sourceTurnIndex: 1,
+        metadata: { source: "rule_extractor" },
+      });
+      assert.ok(inferredId);
+      assert.notEqual(inferredId, manualId);
+      assert.equal(db.db.prepare("SELECT repository, scope_source FROM semantic_memory WHERE id = ?").get(inferredId).repository, "repo-b");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("forget records durable suppression and rejects unknown memory ids", { skip: SKIP_NO_FTS5 }, async () => {
     const { db, cleanup } = await withFixtureDb();
     try {

--- a/tests/unit/db-reliability-foundation.test.mjs
+++ b/tests/unit/db-reliability-foundation.test.mjs
@@ -1,0 +1,263 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { applySessionExtraction } from "../../lib/sessions/backfill.mjs";
+import { SCHEMA_VERSION } from "../../lib/db/schema.mjs";
+import { createRecoverySnapshot, restoreRecoverySnapshot } from "../../lib/maintenance/recovery.mjs";
+import { FTS5_AVAILABLE, withFixtureDb } from "../helpers/fixture-db.mjs";
+
+const SKIP_NO_FTS5 = !FTS5_AVAILABLE
+  ? "FTS5 not compiled into this Node.js SQLite build"
+  : false;
+
+function extraction(sessionId, repository, memories) {
+  return {
+    episodeDigest: {
+      id: `episode-${sessionId}`,
+      sessionId,
+      repository,
+      summary: "Fixture summary",
+      dateKey: "2026-09-07",
+      actions: [],
+      decisions: [],
+      learnings: [],
+      filesChanged: [],
+      refs: [],
+      significance: 5,
+      themes: ["fixture"],
+      openItems: [],
+      source: "rule",
+    },
+    semanticMemories: memories,
+  };
+}
+
+describe("database reliability foundation", () => {
+  test("fresh schema is v19 and contains lifecycle tables", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      assert.equal(db.getCurrentVersion(), 19);
+      assert.equal(SCHEMA_VERSION, 19);
+      for (const table of [
+        "session_evidence",
+        "memory_evidence",
+        "memory_suppression",
+        "ingestion_checkpoint",
+        "repository_identity_mapping",
+      ]) {
+        assert.ok(db.db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?").get(table));
+      }
+      assert.ok(db.tableHasColumn("improvement_backlog", "repository"));
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("checkpoint and capture health APIs return JSON serializable state", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const state = {
+        sourceIdentity: "fixture-source",
+        offset: 42,
+        partialRecord: { text: "partial" },
+        adapterState: { branch: "main" },
+        revision: "r2",
+        health: { lastSuccessAt: "2026-09-07T10:00:00.000Z", pendingBytes: 3, failureCode: null },
+      };
+      const expected = {
+        client: "codex",
+        sessionId: "session-1",
+        ...state,
+        branchState: {},
+      };
+      const saved = db.saveIngestionCheckpoint("codex", "session-1", state);
+      assert.deepEqual({ ...saved, updatedAt: undefined }, { ...expected, updatedAt: undefined });
+      const loaded = db.getIngestionCheckpoint("codex", "session-1");
+      assert.deepEqual({ ...loaded, updatedAt: undefined }, { ...expected, updatedAt: undefined });
+      assert.doesNotThrow(() => JSON.stringify(db.listCaptureHealth()));
+      assert.deepEqual(db.listCaptureHealth({ repository: "fixture-repo" }), []);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reconciliation retains evidence outside the current bounded extraction window", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const first = {
+        type: "user_preference",
+        content: "Preserve the first preference.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-long",
+        sourceTurnIndex: 1,
+        evidence: { key: "evidence:first", sourceRecordId: "1", sourceKind: "preference", revision: "1", contentHash: "a" },
+      };
+      const second = {
+        type: "user_preference",
+        content: "Preserve the second preference.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-long",
+        sourceTurnIndex: 20,
+        evidence: { key: "evidence:second", sourceRecordId: "20", sourceKind: "preference", revision: "1", contentHash: "b" },
+      };
+      applySessionExtraction({ db, sessionId: "session-long", repository: "fixture-repo", extraction: extraction("session-long", "fixture-repo", [first, second]) });
+      applySessionExtraction({ db, sessionId: "session-long", repository: "fixture-repo", extraction: extraction("session-long", "fixture-repo", [second]) });
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM semantic_memory WHERE source_session_id = ?").get("session-long").count, 2);
+      assert.equal(db.listSemanticEvidence(db.db.prepare("SELECT id FROM semantic_memory WHERE content = ?").get(first.content).id).length, 1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reconciliation is replay idempotent and does not reinforce identical evidence", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const memory = {
+        type: "user_preference",
+        content: "Replay should be idempotent.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-replay",
+        sourceTurnIndex: 1,
+        evidence: { key: "evidence:replay", sourceRecordId: "1", sourceKind: "preference", revision: "1", contentHash: "same" },
+      };
+      const result = extraction("session-replay", "fixture-repo", [memory]);
+      applySessionExtraction({ db, sessionId: "session-replay", repository: "fixture-repo", extraction: result });
+      applySessionExtraction({ db, sessionId: "session-replay", repository: "fixture-repo", extraction: result });
+      const row = db.db.prepare("SELECT reinforcement_count FROM semantic_memory WHERE source_session_id = ?").get("session-replay");
+      assert.equal(row.reinforcement_count, 1);
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM session_evidence WHERE evidence_key = ?").get("evidence:replay").count, 1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("different source evidence links to one canonical memory", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const memories = [1, 2].map((sourceTurnIndex) => ({
+        type: "user_preference",
+        content: "Use the stable API shape.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-sources",
+        sourceTurnIndex,
+        evidence: {
+          key: `source-evidence:${sourceTurnIndex}`,
+          sourceRecordId: String(sourceTurnIndex),
+          sourceKind: "preference",
+          revision: "1",
+          contentHash: "same-proposition",
+        },
+      }));
+      const ids = db.reconcileGeneratedMemories({ sessionId: "session-sources", repository: "fixture-repo", memories });
+      assert.equal(ids[0], ids[1]);
+      assert.equal(db.listSemanticEvidence(ids[0]).length, 2);
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM semantic_memory WHERE source_session_id = ?").get("session-sources").count, 1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("forget records durable suppression and rejects unknown memory ids", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const id = db.insertSemanticMemory({ type: "user_preference", content: "Never resurrect this generated preference.", repository: "fixture-repo", scope: "repo", sourceSessionId: "session-forget", sourceTurnIndex: 1, metadata: { source: "rule_extractor" } });
+      db.forgetMemory({ id });
+      assert.equal(db.db.prepare("SELECT superseded_by FROM semantic_memory WHERE id = ?").get(id).superseded_by?.startsWith("manual:"), true);
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM memory_suppression WHERE memory_id = ?").get(id).count, 1);
+      assert.throws(() => db.forgetMemory({ id: "missing-memory" }), /not found/iu);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("suppression is nonplaintext and blocks generated replay while allowing manual correction", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const id = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Keep generated preference suppressed.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-suppress",
+        sourceTurnIndex: 1,
+        metadata: { source: "rule_extractor" },
+        evidence: { key: "suppression-evidence", contentHash: "hashed-content" },
+      });
+      db.forgetMemory({ id });
+      const suppression = db.db.prepare("SELECT * FROM memory_suppression WHERE memory_id = ?").get(id);
+      assert.equal(Object.hasOwn(suppression, "canonical_key"), false);
+      assert.equal(suppression.canonical_fingerprint.includes("Keep generated"), false);
+      const generated = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Keep generated preference suppressed.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-suppress-refresh",
+        sourceTurnIndex: 2,
+        metadata: { source: "rule_extractor" },
+      });
+      assert.equal(generated, null);
+      assert.deepEqual(db.reconcileGeneratedMemories({
+        sessionId: "session-suppress-refresh",
+        repository: "fixture-repo",
+        memories: [{
+          type: "user_preference",
+          content: "Keep generated preference suppressed.",
+          repository: "fixture-repo",
+          scope: "repo",
+          sourceTurnIndex: 2,
+          evidence: { key: "suppression-evidence", contentHash: "hashed-content" },
+          metadata: { source: "rule_extractor" },
+        }],
+      }), [null]);
+      const manual = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Keep generated preference suppressed.",
+        repository: "fixture-repo",
+        scope: "repo",
+        metadata: { source: "memory_save" },
+      });
+      assert.ok(manual);
+      assert.notEqual(manual, id);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("recovery restore preserves current suppressions by default", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, config, cleanup } = await withFixtureDb();
+    try {
+      const id = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Preserve suppression during restore.",
+        repository: "fixture-repo",
+        scope: "repo",
+        metadata: { source: "rule_extractor" },
+      });
+      const snapshot = createRecoverySnapshot({ derivedStorePath: config.paths.derivedStorePath, backupDir: config.paths.backupDir }).snapshotPath;
+      db.forgetMemory({ id });
+      restoreRecoverySnapshot({ derivedStorePath: config.paths.derivedStorePath, snapshotPath: snapshot, write: true, clientsStopped: true, detectActiveUsers: () => [] });
+      const restored = db.db.prepare("SELECT COUNT(*) AS count FROM memory_suppression WHERE memory_id = ?").get(id).count;
+      assert.equal(restored, 1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("mapping APIs preserve explicit legacy to canonical associations", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      assert.deepEqual(db.setRepositoryMapping({ legacy: "legacy/path", canonical: "github.com/acme/repo" }), {
+        legacy: "legacy/path",
+        canonical: "github.com/acme/repo",
+      });
+      assert.deepEqual(db.getRepositoryMappings(), [{ legacy: "legacy/path", canonical: "github.com/acme/repo" }]);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tests/unit/db-reliability-foundation.test.mjs
+++ b/tests/unit/db-reliability-foundation.test.mjs
@@ -67,8 +67,10 @@ describe("database reliability foundation", () => {
       const expected = {
         client: "codex",
         sessionId: "session-1",
+        repository: null,
         ...state,
         branchState: {},
+        checkpointRevision: 1,
       };
       const saved = db.saveIngestionCheckpoint("codex", "session-1", state);
       assert.deepEqual({ ...saved, updatedAt: undefined }, { ...expected, updatedAt: undefined });
@@ -92,6 +94,7 @@ describe("database reliability foundation", () => {
         sourceSessionId: "session-long",
         sourceTurnIndex: 1,
         evidence: { key: "evidence:first", sourceRecordId: "1", sourceKind: "preference", revision: "1", contentHash: "a" },
+        metadata: { sourceAttribution: { role: "user", recordId: "1" }, confidenceBasis: "explicit_preference" },
       };
       const second = {
         type: "user_preference",
@@ -105,7 +108,10 @@ describe("database reliability foundation", () => {
       applySessionExtraction({ db, sessionId: "session-long", repository: "fixture-repo", extraction: extraction("session-long", "fixture-repo", [first, second]) });
       applySessionExtraction({ db, sessionId: "session-long", repository: "fixture-repo", extraction: extraction("session-long", "fixture-repo", [second]) });
       assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM semantic_memory WHERE source_session_id = ?").get("session-long").count, 2);
-      assert.equal(db.listSemanticEvidence(db.db.prepare("SELECT id FROM semantic_memory WHERE content = ?").get(first.content).id).length, 1);
+      const firstEvidence = db.listSemanticEvidence(db.db.prepare("SELECT id FROM semantic_memory WHERE content = ?").get(first.content).id);
+      assert.equal(firstEvidence.length, 1);
+      assert.equal(firstEvidence[0].repository, "fixture-repo");
+      assert.deepEqual(firstEvidence[0].metadata.sourceAttribution, { role: "user", recordId: "1" });
     } finally {
       cleanup();
     }
@@ -217,7 +223,8 @@ describe("database reliability foundation", () => {
       db.forgetMemory({ id });
       const suppression = db.db.prepare("SELECT * FROM memory_suppression WHERE memory_id = ?").get(id);
       assert.equal(Object.hasOwn(suppression, "canonical_key"), false);
-      assert.equal(suppression.canonical_fingerprint.includes("Keep generated"), false);
+      assert.equal(suppression.canonical_fingerprint, null);
+      assert.doesNotMatch(suppression.evidence_fingerprint, /Keep generated/iu);
       const generated = db.insertSemanticMemory({
         type: "user_preference",
         content: "Keep generated preference suppressed.",
@@ -250,6 +257,8 @@ describe("database reliability foundation", () => {
       });
       assert.ok(manual);
       assert.notEqual(manual, id);
+      assert.equal(db.searchSemantic({ query: "Keep generated", repository: "fixture-repo" }).some((row) => row.id === manual), true);
+      assert.equal(db.searchSemantic({ query: "Keep generated", repository: "fixture-repo" }).some((row) => row.id === id), false);
     } finally {
       cleanup();
     }
@@ -283,6 +292,173 @@ describe("database reliability foundation", () => {
         canonical: "github.com/acme/repo",
       });
       assert.deepEqual(db.getRepositoryMappings(), [{ legacy: "legacy/path", canonical: "github.com/acme/repo" }]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("forgetting a null-canonical proposition does not suppress another proposition", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const forgotten = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Prefer kiwi fixtures.",
+        repository: "repo-a",
+        scope: "repo",
+        metadata: { source: "rule_extractor" },
+      });
+      db.forgetMemory({ id: forgotten });
+      const unrelated = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Prefer citrus summaries.",
+        repository: "repo-a",
+        scope: "repo",
+        metadata: { source: "rule_extractor" },
+      });
+      assert.ok(unrelated);
+      const foreign = db.insertSemanticMemory({
+        type: "user_preference",
+        content: "Prefer kiwi fixtures.",
+        repository: "repo-b",
+        scope: "repo",
+        metadata: { source: "rule_extractor" },
+      });
+      assert.ok(foreign);
+      const suppression = db.db.prepare("SELECT canonical_fingerprint, evidence_fingerprint FROM memory_suppression WHERE memory_id = ?").get(forgotten);
+      assert.equal(suppression.canonical_fingerprint, null);
+      assert.match(suppression.evidence_fingerprint, /^[0-9a-f]{64}$/);
+      assert.doesNotMatch(JSON.stringify(suppression), /Prefer kiwi fixtures/iu);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("retired evidence is ineligible and replaying the same revision stays retired", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const memory = {
+        type: "user_preference",
+        content: "Retire this evidence.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-retire",
+        sourceTurnIndex: 1,
+        evidence: { key: "evidence:retire", sourceRecordId: "1", sourceKind: "preference", revision: "opaque-a", contentHash: "retire-hash" },
+      };
+      db.reconcileGeneratedMemories({ sessionId: "session-retire", repository: "fixture-repo", memories: [memory] });
+      db.reconcileGeneratedMemories({ sessionId: "session-retire", repository: "fixture-repo", memories: [], retiredEvidenceKeys: ["evidence:retire"] });
+      assert.deepEqual(db.searchSemantic({ query: "Retire", repository: "fixture-repo" }), []);
+      db.reconcileGeneratedMemories({ sessionId: "session-retire", repository: "fixture-repo", memories: [memory] });
+      const evidence = db.listSemanticEvidence(db.db.prepare("SELECT id FROM semantic_memory WHERE content = ?").get(memory.content).id);
+      assert.equal(evidence[0].retiredAt !== null, true);
+      assert.deepEqual(db.searchSemantic({ query: "Retire", repository: "fixture-repo" }), []);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("applySessionExtraction durably carries evidence and retirement output", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const original = {
+        type: "decision",
+        content: "Use the original deployment path.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-apply-evidence",
+        sourceTurnIndex: 1,
+        metadata: { source: "rule_extractor", sourceAttribution: { role: "user", recordId: "turn-1" } },
+        evidence: { key: "evidence:apply-original", sourceRecordId: "turn-1", sourceKind: "decision", revision: "rev-1", contentHash: "hash-1" },
+      };
+      const replacement = {
+        ...original,
+        content: "Use the replacement deployment path.",
+        sourceTurnIndex: 2,
+        evidence: { key: "evidence:apply-replacement", sourceRecordId: "turn-2", sourceKind: "decision", revision: "rev-2", contentHash: "hash-2" },
+      };
+      const first = extraction("session-apply-evidence", "fixture-repo", [original]);
+      applySessionExtraction({ db, sessionId: "session-apply-evidence", repository: "fixture-repo", extraction: first });
+      const second = extraction("session-apply-evidence", "fixture-repo", [replacement]);
+      second.retiredEvidenceKeys = ["evidence:apply-original"];
+      applySessionExtraction({ db, sessionId: "session-apply-evidence", repository: "fixture-repo", extraction: second });
+      const originalId = db.db.prepare("SELECT id FROM semantic_memory WHERE content = ?").get(original.content).id;
+      const originalEvidence = db.listSemanticEvidence(originalId)[0];
+      assert.equal(originalEvidence.retiredAt !== null, true);
+      assert.deepEqual(originalEvidence.metadata.sourceAttribution, { role: "user", recordId: "turn-1" });
+      assert.deepEqual(db.searchSemantic({ query: "original deployment", repository: "fixture-repo" }), []);
+      assert.equal(db.searchSemantic({ query: "replacement deployment", repository: "fixture-repo" }).length, 1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("applySessionExtraction rolls back all writes when an improvement write fails", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb({
+      configOverrides: { rollout: { autoWriteImprovementGoals: true } },
+    });
+    try {
+      const valid = {
+        type: "assistant_goal",
+        content: "Keep extraction atomic.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-atomic",
+        sourceTurnIndex: 1,
+        metadata: { source: "rule_extractor", goal: "Keep extraction atomic." },
+        evidence: { key: "evidence:atomic", sourceRecordId: "1", sourceKind: "goal", revision: "opaque-a", contentHash: "atomic-hash" },
+      };
+      const original = db.upsertImprovementArtifact.bind(db);
+      db.upsertImprovementArtifact = () => { throw new Error("injected improvement failure"); };
+      assert.throws(() => applySessionExtraction({ db, sessionId: "session-atomic", repository: "fixture-repo", extraction: extraction("session-atomic", "fixture-repo", [valid]) }), /injected improvement failure/);
+      db.upsertImprovementArtifact = original;
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM episode_digest WHERE session_id = ?").get("session-atomic").count, 0);
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM semantic_memory WHERE source_session_id = ?").get("session-atomic").count, 0);
+      assert.equal(db.db.prepare("SELECT COUNT(*) AS count FROM session_evidence WHERE session_id = ?").get("session-atomic").count, 0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("lore_retain and onboarding rows resist inferred replacement", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const retained = db.insertSemanticMemory({
+        type: "assistant_goal",
+        content: "Keep this stable goal.",
+        repository: "fixture-repo",
+        scope: "repo",
+        metadata: { source: "lore_retain", goal: "stable-goal" },
+      });
+      const inferred = db.insertSemanticMemory({
+        type: "assistant_goal",
+        content: "Keep this stable goal.",
+        repository: "fixture-repo",
+        scope: "repo",
+        sourceSessionId: "session-inferred",
+        metadata: { source: "rule_extractor", goal: "stable-goal" },
+      });
+      assert.equal(inferred, retained);
+      const row = db.db.prepare("SELECT metadata_json, reinforcement_count FROM semantic_memory WHERE id = ?").get(retained);
+      assert.equal(JSON.parse(row.metadata_json).source, "lore_retain");
+      assert.equal(row.reinforcement_count, 1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("checkpoint save uses expectedRevision CAS and preserves opaque revisions", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, cleanup } = await withFixtureDb();
+    try {
+      const first = db.saveIngestionCheckpoint("codex", "session-cas", { repository: "repo-a", sourceIdentity: "transcript:/tmp/a", revision: "opaque-a", offset: 10 });
+      assert.equal(first.revision, "opaque-a");
+      const second = db.saveIngestionCheckpoint("codex", "session-cas", { repository: "repo-a", sourceIdentity: "transcript:/tmp/a", revision: "opaque-b", expectedRevision: "opaque-a", offset: 20 });
+      assert.equal(second.revision, "opaque-b");
+      assert.throws(() => db.saveIngestionCheckpoint("codex", "session-cas", { repository: "repo-a", sourceIdentity: "transcript:/tmp/a", revision: "opaque-c", expectedRevision: "opaque-a", offset: 30 }), (error) => error.code === "CHECKPOINT_REVISION_CONFLICT");
+      assert.equal(db.getIngestionCheckpoint("codex", "session-cas").offset, 20);
+      assert.equal(db.getIngestionCheckpoint("codex", "session-cas").checkpointRevision, 2);
+      assert.throws(() => db.saveIngestionCheckpoint("codex", "session-cas", { repository: "repo-a", sourceIdentity: "transcript:/tmp/a", revision: "opaque-c", expectedCheckpointRevision: 1, offset: 30 }), (error) => error.code === "CHECKPOINT_REVISION_CONFLICT");
+      assert.throws(() => db.saveIngestionCheckpoint("codex", "session-cas", { repository: "repo-a", sourceIdentity: "transcript:/tmp/a", revision: "opaque-c", expectedCheckpointRevision: 9, offset: 30 }), (error) => error.code === "CHECKPOINT_REVISION_CONFLICT");
+      assert.equal(db.listCaptureHealth({ repository: "repo-a" })[0].sourceIdentity, "transcript:/tmp/a");
     } finally {
       cleanup();
     }

--- a/tests/unit/extraction-hydration-hotspots.test.mjs
+++ b/tests/unit/extraction-hydration-hotspots.test.mjs
@@ -1,30 +1,11 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, test } from "node:test";
-import { fileURLToPath, pathToFileURL } from "node:url";
 
+import { extractSessionMemories } from "../../lib/sessions/rule-extractor.mjs";
 import { hydrateWorkstreamOverlay } from "../../lib/context/overlay-hydrator.mjs";
-
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
-
-let ruleExtractorHotspotsPromise = null;
-
-async function loadRuleExtractorHotspots() {
-  if (!ruleExtractorHotspotsPromise) {
-    const ruleExtractorPath = path.join(REPO_ROOT, "lib", "sessions", "rule-extractor.mjs");
-    const ruleExtractorUrl = pathToFileURL(ruleExtractorPath).href;
-    const source = readFileSync(ruleExtractorPath, "utf8")
-      .replace(/from "\.\.\/memory\/memory-scope\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "memory", "memory-scope.mjs")).href}"`)
-      .replace(/from "\.\.\/rollout\/rollout-flags\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "rollout", "rollout-flags.mjs")).href}"`)
-      .replace(/from "\.\.\/memory\/retention-sanitizer\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "memory", "retention-sanitizer.mjs")).href}"`)
-      .replace(/from "\.\.\/utils\/text-normalizer\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "utils", "text-normalizer.mjs")).href}"`)
-      .replace("function extractInteractionStyleMemory({ message, repository, sessionId, turnIndex }) {", "export function extractInteractionStyleMemory({ message, repository, sessionId, turnIndex }) {");
-    ruleExtractorHotspotsPromise = import(`data:text/javascript;base64,${Buffer.from(`${source}\n//# sourceURL=${ruleExtractorUrl}\n`).toString("base64")}`);
-  }
-  return ruleExtractorHotspotsPromise;
-}
 
 function createWorkspaceDir(name) {
   const workspacePath = mkdtempSync(path.join(os.tmpdir(), `lore-${name}-`));
@@ -37,14 +18,23 @@ function createWorkspaceDir(name) {
 }
 
 describe("fourth-wave extraction and hydration hotspots", () => {
-  test("extractInteractionStyleMemory captures warm colleague humor and name-use preferences", async () => {
-    const { extractInteractionStyleMemory } = await loadRuleExtractorHotspots();
-    const memory = extractInteractionStyleMemory({
-      message: "Please talk to me like a warm colleague, feel free to use a little humor, and use my name naturally when it fits.",
+  test("session extraction captures warm colleague humor and name-use preferences", () => {
+    const extraction = extractSessionMemories({
       repository: "fixture-repo",
       sessionId: "session-style",
-      turnIndex: 3,
+      sessionArtifacts: {
+        session: {},
+        checkpoints: [],
+        files: [],
+        refs: [],
+        turns: [{
+          turn_index: 3,
+          user_message: "Please talk to me like a warm colleague, feel free to use a little humor, and use my name naturally when it fits.",
+        }],
+      },
+      workspace: {},
     });
+    const memory = extraction.semanticMemories.find((entry) => entry.type === "interaction_style");
 
     assert.equal(memory.type, "interaction_style");
     assert.equal(memory.repository, null);

--- a/tests/unit/memory-scope-assistant-identity.test.mjs
+++ b/tests/unit/memory-scope-assistant-identity.test.mjs
@@ -40,12 +40,12 @@ describe("detectAssistantIdentityName", () => {
 // historical messages). Only explicit naming vocabulary counts here.
 describe("detectAssistantIdentityDeclaration", () => {
   test("matches explicit naming phrases", () => {
-    assert.equal(detectAssistantIdentityDeclaration("Shall I call you Coda from now on?"), "Coda");
+    assert.equal(detectAssistantIdentityDeclaration("Shall I call you Coda from now on?"), null);
     assert.equal(detectAssistantIdentityDeclaration("Ok, call yourself Nova please."), "Nova");
     assert.equal(detectAssistantIdentityDeclaration("Your name is Juno now."), "Juno");
     assert.equal(detectAssistantIdentityDeclaration("Please use the name Zed for this."), "Zed");
-    assert.equal(detectAssistantIdentityDeclaration("I used the name Axel in that doc."), "Axel");
-    assert.equal(detectAssistantIdentityDeclaration("Why I used the name Vega is a long story."), "Vega");
+    assert.equal(detectAssistantIdentityDeclaration("I used the name Axel in that doc."), null);
+    assert.equal(detectAssistantIdentityDeclaration("Why I used the name Vega is a long story."), null);
   });
 
   test("does not treat sentence-initial interjections as a name", () => {

--- a/tests/unit/released-schema-fixtures.test.mjs
+++ b/tests/unit/released-schema-fixtures.test.mjs
@@ -13,7 +13,7 @@ const FIXTURE_DIR = path.join(process.cwd(), "tests", "fixtures", "released-upgr
 const FIXTURES = [
   { file: "v13-lore-v0.2.0.sql", version: 13, versionTable: "coherence_schema_version", expectsBackup: true },
   { file: "v15-lore-v0.3.0.sql", version: 15, versionTable: "lore_schema_version", expectsBackup: true },
-  { file: "v18-lore-v0.10.0.sql", version: 18, versionTable: "lore_schema_version", expectsBackup: false },
+  { file: "v18-lore-v0.10.0.sql", version: 18, versionTable: "lore_schema_version", expectsBackup: true },
 ];
 
 const SKIP_NO_FTS5 = !FTS5_AVAILABLE

--- a/tests/unit/released-schema-fixtures.test.mjs
+++ b/tests/unit/released-schema-fixtures.test.mjs
@@ -101,4 +101,36 @@ describe("released Lore schema fixtures", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  test("upgrades ambiguous legacy manual markers as hashed repair candidates", { skip: SKIP_NO_FTS5 }, () => {
+    const root = tempDir();
+    const dbPath = path.join(root, "ambiguous.db");
+    const backupDir = path.join(root, "backups");
+    try {
+      const raw = new DatabaseSync(dbPath);
+      raw.exec(readFileSync(path.join(FIXTURE_DIR, "v18-lore-v0.10.0.sql"), "utf8"));
+      raw.prepare(`
+        INSERT INTO semantic_memory
+          (id, type, content, confidence, scope, scope_source, repository,
+           tags, created_at, updated_at, superseded_by, metadata_json)
+        VALUES (?, 'fact', ?, 1.0, 'repo', 'auto', ?, '', ?, ?, ?, '{}')
+      `).run("legacy-ambiguous", "Preserve ambiguous lineage.", "fixture-repository",
+        "2026-01-02T03:04:05.000Z", "2026-01-03T04:05:06.000Z", "manual-user-memory");
+      raw.close();
+      const db = new LoreDb({ paths: { derivedStorePath: dbPath, backupDir } });
+      db.initialize();
+      const candidate = db.db.prepare(`
+        SELECT memory_id, repair_candidate, legacy_marker_fingerprint, evidence_fingerprint
+        FROM memory_suppression WHERE memory_id = ?
+      `).get("legacy-ambiguous");
+      assert.equal(candidate.memory_id, "legacy-ambiguous");
+      assert.equal(candidate.repair_candidate, 1);
+      assert.match(candidate.legacy_marker_fingerprint, /^[0-9a-f]{64}$/);
+      assert.match(candidate.evidence_fingerprint, /^[0-9a-f]{64}$/);
+      assert.equal(db.db.prepare("SELECT superseded_by FROM semantic_memory WHERE id = ?").get("legacy-ambiguous").superseded_by, "manual-user-memory");
+      db.close();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -678,6 +678,21 @@ describe("extraction evidence", () => {
   });
 });
 
+test("a reversal retires every corroborating old source while retaining corroborating current sources", () => {
+  const turns = [
+    { turn_index: 1, source_record_id: "u1", user_message: "We chose Redis for catalog invalidation.", assistant_response: "", assistant_source_records: [{ source_record_id: "a1", text: "We chose Redis for catalog invalidation." }] },
+    { turn_index: 2, source_record_id: "u2", user_message: "We switched to PostgreSQL for catalog invalidation because durability matters.", assistant_response: "", assistant_source_records: [{ source_record_id: "a2", text: "We switched to PostgreSQL for catalog invalidation because durability matters." }] },
+  ];
+  const result = extractSessionMemories({
+    sessionId: "corroborated-reversal", repository: "owner/catalog",
+    sessionArtifacts: { session: {}, checkpoints: [], files: [], refs: [], turns },
+    workspace: { workspace: {} },
+  });
+  const retired = new Set(result.retiredEvidenceKeys);
+  assert.deepEqual(result.semanticMemories.filter((row) => retired.has(row.evidence.key)).map((row) => row.evidence.sourceRecordId).sort(), ["a1", "u1"]);
+  assert.deepEqual(result.semanticMemories.filter((row) => !retired.has(row.evidence.key)).map((row) => row.evidence.sourceRecordId).sort(), ["a2", "u2"]);
+});
+
 describe("scope classification", () => {
   test("defaults known origins to repo and leaves unknown origins out of global scope", () => {
     assert.deepEqual(classifySemanticMemory({

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -569,6 +569,74 @@ describe("extraction evidence", () => {
     assert.equal(firstPreference.evidence.key, secondPreference.evidence.key);
   });
 
+  test("attributes each assistant decision to its own source record", () => {
+    const extraction = extract({ turns: [{
+      source_record_id: "user-1",
+      source_revision: "user-revision",
+      user_message: "What did we choose?",
+      assistant_response: "We chose Redis for billing. We chose Avro for serialization.",
+      assistant_source_records: [
+        { source_record_id: "assistant-1", source_revision: "assistant-revision-1", text: "We chose Redis for billing." },
+        { source_record_id: "assistant-2", source_revision: "assistant-revision-2", text: "We chose Avro for serialization." },
+      ],
+    }] });
+    const decisions = semantic(extraction, "decision");
+    assert.equal(decisions.length, 2);
+    assert.deepEqual(decisions.map((memory) => memory.evidence.sourceRecordId), ["assistant-1", "assistant-2"]);
+    assert.deepEqual(decisions.map((memory) => memory.evidence.revision), ["assistant-revision-1", "assistant-revision-2"]);
+    assert.deepEqual(decisions.map((memory) => memory.metadata.sourceAttribution.sourceRecordId), ["assistant-1", "assistant-2"]);
+    assert.ok(decisions.every((memory) => memory.metadata.sourceAttribution.sourceRole === "assistant"));
+    assert.ok(decisions.every((memory) => memory.metadata.verificationStatus === "unverified_assistant_claim"));
+  });
+
+  test("assistant record fallback revisions track only that record's text", () => {
+    const turn = {
+      source_record_id: "user-1",
+      source_revision: "aggregate-revision",
+      user_message: "What did we choose?",
+      assistant_response: "Combined assistant text is a compatibility field.",
+      assistant_source_records: [{ source_record_id: "assistant-1", text: "We chose Avro for serialization. Context A." }],
+    };
+    const first = semantic(extract({ turns: [turn] }), "decision")[0];
+    const changedUser = semantic(extract({ turns: [{ ...turn, user_message: "Different user context", source_revision: "aggregate-revision-2" }] }), "decision")[0];
+    const changedAssistant = semantic(extract({ turns: [{ ...turn, assistant_source_records: [{ source_record_id: "assistant-1", text: "We chose Avro for serialization. Context B." }] }] }), "decision")[0];
+    assert.ok(first);
+    assert.equal(first.evidence.key, changedUser.evidence.key);
+    assert.equal(first.evidence.revision, changedUser.evidence.revision);
+    assert.equal(first.evidence.key, changedAssistant.evidence.key);
+    assert.notEqual(first.evidence.revision, changedAssistant.evidence.revision);
+    assert.equal(first.evidence.revision, createHash("sha256")
+      .update(JSON.stringify({ role: "assistant", text: "We chose Avro for serialization. Context A." }))
+      .digest("hex"));
+  });
+
+  test("authoritative assistant records cannot replay stale combined text", () => {
+    const extraction = extract({ turns: [{
+      user_message: "What did we choose?",
+      assistant_response: "We chose Redis for billing.",
+      assistant_source_records: [],
+    }] });
+    assert.deepEqual(extraction.semanticMemories, []);
+  });
+
+  test("inferred repair goals use the actual assistant failure record", () => {
+    const extraction = extract({ turns: [1, 2].map((index) => ({
+      source_record_id: `user-${index}`,
+      source_revision: `user-revision-${index}`,
+      user_message: "Please continue.",
+      assistant_response: "Combined compatibility response.",
+      assistant_source_records: [
+        { source_record_id: `assistant-${index}`, source_revision: `assistant-revision-${index}`, text: `The build failed${index === 2 ? " again" : ""}.` },
+        { source_record_id: `assistant-note-${index}`, text: "I will investigate." },
+      ],
+    })) });
+    const goal = semantic(extraction, "assistant_goal")[0];
+    assert.ok(goal);
+    assert.equal(goal.evidence.sourceRecordId, "assistant-2");
+    assert.equal(goal.evidence.revision, "assistant-revision-2");
+    assert.equal(goal.metadata.sourceAttribution.sourceRole, "assistant");
+  });
+
   test("local inference enhancement preserves extraction retirement keys", async () => {
     const extraction = {
       episodeDigest: {

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -3,6 +3,7 @@ import { describe, test } from "node:test";
 
 import { extractSessionMemories } from "../../lib/sessions/rule-extractor.mjs";
 import { MEMORY_SCOPE, classifySemanticMemory } from "../../lib/memory/memory-scope.mjs";
+import { enhanceSessionExtractionWithLocalInference } from "../../lib/inference/local-inference-extraction.mjs";
 
 function extract({ repository = "owner/repo", turns, sessionId = "fixture-session" }) {
   return extractSessionMemories({
@@ -78,6 +79,100 @@ describe("conservative rule extraction", () => {
     ]);
   });
 
+  test("accepts natural explicit directives and scoped preambles", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: [
+          "Prefer a compact release note for every patch.",
+          "For this repository, please prefer deterministic fixtures.",
+          "Please use two-space indentation.",
+          "Across all my projects, I prefer plain ESM.",
+        ].join(" "),
+      }],
+    });
+
+    const preferences = semantic(extraction, "user_preference");
+    assert.deepEqual(preferences.map((memory) => memory.content), [
+      "Prefer a compact release note for every patch.",
+      "For this repository, please prefer deterministic fixtures.",
+      "Please use two-space indentation.",
+      "Across all my projects, I prefer plain ESM.",
+    ]);
+    assert.deepEqual(preferences.map((memory) => memory.scope), [
+      MEMORY_SCOPE.REPO,
+      MEMORY_SCOPE.REPO,
+      MEMORY_SCOPE.REPO,
+      MEMORY_SCOPE.GLOBAL,
+    ]);
+    assert.equal(preferences[3].repository, null);
+  });
+
+  test("keeps context around a direct request after a rationale", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: "It helps me when implementation notes lead with the user impact and then explain the code, so please use that order in this project.",
+      }],
+    });
+
+    const preference = semantic(extraction, "user_preference")[0];
+    assert.match(preference.content, /implementation notes/);
+    assert.match(preference.content, /user impact/);
+    assert.equal(preference.scope, MEMORY_SCOPE.REPO);
+  });
+
+  test("recognizes an explicit cross-project work style", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: "Across projects I work best with direct, concise status updates that name uncertainty instead of hiding it.",
+      }],
+    });
+
+    const preference = semantic(extraction, "user_preference")[0];
+    assert.equal(preference.scope, MEMORY_SCOPE.GLOBAL);
+  });
+
+  test("recognizes a corrected imperative without treating the old form as current here", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: "Actually, that is wrong: use a 45 second timeout because the upstream batch window is longer.",
+      }],
+    });
+
+    assert.deepEqual(semantic(extraction, "user_preference").map((memory) => memory.content), [
+      "Actually, that is wrong: use a 45 second timeout because the upstream batch window is longer.",
+    ]);
+  });
+
+  test("does not promote preferences with trailing or parenthetical conditions", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: [
+          "I prefer Redis if we ever need a cache.",
+          "I prefer SQLite (only if the fixture stays local).",
+          "Please use Postgres when we need concurrent writers.",
+          "Prefer the fallback unless the provider is available.",
+        ].join(" "),
+      }],
+    });
+
+    assert.deepEqual(semantic(extraction, "user_preference"), []);
+  });
+
+  test("extracts independent preference and rejection clauses in one sentence", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: "For edge services, prefer bounded queues and never drop the request identifier from logs; both rules matter.",
+      }],
+    });
+
+    assert.deepEqual(semantic(extraction, "user_preference").map((memory) => memory.content), [
+      "For edge services, prefer bounded queues",
+    ]);
+    assert.deepEqual(semantic(extraction, "rejected_approach").map((memory) => memory.content), [
+      "never drop the request identifier from logs",
+    ]);
+  });
+
   test("does not promote questions, quotations, hypotheticals, negated preferences, or bug reports", () => {
     const extraction = extract({
       turns: [
@@ -92,6 +187,18 @@ describe("conservative rule extraction", () => {
 
     assert.deepEqual(semantic(extraction, "user_preference"), []);
     assert.deepEqual(semantic(extraction, "rejected_approach"), []);
+  });
+
+  test("can extract an explicit sentence after quoted text", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: "I disagree with the sentence \"Prefer one huge review commit.\" For this work, split changes by behavior so each commit can be reverted.",
+      }],
+    });
+
+    assert.deepEqual(semantic(extraction, "user_preference").map((memory) => memory.content), [
+      "For this work, split changes by behavior so each commit can be reverted.",
+    ]);
   });
 
   test("extracts completed decisions and rationale from both roles, with outcome attribution", () => {
@@ -136,6 +243,55 @@ describe("conservative rule extraction", () => {
     assert.equal(decisions.every((memory) => memory.scope === MEMORY_SCOPE.REPO), true);
     assert.deepEqual(extraction.retiredEvidenceKeys, [decisions[0].evidence.key]);
   });
+
+  test("retires only a prior decision with the same meaningful topic", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "We decided to use PostgreSQL for billing because deployment is simple." },
+        { user_message: "Instead, we chose SQLite for analytics because deployment is embedded." },
+        { user_message: "We decided to use PostgreSQL for notifications." },
+        { user_message: "We chose SQLite for notifications instead." },
+      ],
+    });
+
+    const decisions = semantic(extraction, "decision");
+    assert.equal(decisions.length, 4);
+    assert.deepEqual(extraction.retiredEvidenceKeys, [
+      decisions[2].evidence.key,
+    ]);
+  });
+
+  test("recognizes common decision reversal phrasing", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "We decided to use PostgreSQL for billing." },
+        { user_message: "We changed to SQLite for billing." },
+        { user_message: "We decided to use Redis for caching." },
+        { user_message: "We chose Memcached for caching instead." },
+      ],
+    });
+
+    const decisions = semantic(extraction, "decision");
+    assert.equal(decisions.length, 4);
+    assert.equal(decisions[1].metadata.decisionStatus, "reversal");
+    assert.equal(decisions[3].metadata.decisionStatus, "reversal");
+    assert.deepEqual(extraction.retiredEvidenceKeys, [
+      decisions[0].evidence.key,
+      decisions[2].evidence.key,
+    ]);
+  });
+
+  test("extracts a completed decision after contextual wording", () => {
+    const extraction = extract({
+      turns: [{
+        assistant_response: "After comparing compatibility and tooling, we chose Avro with a schema registry; the earlier JSON suggestion is not final.",
+      }],
+    });
+
+    const decisions = semantic(extraction, "decision");
+    assert.equal(decisions.length, 1);
+    assert.match(decisions[0].content, /Avro with a schema registry/);
+  });
 });
 
 describe("extraction evidence", () => {
@@ -166,6 +322,69 @@ describe("extraction evidence", () => {
       sourceRole: "user",
     });
   });
+
+  test("changes fallback revision when the source record changes", () => {
+    const first = extract({
+      sessionId: "revision-session",
+      turns: [{
+        source_record_id: "record-1",
+        user_message: "Always use fixtures. Extra context A.",
+      }],
+    });
+    const second = extract({
+      sessionId: "revision-session",
+      turns: [{
+        source_record_id: "record-1",
+        user_message: "Always use fixtures. Extra context B.",
+      }],
+    });
+    const firstPreference = semantic(first, "user_preference")[0];
+    const secondPreference = semantic(second, "user_preference")[0];
+
+    assert.equal(firstPreference.content, secondPreference.content);
+    assert.notEqual(firstPreference.evidence.revision, secondPreference.evidence.revision);
+    assert.equal(firstPreference.evidence.key, secondPreference.evidence.key);
+  });
+
+  test("local inference enhancement preserves extraction retirement keys", async () => {
+    const extraction = {
+      episodeDigest: {
+        sessionId: "enhancement-session",
+        summary: "Deterministic summary",
+        actions: [],
+        decisions: [],
+        learnings: [],
+        openItems: [],
+        themes: [],
+      },
+      semanticMemories: [],
+      retiredEvidenceKeys: ["prior-evidence-key"],
+    };
+    const enhanced = await enhanceSessionExtractionWithLocalInference({
+      config: {
+        enabled: true,
+        model: "fixture-model",
+        baseUrl: "http://127.0.0.1:1234",
+      },
+      sessionArtifacts: {
+        session: {},
+        checkpoints: [],
+        turns: [],
+        files: [],
+        refs: [],
+      },
+      extraction,
+      fetchImpl: async () => new Response(JSON.stringify({
+        choices: [{
+          message: {
+            content: JSON.stringify({ summary: "Model summary" }),
+          },
+        }],
+      }), { status: 200 }),
+    });
+
+    assert.deepEqual(enhanced.retiredEvidenceKeys, ["prior-evidence-key"]);
+  });
 });
 
 describe("scope classification", () => {
@@ -194,6 +413,20 @@ describe("scope classification", () => {
       type: "user_preference",
       repository: "owner/repo",
       content: "Across all projects, always use plain ESM.",
+    }), {
+      scope: MEMORY_SCOPE.GLOBAL,
+      repository: null,
+      metadata: {
+        originRepository: "owner/repo",
+      },
+    });
+  });
+
+  test("recognizes all my projects as an explicit global scope", () => {
+    assert.deepEqual(classifySemanticMemory({
+      type: "user_preference",
+      repository: "owner/repo",
+      content: "Across all my projects, I prefer plain ESM.",
     }), {
       scope: MEMORY_SCOPE.GLOBAL,
       repository: null,

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -158,12 +158,59 @@ describe("conservative rule extraction", () => {
         { user_message: "Please ask for the failing logs." },
         { user_message: "Please do not include the failing request in the bug report." },
         { user_message: "Please avoid retrying the failing payment request for this incident." },
-        { user_message: "In future, always include the failing request in the bug report." },
-        { user_message: "As a policy, never include the failing request in the bug report." },
       ],
     });
 
     assert.deepEqual(extraction.semanticMemories, []);
+  });
+
+  test("retains explicit policies and general failure or payment constraints", () => {
+    const cases = [
+      ["In future, always include the failing request in the bug report.", "user_preference"],
+      ["As a policy, never include the failing request in the bug report.", "rejected_approach"],
+      ["Please avoid silently retrying payment mutations. A duplicate charge is worse than a visible failure, so retries need an idempotency key.", "rejected_approach"],
+      ["Always preserve failure evidence for future reviews.", "user_preference"],
+      ["Never retry payment mutations without an idempotency key.", "rejected_approach"],
+      ["Please use payment idempotency keys for mutations.", "user_preference"],
+      ["Please keep failure reports concise for every incident.", "user_preference"],
+      ["Never retain personal customer names in debugging memories.", "rejected_approach"],
+      ["From now on, please include the failing request in the bug report.", "user_preference"],
+      ["For this repository, as a policy, please include the failing request in the bug report.", "user_preference"],
+    ];
+    for (const [user_message, type] of cases) {
+      const memories = extract({ turns: [{ user_message }] }).semanticMemories;
+      assert.equal(memories.length, 1, user_message);
+      assert.equal(memories[0].type, type, user_message);
+      assert.equal(memories[0].scope, MEMORY_SCOPE.REPO);
+    }
+  });
+
+  test("keeps explicitly temporary requests out of enduring directives", () => {
+    for (const user_message of [
+      "Please use payment idempotency keys just this once.",
+      "For this incident, please preserve failure evidence.",
+      "Please run the tests now.",
+      "Please write a bug report.",
+      "Please use the attachment.",
+      "Please make a reproduction.",
+      "Please keep this request open.",
+      "I prefer verbose logging for this run only.",
+      "Please avoid retrying payment mutations for this incident only.",
+    ]) {
+      assert.deepEqual(extract({ turns: [{ user_message }] }).semanticMemories, [], user_message);
+    }
+  });
+
+  test("does not detach directive clauses from questions, quotations, or hypothetical qualifiers", () => {
+    for (const user_message of [
+      "Should we prefer Redis and never use SQLite?",
+      "If we need caching, prefer Redis and never use SQLite.",
+      "The old guide says 'Prefer Redis and never use SQLite.'",
+      "The old guide says `Prefer Redis and never use SQLite.`",
+      "Prefer Redis and never use SQLite if the prototype needs caching.",
+    ]) {
+      assert.deepEqual(extract({ turns: [{ user_message }] }).semanticMemories, [], user_message);
+    }
   });
 
   test("keeps standing safety constraints despite incident request guards", () => {
@@ -323,6 +370,55 @@ describe("conservative rule extraction", () => {
     assert.deepEqual(extraction.retiredEvidenceKeys, [
       decisions[2].evidence.key,
     ]);
+  });
+
+  test("shared rationales and generic subject words cannot retire distinct decisions", () => {
+    for (const [earlier, later] of [
+      ["We decided to use Redis for billing because reliability matters.", "Instead, we chose PostgreSQL for analytics because reliability matters."],
+      ["We chose Redis for billing API because performance matters.", "Instead, we chose PostgreSQL for analytics API because performance matters."],
+      ["We chose Redis for catalog invalidation.", "Instead, we chose PostgreSQL for inventory invalidation because losing invalidations is unacceptable."],
+      ["We chose Redis because reliability matters.", "Instead, we chose PostgreSQL because reliability matters."],
+      ["We chose Redis for catalog invalidation.", "Instead, we chose PostgreSQL because catalog invalidation was mentioned in the review."],
+    ]) {
+      const extraction = extract({ turns: [{ user_message: earlier }, { assistant_response: later }] });
+      assert.equal(semantic(extraction, "decision").length, 2);
+      assert.deepEqual(extraction.retiredEvidenceKeys, [], `${earlier} / ${later}`);
+    }
+  });
+
+  test("an entity reference must identify one prior decision subject before retirement", () => {
+    const extraction = extract({ turns: [
+      { user_message: "We chose Redis for catalog invalidation." },
+      { user_message: "We chose polling for inventory invalidation." },
+      { assistant_response: "The decision changed after review: use PostgreSQL notifications instead, because losing invalidations is unacceptable." },
+    ] });
+    assert.equal(semantic(extraction, "decision").length, 3);
+    assert.deepEqual(extraction.retiredEvidenceKeys, []);
+  });
+
+  test("only completion context can introduce an attributed decision", () => {
+    for (const text of [
+      "Perhaps we chose PostgreSQL for billing.",
+      "The draft says we chose PostgreSQL for billing.",
+      "In a hypothetical review, we chose PostgreSQL for billing.",
+      "We chose PostgreSQL for billing, or maybe we did not.",
+    ]) {
+      for (const role of ["user_message", "assistant_response"]) {
+        assert.deepEqual(semantic(extract({ turns: [{ [role]: text }] }), "decision"), [], text);
+      }
+    }
+  });
+
+  test("questions and hypothetical or quoted repeated failures do not infer repair goals", () => {
+    for (const [first, second] of [
+      ["Did the build fail?", "Did the build fail again?"],
+      ["Did the build fail? Please inspect the logs.", "Did the build fail again? Please inspect the logs."],
+      ["Suppose the build failed.", "Suppose the build failed again."],
+      ["The example says \"The build failed.\"", "The example says \"The build failed again.\""],
+    ]) {
+      const extraction = extract({ turns: [{ assistant_response: first }, { assistant_response: second }] });
+      assert.deepEqual(extraction.semanticMemories, [], `${first} / ${second}`);
+    }
   });
 
   test("recognizes common decision reversal phrasing", () => {

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { extractSessionMemories } from "../../lib/sessions/rule-extractor.mjs";
+import { MEMORY_SCOPE, classifySemanticMemory } from "../../lib/memory/memory-scope.mjs";
+
+function extract({ repository = "owner/repo", turns, sessionId = "fixture-session" }) {
+  return extractSessionMemories({
+    sessionId,
+    repository,
+    sessionArtifacts: {
+      session: {
+        repository,
+        branch: "main",
+        summary: "Fixture extraction session",
+        updated_at: "2026-09-07T10:00:00.000Z",
+      },
+      checkpoints: [],
+      files: [],
+      refs: [],
+      turns: turns.map((turn, index) => ({
+        turn_index: index + 1,
+        ...turn,
+      })),
+    },
+    workspace: { workspace: null },
+  });
+}
+
+function semantic(extraction, type) {
+  return extraction.semanticMemories.filter((memory) => memory.type === type);
+}
+
+describe("conservative rule extraction", () => {
+  test("extracts explicit sentence-level preferences from long messages", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: "I prefer concise answers. Please keep each response focused and direct. The implementation can remain detailed where needed.",
+        assistant_response: "Understood.",
+      }],
+    });
+
+    const preferences = semantic(extraction, "user_preference");
+    assert.deepEqual(preferences.map((memory) => memory.content), [
+      "I prefer concise answers.",
+      "Please keep each response focused and direct.",
+    ]);
+    assert.equal(preferences.every((memory) => memory.scope === MEMORY_SCOPE.REPO), true);
+    assert.equal(preferences.every((memory) => memory.confidence < 0.9), true);
+    assert.equal(preferences[0].metadata.confidenceBasis, "explicit_preference_sentence");
+    assert.equal(preferences[0].metadata.sourceRole, "user");
+  });
+
+  test("retains explicit evidence from turns older than the usual rolling window", () => {
+    const turns = Array.from({ length: 24 }, (_, index) => ({
+      user_message: index === 0
+        ? "I prefer deterministic fixture inputs."
+        : `Routine implementation update ${index}.`,
+    }));
+    const preferences = semantic(extract({ turns }), "user_preference");
+    assert.equal(preferences.length, 1);
+    assert.equal(preferences[0].sourceTurnIndex, 1);
+  });
+
+  test("accepts explicit first-person always language while excluding complaint language", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "I always use fixture databases for tests." },
+        { user_message: "You always break the fixture setup." },
+        { user_message: "Please do not ever expose test credentials." },
+      ],
+    });
+    assert.deepEqual(semantic(extraction, "user_preference").map((memory) => memory.content), [
+      "I always use fixture databases for tests.",
+    ]);
+    assert.deepEqual(semantic(extraction, "rejected_approach").map((memory) => memory.content), [
+      "Please do not ever expose test credentials.",
+    ]);
+  });
+
+  test("does not promote questions, quotations, hypotheticals, negated preferences, or bug reports", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "What do you prefer for storage?" },
+        { user_message: "The old guide says \"always use SQLite\"." },
+        { user_message: "If we ever need a cache, we might prefer Redis." },
+        { user_message: "I don't prefer verbose output." },
+        { user_message: "The test always fails on Windows." },
+        { user_message: "The service never worked after the restart." },
+      ],
+    });
+
+    assert.deepEqual(semantic(extraction, "user_preference"), []);
+    assert.deepEqual(semantic(extraction, "rejected_approach"), []);
+  });
+
+  test("extracts completed decisions and rationale from both roles, with outcome attribution", () => {
+    const extraction = extract({
+      turns: [
+        {
+          source_record_id: "turn-a",
+          source_revision: "rev-a",
+          user_message: "What database should we use?",
+          assistant_response: "We decided to use PostgreSQL because we need concurrent writers.",
+        },
+        {
+          source_record_id: "turn-b",
+          user_message: "We chose SQLite for the fixture database because it is portable.",
+          assistant_response: "The question is still open for production.",
+        },
+      ],
+    });
+
+    const decisions = semantic(extraction, "decision");
+    assert.equal(decisions.length, 2);
+    assert.equal(decisions[0].content, "Decision: use PostgreSQL because we need concurrent writers.");
+    assert.equal(decisions[0].metadata.sourceRole, "assistant");
+    assert.equal(decisions[0].metadata.verificationStatus, "unverified_assistant_claim");
+    assert.equal(decisions[1].metadata.sourceRole, "user");
+    assert.match(decisions[1].content, /SQLite.*portable/);
+    assert.equal(decisions.some((memory) => /What database/.test(memory.content)), false);
+  });
+
+  test("keeps a later decision reversal as evidence instead of a global instruction", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "We decided to use PostgreSQL for notifications." },
+        { user_message: "Instead, we chose SQLite for notifications because the deployment target is embedded." },
+      ],
+    });
+
+    const decisions = semantic(extraction, "decision");
+    assert.equal(decisions.length, 2);
+    assert.equal(decisions[1].metadata.decisionStatus, "reversal");
+    assert.equal(decisions[1].tags.includes("reversal"), true);
+    assert.equal(decisions.every((memory) => memory.scope === MEMORY_SCOPE.REPO), true);
+    assert.deepEqual(extraction.retiredEvidenceKeys, [decisions[0].evidence.key]);
+  });
+});
+
+describe("extraction evidence", () => {
+  test("attaches deterministic evidence descriptors using source identity and revision", () => {
+    const args = {
+      sessionId: "evidence-session",
+      repository: "owner/repo",
+      turns: [{
+        source_record_id: "record-17",
+        source_revision: "revision-3",
+        user_message: "Always use the fixture database for tests.",
+      }],
+    };
+    const first = extract(args);
+    const second = extract(args);
+    const memory = semantic(first, "user_preference")[0];
+    const repeated = semantic(second, "user_preference")[0];
+
+    assert.deepEqual(memory.evidence, repeated.evidence);
+    assert.equal(memory.evidence.sourceRecordId, "record-17");
+    assert.equal(memory.evidence.sourceKind, "preference");
+    assert.equal(memory.evidence.revision, "revision-3");
+    assert.match(memory.evidence.contentHash, /^[a-f0-9]{64}$/);
+    assert.match(memory.evidence.key, /^session:evidence-session:record:record-17:type:user_preference:proposition:[a-f0-9]{64}$/);
+    assert.deepEqual(memory.metadata.sourceAttribution, {
+      sessionId: "evidence-session",
+      sourceRecordId: "record-17",
+      sourceRole: "user",
+    });
+  });
+});
+
+describe("scope classification", () => {
+  test("defaults known origins to repo and leaves unknown origins out of global scope", () => {
+    assert.deepEqual(classifySemanticMemory({
+      type: "user_preference",
+      content: "Prefer focused review comments.",
+      repository: "owner/repo",
+    }), {
+      scope: MEMORY_SCOPE.REPO,
+      repository: "owner/repo",
+      metadata: {},
+    });
+    assert.deepEqual(classifySemanticMemory({
+      type: "user_preference",
+      content: "Prefer focused review comments.",
+    }), {
+      scope: MEMORY_SCOPE.REPO,
+      repository: null,
+      metadata: {},
+    });
+  });
+
+  test("honors explicit cross-project scope declarations", () => {
+    assert.deepEqual(classifySemanticMemory({
+      type: "user_preference",
+      repository: "owner/repo",
+      content: "Across all projects, always use plain ESM.",
+    }), {
+      scope: MEMORY_SCOPE.GLOBAL,
+      repository: null,
+      metadata: {
+        originRepository: "owner/repo",
+      },
+    });
+  });
+});

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -892,3 +892,89 @@ test("bounded episode outcomes still lead with the latest completed decision", (
   assert.match(result.episodeDigest.summary, /format11/);
   assert.ok(result.episodeDigest.decisions.some((decision) => /format11/.test(decision)));
 });
+
+describe("recurring feedback attribution and scope", () => {
+  test("keeps direct repository feedback local and explicit cross-project feedback global", () => {
+    const local = semantic(extract({ turns: [{ user_message: "You keep using semicolons in this Python repository." }] }), "recurring_mistake");
+    assert.equal(local.length, 1);
+    assert.equal(local[0].scope, "repo");
+    assert.equal(local[0].repository, "owner/repo");
+    assert.equal(local[0].metadata.sourceRole, "user");
+    assert.equal(local[0].metadata.confidenceBasis, "direct_recurring_feedback");
+    const global = semantic(extract({ turns: [{ user_message: "Across all projects, you keep ignoring my explicit corrections." }] }), "recurring_mistake");
+    assert.equal(global.length, 1);
+    assert.equal(global[0].scope, "global");
+    assert.equal(global[0].repository, null);
+  });
+
+  test("does not promote reported, quoted, hypothetical or approving observations to recurring mistakes", () => {
+    for (const user_message of [
+      "The bug report says you always return stale cache entries.",
+      'The example says "you keep using stale cache entries."',
+      "If you keep returning stale cache entries, the test might fail.",
+      "Do you always return stale cache entries?",
+      "You always explain the result clearly, which is helpful.",
+      "Again the server returns stale cache entries.",
+    ]) {
+      assert.deepEqual(semantic(extract({ turns: [{ user_message }] }), "recurring_mistake"), [], user_message);
+    }
+    const reportedCorrections = extract({ turns: [
+      { user_message: "The bug report says the cache should be invalidated." },
+      { user_message: "The incident report says the retry needs to finish." },
+    ] });
+    assert.deepEqual(semantic(reportedCorrections, "recurring_mistake"), []);
+  });
+
+  test("implicit repeated corrections stay local and unknown origin cannot become global", () => {
+    const turns = [
+      { user_message: "No, keep the artifact content unchanged while refactoring." },
+      { user_message: "Still, stop touching other production files in this lane." },
+    ];
+    const local = semantic(extract({ turns }), "recurring_mistake");
+    assert.equal(local.length, 1);
+    assert.equal(local[0].scope, "repo");
+    assert.equal(local[0].repository, "owner/repo");
+    const unknown = semantic(extract({ repository: null, turns }), "recurring_mistake");
+    assert.equal(unknown[0].scope, "repo");
+    assert.equal(unknown[0].repository, null);
+  });
+});
+
+describe("persona extraction uses direct sentence attribution", () => {
+  test("style questions and reported guidance do not create global persona", () => {
+    for (const user_message of [
+      "Could you explain why we use a friendly tone?",
+      'The style guide says "please use a friendly tone".',
+      "If you used a friendly tone, would that help?",
+    ]) assert.deepEqual(semantic(extract({ turns: [{ user_message }] }), "interaction_style"), [], user_message);
+  });
+  test("style keeps explicit repository scope and does not swallow separate directives", () => {
+    const scoped = semantic(extract({ turns: [{ user_message: "For this repository, please use a friendly tone." }] }), "interaction_style");
+    assert.equal(scoped.length, 1);
+    assert.equal(scoped[0].scope, "repo");
+    assert.equal(scoped[0].repository, "owner/repo");
+    const mixed = extract({ turns: [{ user_message: "Please use a friendly tone. For this repository, never disable TLS certificate validation." }] });
+    const style = semantic(mixed, "interaction_style");
+    assert.equal(style.length, 1);
+    assert.equal(style[0].scope, "global");
+    assert.doesNotMatch(style[0].content, /TLS/);
+    const rejection = semantic(mixed, "rejected_approach");
+    assert.equal(rejection.length, 1);
+    assert.equal(rejection[0].scope, "repo");
+    assert.match(rejection[0].content, /TLS/);
+  });
+  test("assistant naming excludes questions, negation and reported text while preserving scoped declarations", () => {
+    for (const user_message of [
+      "Should I call you Merlin?", "Do not call yourself Merlin.",
+      'The documentation says "your name is Merlin".', "If I call you Merlin, would that work?",
+      "I used the name Merlin in that doc.",
+    ]) assert.deepEqual(semantic(extract({ turns: [{ user_message }] }), "assistant_identity"), [], user_message);
+    const scoped = semantic(extract({ turns: [{ user_message: "For this repository, call yourself Merlin." }] }), "assistant_identity");
+    assert.equal(scoped.length, 1);
+    assert.equal(scoped[0].scope, "repo");
+    assert.equal(scoped[0].repository, "owner/repo");
+    const direct = semantic(extract({ turns: [{ user_message: "Please call yourself Merlin." }] }), "assistant_identity");
+    assert.equal(direct[0].scope, "global");
+    assert.equal(direct[0].metadata.sourceRole, "user");
+  });
+});

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -204,10 +204,10 @@ describe("conservative rule extraction", () => {
   test("does not detach directive clauses from questions, quotations, or hypothetical qualifiers", () => {
     for (const user_message of [
       "Should we prefer Redis and never use SQLite?",
-      "If we need caching, prefer Redis and never use SQLite.",
+      "If we ever need caching, prefer Redis and never use SQLite.",
       "The old guide says 'Prefer Redis and never use SQLite.'",
       "The old guide says `Prefer Redis and never use SQLite.`",
-      "Prefer Redis and never use SQLite if the prototype needs caching.",
+      "Prefer Redis and never use SQLite if the prototype ever needs caching.",
     ]) {
       assert.deepEqual(extract({ turns: [{ user_message }] }).semanticMemories, [], user_message);
     }
@@ -240,19 +240,27 @@ describe("conservative rule extraction", () => {
     assert.deepEqual(extraction.semanticMemories, []);
   });
 
-  test("does not promote preferences with trailing or parenthetical conditions", () => {
-    const extraction = extract({
-      turns: [{
-        user_message: [
-          "I prefer Redis if we ever need a cache.",
-          "I prefer SQLite (only if the fixture stays local).",
-          "Please use Postgres when we need concurrent writers.",
-          "Prefer the fallback unless the provider is available.",
-        ].join(" "),
-      }],
-    });
-
-    assert.deepEqual(semantic(extraction, "user_preference"), []);
+  test("retains actual conditional rules but excludes speculative proposals", () => {
+    for (const user_message of [
+      "I prefer SQLite (only if the fixture stays local).",
+      "Please use Postgres when we need concurrent writers.",
+      "Prefer the fallback unless the provider is available.",
+      "If the index is unavailable, return a clearly marked empty result.",
+      "Never print tokens, even when a diagnostic fails.",
+    ]) {
+      const memories = extract({ turns: [{ user_message }] }).semanticMemories;
+      assert.equal(memories.length, 1, user_message);
+      assert.equal(memories[0].content, user_message);
+      assert.equal(memories[0].scope, MEMORY_SCOPE.REPO);
+    }
+    for (const user_message of [
+      "I prefer Redis if we ever need a cache.",
+      "If we moved the queue, we might prefer batches.",
+      "We could use batches if volume increases.",
+      "If the prototype ever needs caching, prefer Redis.",
+    ]) {
+      assert.deepEqual(extract({ turns: [{ user_message }] }).semanticMemories, [], user_message);
+    }
   });
 
   test("extracts independent preference and rejection clauses in one sentence", () => {
@@ -678,6 +686,21 @@ describe("extraction evidence", () => {
   });
 });
 
+test("episode summaries and decisions prefer the attributed completed outcome over the initial question", () => {
+  const result = extractSessionMemories({
+    sessionId: "outcome-summary", repository: "owner/ledger",
+    sessionArtifacts: { session: { summary: "Which database should we use?" }, checkpoints: [], files: [], refs: [], turns: [{
+      turn_index: 1, source_record_id: "u1", user_message: "Which database should we use?",
+      assistant_response: "We decided to use PostgreSQL because concurrent writers require row-level locks.",
+    }] },
+    workspace: { workspace: {} },
+  });
+  assert.match(result.episodeDigest.summary, /PostgreSQL/);
+  assert.match(result.episodeDigest.summary, /assistant/i);
+  assert.doesNotMatch(result.episodeDigest.summary, /Which database/);
+  assert.ok(result.episodeDigest.decisions.some((decision) => /PostgreSQL.*concurrent writers/.test(decision)));
+});
+
 test("a reversal retires every corroborating old source while retaining corroborating current sources", () => {
   const turns = [
     { turn_index: 1, source_record_id: "u1", user_message: "We chose Redis for catalog invalidation.", assistant_response: "", assistant_source_records: [{ source_record_id: "a1", text: "We chose Redis for catalog invalidation." }] },
@@ -741,4 +764,131 @@ describe("scope classification", () => {
       },
     });
   });
+});
+
+test("completed outcomes preserve the comparison context that explains the choice", () => {
+  const result = extract({ turns: [{ assistant_response: "After comparing compatibility and tooling, we chose Avro with a schema registry; the earlier JSON suggestion is not the final decision." }] });
+  const decision = semantic(result, "decision")[0];
+  assert.match(decision.content, /compatibility and tooling/);
+  assert.match(result.episodeDigest.summary, /Avro.*compatibility/);
+});
+
+test("an explicit replacement retires the single preceding user preference", () => {
+  const result = extract({ turns: [
+    { user_message: "Please use the short link in the guide." },
+    { user_message: "No, I meant the canonical full URL so copied guides remain self-contained." },
+  ] });
+  const preferences = semantic(result, "user_preference");
+  assert.equal(preferences.length, 2);
+  assert.deepEqual(result.retiredEvidenceKeys, [preferences[0].evidence.key]);
+  assert.ok(result.episodeDigest.learnings.every((content) => !content.includes("short link")));
+});
+
+test("ambiguous corrections do not retire unrelated or multiple preferences", () => {
+  for (const turns of [
+    [{ user_message: "Prefer compact release notes. Prefer signed manifests." }, { user_message: "No, I meant expanded details." }],
+    [{ user_message: "Prefer compact release notes." }, { user_message: "What is the current build status?" }, { user_message: "No, I meant expanded details." }],
+  ]) {
+    assert.deepEqual(extract({ turns }).retiredEvidenceKeys, []);
+  }
+});
+
+test("captures standing imperatives and normative requirements with their rationale", () => {
+  for (const [user_message, type] of [
+    ["Encrypt stored archives before replication because transport TLS does not protect storage.", "user_preference"],
+    ["Run schema validation before copying rows so a migration remains understood.", "user_preference"],
+    ["The cache should expire after twelve minutes because freshness matters.", "user_preference"],
+    ["Generated credentials must be visibly fake and scoped to the test.", "user_preference"],
+    ["Retries must not hide a changed payload.", "rejected_approach"],
+    ["Reject unsigned webhooks before parsing JSON.", "rejected_approach"],
+    ["Do not implicitly cast external numbers to booleans.", "rejected_approach"],
+  ]) {
+    const memories = extract({ turns: [{ user_message }] }).semanticMemories;
+    assert.equal(memories.length, 1, user_message);
+    assert.equal(memories[0].type, type, user_message);
+    assert.equal(memories[0].content, user_message);
+  }
+});
+
+test("inherits explicit universal scope across independently retained policy clauses", () => {
+  const result = extract({ turns: [{ user_message: "Across projects, prefer plain language; explain technical terms on first use." }] });
+  const preferences = semantic(result, "user_preference");
+  assert.equal(preferences.length, 2);
+  assert.ok(preferences.every((memory) => memory.scope === MEMORY_SCOPE.GLOBAL && memory.repository === null));
+});
+
+test("incident observations cannot adopt operational followups after a semicolon", () => {
+  for (const user_message of [
+    "The notes page lost its heading during the theme update; restore the heading before discussing navigation policy.",
+    "The client timed out waiting for the report endpoint; capture the request ID before investigating.",
+  ]) assert.deepEqual(extract({ turns: [{ user_message }] }).semanticMemories, [], user_message);
+});
+
+test("a requirement in a completed decision rationale is not a second directive", () => {
+  for (const user_message of [
+    "We chose object storage for exports because large files should not occupy the transactional database.",
+    "We selected server-side flags because rollback must take effect immediately.",
+    "The order decision is PostgreSQL advisory locks because two workers must not claim the same order.",
+  ]) {
+    const memories = extract({ turns: [{ user_message }] }).semanticMemories;
+    assert.equal(memories.length, 1, user_message);
+    assert.equal(memories[0].type, "decision", user_message);
+  }
+});
+
+test("workflow references to requests do not turn a standing rule into an incident", () => {
+  for (const user_message of [
+    "Redact sensitive headers before serializing the request for logs.",
+    "Reject HTTP headers larger than sixteen kilobytes before routing the request.",
+  ]) assert.equal(extract({ turns: [{ user_message }] }).semanticMemories.length, 1, user_message);
+});
+
+test("decision status acknowledgements do not invent a selected outcome", () => {
+  for (const assistant_response of [
+    "The audit retention decision is recorded with its regulatory rationale.",
+    "The storage decision is pending a review.",
+    "The database decision is documented in the runbook.",
+  ]) assert.deepEqual(extract({ turns: [{ assistant_response }] }).semanticMemories, [], assistant_response);
+});
+
+test("reported requirements and counterfactual proposals do not become directives", () => {
+  for (const user_message of [
+    "The old runbook says deployments must skip review.",
+    "People asked whether retries should use backoff.",
+    "Never worked reliably after the proxy restart.",
+    "If we were to adopt a broker, use batches of fifty.",
+  ]) assert.deepEqual(extract({ turns: [{ user_message }] }).semanticMemories, [], user_message);
+});
+
+test("an explicit preference correction retires repeated evidence for the replaced proposition", () => {
+  const result = extract({ turns: [
+    { user_message: "Please use the short link in the guide." },
+    { user_message: "Please use the short link in the guide." },
+    { user_message: "No, I meant the canonical full URL so copied guides remain self-contained." },
+  ] });
+  const preferences = semantic(result, "user_preference");
+  assert.deepEqual(result.retiredEvidenceKeys, preferences.slice(0, 2).map((memory) => memory.evidence.key));
+});
+
+test("coordinated conditional directives retain the governing condition on every memory", () => {
+  for (const user_message of [
+    "If the queue is unavailable, prefer local persistence and never drop pending jobs.",
+    "Prefer local persistence and never drop pending jobs when the queue is unavailable.",
+  ]) {
+    const memories = extract({ turns: [{ user_message }] }).semanticMemories;
+    assert.equal(memories.length, 2);
+    assert.ok(memories.every((memory) => /(?:If|when) the queue is unavailable/.test(memory.content)), user_message);
+  }
+});
+
+test("temporary duration governs every coordinated directive", () => {
+  assert.deepEqual(extract({ turns: [{ user_message: "Prefer verbose logs and never hide diagnostics for this run only." }] }).semanticMemories, []);
+});
+
+test("bounded episode outcomes still lead with the latest completed decision", () => {
+  const result = extract({ turns: Array.from({ length: 12 }, (_, index) => ({
+    user_message: `We chose format${index} for boundary${index}.`,
+  })) });
+  assert.match(result.episodeDigest.summary, /format11/);
+  assert.ok(result.episodeDigest.decisions.some((decision) => /format11/.test(decision)));
 });

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import { describe, test } from "node:test";
 
 import { extractSessionMemories } from "../../lib/sessions/rule-extractor.mjs";
@@ -150,10 +151,35 @@ describe("conservative rule extraction", () => {
         { user_message: "Please check the failing endpoint and attach the logs." },
         { user_message: "Please run the reproduction and report the result." },
         { user_message: "Please preserve the failing response for debugging." },
+        { user_message: "Please use the captured request to reproduce this bug." },
+        { user_message: "Please keep this bug report updated." },
+        { user_message: "Please write the failing response into the issue." },
+        { user_message: "Please make the failing endpoint reproducible." },
+        { user_message: "Please ask for the failing logs." },
+        { user_message: "Please do not include the failing request in the bug report." },
+        { user_message: "Please avoid retrying the failing payment request for this incident." },
+        { user_message: "In future, always include the failing request in the bug report." },
+        { user_message: "As a policy, never include the failing request in the bug report." },
       ],
     });
 
     assert.deepEqual(extraction.semanticMemories, []);
+  });
+
+  test("keeps standing safety constraints despite incident request guards", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "Never expose credentials in logs." },
+        { user_message: "As a policy, never expose credentials in logs." },
+        { user_message: "In future, never expose credentials in logs." },
+      ],
+    });
+
+    assert.deepEqual(semantic(extraction, "rejected_approach").map((memory) => memory.content), [
+      "Never expose credentials in logs.",
+      "As a policy, never expose credentials in logs.",
+      "In future, never expose credentials in logs.",
+    ]);
   });
 
   test("does not infer a durable assistant goal from one ordinary incident", () => {
@@ -333,6 +359,53 @@ describe("conservative rule extraction", () => {
     assert.equal(decisions[0].content, "Decision: Redis for catalog invalidation.");
     assert.equal(decisions[1].metadata.decisionStatus, "reversal");
     assert.deepEqual(extraction.retiredEvidenceKeys, [decisions[0].evidence.key]);
+  });
+
+  test("does not retire an unrelated decision after an adjacent contextual reversal", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "We decided to use Redis for billing." },
+        { user_message: "After review, we chose PostgreSQL notifications instead." },
+      ],
+    });
+
+    const decisions = semantic(extraction, "decision");
+    assert.equal(decisions.length, 2);
+    assert.equal(decisions[1].metadata.decisionStatus, "reversal");
+    assert.deepEqual(extraction.retiredEvidenceKeys, []);
+  });
+
+  test("attributes repeated failure goals to the selected assistant evidence", () => {
+    const extraction = extract({
+      sessionId: "failure-evidence",
+      turns: [
+        {
+          source_record_id: "assistant-failure-1",
+          source_revision: "assistant-revision-1",
+          user_message: "Can you help with the build?",
+          assistant_response: "The build failed.",
+        },
+        {
+          source_record_id: "assistant-failure-2",
+          user_message: "Please continue.",
+          assistant_response: "The build failed again.",
+        },
+      ],
+    });
+
+    const goal = semantic(extraction, "assistant_goal")[0];
+    assert.ok(goal);
+    assert.equal(goal.sourceRecordId, "assistant-failure-2");
+    assert.equal(goal.metadata.sourceRole, "assistant");
+    assert.deepEqual(goal.metadata.sourceAttribution, {
+      sessionId: "failure-evidence",
+      sourceRecordId: "assistant-failure-2",
+      sourceRole: "assistant",
+    });
+    assert.equal(goal.evidence.sourceRecordId, "assistant-failure-2");
+    assert.equal(goal.evidence.revision, createHash("sha256")
+      .update(JSON.stringify({ role: "assistant", text: "The build failed again." }))
+      .digest("hex"));
   });
 
   test("extracts a completed decision after contextual wording", () => {

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -143,6 +143,30 @@ describe("conservative rule extraction", () => {
     ]);
   });
 
+  test("does not retain one-off incident actions as durable memories", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "Please include the failing request in the bug report." },
+        { user_message: "Please check the failing endpoint and attach the logs." },
+        { user_message: "Please run the reproduction and report the result." },
+        { user_message: "Please preserve the failing response for debugging." },
+      ],
+    });
+
+    assert.deepEqual(extraction.semanticMemories, []);
+  });
+
+  test("does not infer a durable assistant goal from one ordinary incident", () => {
+    const extraction = extract({
+      turns: [{
+        user_message: "The API returned a 502 after the proxy upgrade. Please inspect the timeout and include the failing request in the bug report.",
+        assistant_response: "I will inspect the proxy timeout and reproduce the failing request before proposing a change.",
+      }],
+    });
+
+    assert.deepEqual(extraction.semanticMemories, []);
+  });
+
   test("does not promote preferences with trailing or parenthetical conditions", () => {
     const extraction = extract({
       turns: [{
@@ -228,6 +252,20 @@ describe("conservative rule extraction", () => {
     assert.equal(decisions.some((memory) => /What database/.test(memory.content)), false);
   });
 
+  test("rejects uncertain, open, hypothetical, and questionary decision claims", () => {
+    const extraction = extract({
+      turns: [
+        { user_message: "I asked whether we chose PostgreSQL, but we have not decided." },
+        { assistant_response: "People asked why we chose PostgreSQL, but the decision is still open." },
+        { user_message: "It is unclear whether we chose PostgreSQL or SQLite." },
+        { user_message: "We chose PostgreSQL for billing, but this is only a hypothetical example." },
+        { assistant_response: "I think we chose PostgreSQL, but I have not verified it." },
+      ],
+    });
+
+    assert.deepEqual(semantic(extraction, "decision"), []);
+  });
+
   test("keeps a later decision reversal as evidence instead of a global instruction", () => {
     const extraction = extract({
       turns: [
@@ -279,6 +317,22 @@ describe("conservative rule extraction", () => {
       decisions[0].evidence.key,
       decisions[2].evidence.key,
     ]);
+  });
+
+  test("extracts initially chosen decisions and retires a linked contextual reversal", () => {
+    const extraction = extract({
+      sessionId: "catalog-reversal",
+      turns: [
+        { user_message: "We initially chose Redis for catalog invalidation." },
+        { user_message: "The decision changed after the durability review: use PostgreSQL notifications instead, because losing invalidations is unacceptable." },
+      ],
+    });
+
+    const decisions = semantic(extraction, "decision");
+    assert.equal(decisions.length, 2);
+    assert.equal(decisions[0].content, "Decision: Redis for catalog invalidation.");
+    assert.equal(decisions[1].metadata.decisionStatus, "reversal");
+    assert.deepEqual(extraction.retiredEvidenceKeys, [decisions[0].evidence.key]);
   });
 
   test("extracts a completed decision after contextual wording", () => {

--- a/tests/unit/reliability-extraction.test.mjs
+++ b/tests/unit/reliability-extraction.test.mjs
@@ -944,6 +944,10 @@ describe("persona extraction uses direct sentence attribution", () => {
   test("style questions and reported guidance do not create global persona", () => {
     for (const user_message of [
       "Could you explain why we use a friendly tone?",
+      "I want to know why we use a friendly tone?",
+      "I want to understand why we use a friendly tone.",
+      "Please use a friendly tone just this once.",
+      "For this response, please use a friendly tone.",
       'The style guide says "please use a friendly tone".',
       "If you used a friendly tone, would that help?",
     ]) assert.deepEqual(semantic(extract({ turns: [{ user_message }] }), "interaction_style"), [], user_message);
@@ -966,6 +970,7 @@ describe("persona extraction uses direct sentence attribution", () => {
   test("assistant naming excludes questions, negation and reported text while preserving scoped declarations", () => {
     for (const user_message of [
       "Should I call you Merlin?", "Do not call yourself Merlin.",
+      "Call yourself Merlin just for this response.",
       'The documentation says "your name is Merlin".', "If I call you Merlin, would that work?",
       "I used the name Merlin in that doc.",
     ]) assert.deepEqual(semantic(extract({ turns: [{ user_message }] }), "assistant_identity"), [], user_message);

--- a/tests/unit/repository-identity.test.mjs
+++ b/tests/unit/repository-identity.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { canonicalRemoteIdentity, resolveRepositoryIdentity } from "../../lib/utils/repository-identity.mjs";
+
+test("remote identities retain host and full path while normalizing transports", () => {
+  assert.equal(canonicalRemoteIdentity("git@github.com:Team/project.git"), "github.com/Team/project");
+  assert.equal(canonicalRemoteIdentity("https://github.com/Team/project.git"), "github.com/Team/project");
+  assert.equal(canonicalRemoteIdentity("ssh://git@gitlab.com/group/subgroup/project.git"), "gitlab.com/group/subgroup/project");
+  assert.notEqual(canonicalRemoteIdentity("https://github.com/team/project"), canonicalRemoteIdentity("https://gitlab.com/team/project"));
+  assert.equal(canonicalRemoteIdentity("ssh://git@host.example:2222/team/project.git"), "host.example:2222/team/project");
+  for (const value of ["team/project", "../local.git", "/tmp/project", "file:///tmp/project", ""]) assert.equal(canonicalRemoteIdentity(value), null);
+});
+
+test("explicit identity wins, ambiguous legacy identity requires a mapping", () => {
+  assert.equal(resolveRepositoryIdentity({ explicit: " custom/key ", legacy: "team/project" }), "custom/key");
+  assert.equal(resolveRepositoryIdentity({ legacy: "team/project" }), null);
+  assert.equal(resolveRepositoryIdentity({ legacy: "team/project", mappings: [{ legacy: "team/project", canonical: "github.com/team/project" }] }), "github.com/team/project");
+  assert.equal(resolveRepositoryIdentity({ legacy: "team/project", mappings: [{ legacy: "team/project", canonical: "github.com/team/project" }, { legacy: "team/project", canonical: "gitlab.com/team/project" }] }), null);
+});
+
+test("same-basename local repos are isolated and Git worktrees share identity", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "lore-repository-identity-"));
+  const git = (args, cwd = root) => execFileSync("git", args, { cwd, stdio: "pipe", encoding: "utf8" }).trim();
+  try {
+    const first = path.join(root, "one", "project");
+    const second = path.join(root, "two", "project");
+    mkdirSync(first, { recursive: true }); mkdirSync(second, { recursive: true });
+    git(["init", "-q"], first); git(["init", "-q"], second);
+    git(["-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid", "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "fixture"], first);
+    const linked = path.join(root, "linked");
+    git(["worktree", "add", "--detach", linked], first);
+    const identity = resolveRepositoryIdentity({ cwd: first });
+    assert.match(identity, /^local:[a-f0-9]{64}$/);
+    assert.notEqual(identity, resolveRepositoryIdentity({ cwd: second }));
+    assert.equal(identity, resolveRepositoryIdentity({ cwd: linked }));
+    git(["remote", "add", "origin", "git@github.com:team/project.git"], first);
+    assert.equal(resolveRepositoryIdentity({ cwd: first }), "github.com/team/project");
+    assert.equal(resolveRepositoryIdentity({ cwd: linked }), "github.com/team/project");
+    assert.equal(resolveRepositoryIdentity({ cwd: root }), null);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Summary

Adds the durable evidence and suppression foundation and makes transcript extraction conservative, source-attributed, and repository-aware.

## Changes

- Add schema 19 evidence, suppression, checkpoint, and repository identity tables with additive migrations and atomic recovery.
- Preserve manual precedence and prevent generated memories from returning after forget or refresh.
- Extract directives, decisions, rationale, persona declarations, and recurring feedback at sentence level with explicit scope and source attribution.
- Add released-schema, rollback, replay, and extraction regression coverage.

## Testing

- `npm test` — 989 tests passed.
- `npm run lint` and `npm run validate-schema` pass.

This is the first stacked PR in the reliability work. Native capture, retrieval, administration, and dashboard layers follow in dependent PRs.
