### PR TITLE
feat: add provenance dashboard and reliability docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,13 +491,23 @@ The dashboard is also the quickest way to inspect a memory's evidence links,
 source role, confidence basis, scope, expiry, suppression, and correction
 timeline. Its overview reports native capture checkpoints and embedding
 coverage, including resumable sessions and recent lexical fallback reasons.
-Resume actions and administration actions are copy-only previews; the browser
-never executes them or writes to the database.
+Resume actions and administration actions are copy-only commands; the browser
+never executes them or writes to the database. Running a copied `capture
+--resume` command resumes capture and can write newly captured evidence.
 
-For native capture that reports pending bytes, rerun the displayed command from
-the Lore checkout after reviewing the source path and workspace. Direct
-administration commands default to a read-only preview and accept JSON on
-stdin:
+For native capture that reports pending bytes or pending branch/cleanup work,
+review the displayed source path and workspace, then rerun the displayed
+command from the Lore checkout. The bounded resume pass reads at most 4 MiB
+with a 250 ms cooperative read budget per invocation, retains at most a 1 MiB incomplete record, and reports
+oversized-record skips through categorical health. Its JSON stdin is
+`{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}`:
+
+```sh
+printf '%s\n' '{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}' | node lore-cli.mjs capture --resume --client codex --session '<native-session-id>'
+```
+
+Direct administration commands default to a read-only preview and accept JSON
+on stdin:
 
 ```sh
 printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node lore-cli.mjs tool memory_correct
@@ -507,6 +517,35 @@ printf '%s\n' '{"memoryIds":["<id>"]}' | node lore-cli.mjs tool memory_purge
 
 Review the preview's `planFingerprint`, affected derived records, retained
 source and backup consequences, and unresolved items before an explicit apply.
+For correction, `repository` changes the replacement destination; omit it to
+keep the old repository, or set `scope: "global"` and `repository: null` for
+an explicit global replacement. For repair, apply only the actionable source
+re-extraction candidates or `mapping:<legacy>-><canonical>` IDs returned by the
+preview. Missing or oversized sources remain unresolved. Source-backed repair
+scans at most 32 MiB and 10,000 turns; unavailable or oversized legacy sources
+remain unresolved.
+
+For example, a reviewed correction apply is:
+
+```sh
+printf '%s\n' '{"action":"apply","memoryId":"<id>","content":"<replacement>","reason":"<why>","planFingerprint":"<preview-fingerprint>"}' | node lore-cli.mjs tool memory_correct
+```
+
+Repair mappings and candidates must be selected explicitly:
+
+```sh
+printf '%s\n' '{"action":"apply","repositoryMappings":[{"legacy":"<legacy>","canonical":"<canonical>"}],"selectedCandidateIds":["mapping:<legacy>-><canonical>"],"planFingerprint":"<preview-fingerprint>"}' | node lore-cli.mjs tool memory_repair
+```
+
+Purge aggregate candidates use typed IDs such as
+`aggregate:episode_digest:<json-primary-key>`. If the initial preview reports
+residual aggregates, run a new preview with `includeDependentAggregates: true`,
+then use that new fingerprint and select every residual aggregate ID it reports:
+
+```sh
+printf '%s\n' '{"action":"apply","memoryIds":["<id>"],"includeDependentAggregates":true,"selectedCandidateIds":["aggregate:<table>:<json-primary-key>"],"planFingerprint":"<preview-fingerprint>"}' | node lore-cli.mjs tool memory_purge
+```
+
 Purge removes selected derived records and keeps raw sources, snapshots, and
 non-plaintext suppression; it is not secure erasure.
 

--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ on stdin:
 
 ```sh
 printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node lore-cli.mjs tool memory_correct
-printf '%s\n' '{"sessionIds":["<session-id>"]}' | node lore-cli.mjs tool memory_repair
+printf '%s\n' '{"memoryIds":["<id>"]}' | node lore-cli.mjs tool memory_repair
 printf '%s\n' '{"memoryIds":["<id>"]}' | node lore-cli.mjs tool memory_purge
 ```
 

--- a/README.md
+++ b/README.md
@@ -503,16 +503,16 @@ oversized-record skips through categorical health. Its JSON stdin is
 `{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}`:
 
 ```sh
-printf '%s\n' '{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}' | node lore-cli.mjs capture --resume --client codex --session '<native-session-id>'
+printf '%s\n' '{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}' | node /absolute/path/to/lore/lore-cli.mjs capture --resume --client codex --session '<native-session-id>'
 ```
 
 Direct administration commands default to a read-only preview and accept JSON
 on stdin:
 
 ```sh
-printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node lore-cli.mjs tool memory_correct
-printf '%s\n' '{"memoryIds":["<id>"]}' | node lore-cli.mjs tool memory_repair
-printf '%s\n' '{"memoryIds":["<id>"]}' | node lore-cli.mjs tool memory_purge
+printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_correct
+printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_repair
+printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_purge
 ```
 
 Review the preview's `planFingerprint`, affected derived records, retained
@@ -528,13 +528,13 @@ remain unresolved.
 For example, a reviewed correction apply is:
 
 ```sh
-printf '%s\n' '{"action":"apply","memoryId":"<id>","content":"<replacement>","reason":"<why>","planFingerprint":"<preview-fingerprint>"}' | node lore-cli.mjs tool memory_correct
+printf '%s\n' '{"action":"apply","memoryId":"<id>","content":"<replacement>","reason":"<why>","planFingerprint":"<preview-fingerprint>"}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_correct
 ```
 
 Repair mappings and candidates must be selected explicitly:
 
 ```sh
-printf '%s\n' '{"action":"apply","repositoryMappings":[{"legacy":"<legacy>","canonical":"<canonical>"}],"selectedCandidateIds":["mapping:<legacy>-><canonical>"],"planFingerprint":"<preview-fingerprint>"}' | node lore-cli.mjs tool memory_repair
+printf '%s\n' '{"action":"apply","repositoryMappings":[{"legacy":"<legacy>","canonical":"<canonical>"}],"selectedCandidateIds":["mapping:<legacy>-><canonical>"],"planFingerprint":"<preview-fingerprint>"}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_repair
 ```
 
 Purge aggregate candidates use typed IDs such as
@@ -543,7 +543,7 @@ residual aggregates, run a new preview with `includeDependentAggregates: true`,
 then use that new fingerprint and select every residual aggregate ID it reports:
 
 ```sh
-printf '%s\n' '{"action":"apply","memoryIds":["<id>"],"includeDependentAggregates":true,"selectedCandidateIds":["aggregate:<table>:<json-primary-key>"],"planFingerprint":"<preview-fingerprint>"}' | node lore-cli.mjs tool memory_purge
+printf '%s\n' '{"action":"apply","memoryIds":["<id>"],"includeDependentAggregates":true,"selectedCandidateIds":["aggregate:<table>:<json-primary-key>"],"planFingerprint":"<preview-fingerprint>"}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_purge
 ```
 
 Purge removes selected derived records and keeps raw sources, snapshots, and

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ The canonical breakdown lives in [`docs/support-matrix.md`](docs/support-matrix.
 
 Pi exposes `lore_save`, `lore_onboard`, `lore_recall`, and `lore_status`, plus `/lore status`, `/lore save <text>`, and `/lore search <query>`.
 
-The experimental Codex, Claude Code, and Antigravity adapters expose these shell commands through `lore-cli.mjs tool <name>`: `lore_recall`, `lore_retain`, `lore_onboard`, `memory_search`, `memory_save`, `memory_forget`, and `memory_status`. They do not expose `memory_explain`, `memory_validate`, or the experimental Copilot tools. Their native event names and lifecycle mappings are listed in the [CLI integration guide](docs/cli-integrations.md#lifecycle-behavior).
+The experimental Codex, Claude Code, and Antigravity adapters expose these shell commands through `lore-cli.mjs tool <name>`: `lore_recall`, `lore_retain`, `lore_onboard`, `memory_search`, `memory_save`, `memory_forget`, `memory_status`, `memory_correct`, `memory_repair`, and `memory_purge`. They do not expose `memory_explain`, `memory_validate`, or the other experimental Copilot tools. Their native event names and lifecycle mappings are listed in the [CLI integration guide](docs/cli-integrations.md#lifecycle-behavior).
 
 For runtime and platform promises, see [`docs/compatibility.md`](docs/compatibility.md).
 
@@ -486,6 +486,29 @@ If you enable the optional browser dashboard, keep in mind:
 - it can display sensitive local memory content, including code, notes, file paths, and decisions
 
 Useful, yes. Internet-facing, absolutely not.
+
+The dashboard is also the quickest way to inspect a memory's evidence links,
+source role, confidence basis, scope, expiry, suppression, and correction
+timeline. Its overview reports native capture checkpoints and embedding
+coverage, including resumable sessions and recent lexical fallback reasons.
+Resume actions and administration actions are copy-only previews; the browser
+never executes them or writes to the database.
+
+For native capture that reports pending bytes, rerun the displayed command from
+the Lore checkout after reviewing the source path and workspace. Direct
+administration commands default to a read-only preview and accept JSON on
+stdin:
+
+```sh
+printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node lore-cli.mjs tool memory_correct
+printf '%s\n' '{"sessionIds":["<session-id>"]}' | node lore-cli.mjs tool memory_repair
+printf '%s\n' '{"memoryIds":["<id>"]}' | node lore-cli.mjs tool memory_purge
+```
+
+Review the preview's `planFingerprint`, affected derived records, retained
+source and backup consequences, and unresolved items before an explicit apply.
+Purge removes selected derived records and keeps raw sources, snapshots, and
+non-plaintext suppression; it is not secure erasure.
 
 For the full security model, see [SECURITY.md](SECURITY.md).
 

--- a/browser/app.js
+++ b/browser/app.js
@@ -200,6 +200,12 @@ function normalizeOverviewData(data) {
 }
 
 function renderCaptureHealth(health) {
+  const statusForCapture = (row) => {
+    if (row.status) return row.status
+    if (row.failureCode) return "failed"
+    if (Number(row.pendingBytes) > 0 || row.pendingWork?.branch || row.pendingWork?.cleanup) return "pending"
+    return "healthy"
+  }
   return `
     <section class="card section-card health-section">
       <div class="section-head">
@@ -214,11 +220,11 @@ function renderCaptureHealth(health) {
           <tbody>
             ${health.map((row) => `
               <tr>
-                <td><strong>${escapeHtml(row.client ?? "unknown")}</strong><div class="small">${escapeHtml(row.sessionId ?? "unknown session")}</div><div class="small">repo=${escapeHtml(row.repository ?? "global")}</div></td>
+                <td><strong>${escapeHtml(row.client ?? "unknown")}</strong><div class="small">${escapeHtml(row.sessionId ?? "unknown session")}</div><div class="small">origin=${escapeHtml(row.originLabel ?? row.repository ?? "unknown origin")}</div></td>
                 <td>${escapeHtml(formatTime(row.lastSuccessAt))}</td>
                 <td>${escapeHtml(row.pendingBytes ?? 0)} bytes</td>
-                <td>${row.failureCode ? `<span class="tag warn">${escapeHtml(row.failureCode)}</span>` : '<span class="tag ok">healthy</span>'}<div class="small">offset=${escapeHtml(row.offset ?? 0)}</div></td>
-                <td>${row.resumeCommand ? `<button type="button" class="action-btn copy-command" data-copy-command="${escapeHtml(row.resumeCommand)}" aria-label="Copy resume command">Copy preview command</button><div class="small copy-feedback" aria-live="polite"></div>` : '<span class="small">No resumable source</span>'}</td>
+                <td>${(() => { const status = statusForCapture(row); return `<span class="tag ${status === "healthy" ? "ok" : "warn"}">${escapeHtml(status)}</span>${row.failureCode ? `<div class="small">failure=${escapeHtml(row.failureCode)}</div>` : ""}<div class="small">offset=${escapeHtml(row.offset ?? 0)}</div>${row.pendingWork?.branch ? '<div class="small">branch reconciliation pending</div>' : ""}${row.pendingWork?.cleanup ? '<div class="small">cleanup pending</div>' : ""}` })()}</td>
+                <td>${row.resumeCommand ? `<button type="button" class="action-btn copy-command" data-copy-kind="resume" data-copy-command="${escapeHtml(row.resumeCommand)}" aria-label="Copy resume command">Copy resume command</button><div class="small copy-feedback" aria-live="polite"></div>` : '<span class="small">No resumable source</span>'}</td>
               </tr>
             `).join("") || '<tr><td colspan="5" class="row-muted">No capture checkpoints recorded.</td></tr>'}
           </tbody>
@@ -230,22 +236,22 @@ function renderCaptureHealth(health) {
 
 function renderIndexingCoverage(indexing) {
   const diagnostics = asArray(indexing.fallbackDiagnostics)
-  const status = indexing.enabled === false ? "disabled" : `${indexing.coveragePercent ?? 0}% covered`
+  const status = indexing.enabled === false ? "disabled" : `${indexing.coveragePercent ?? 0}% sampled`
   return `
     <section class="card section-card health-section">
       <div class="section-head">
         <div>
           <h2>Embedding coverage</h2>
-          <div class="small">Cached vectors augment lexical retrieval. Coverage is derived from active memories.</div>
+          <div class="small">Cached vectors augment lexical retrieval. Coverage is a bounded sample of eligible active memories.</div>
         </div>
         <span class="tag ${indexing.enabled === false ? "warn" : "ok"}">${escapeHtml(status)}</span>
       </div>
       ${renderMetricGrid([
         ["Active memories", indexing.totalActive ?? 0],
         ["Indexed", indexing.indexed ?? 0],
-        ["Pending", indexing.pending ?? 0],
+        ["Pending", indexing.pending == null ? "not estimated" : indexing.pending],
       ])}
-      <div class="small coverage-note">${indexing.enabled === false ? "Embeddings are disabled in configuration; lexical retrieval remains available." : "Indexing is bounded and incremental; pending rows can be processed during maintenance."}</div>
+      <div class="small coverage-note">${indexing.enabled === false ? "Embeddings are disabled in configuration; lexical retrieval remains available." : `Indexed ${indexing.indexedSample ?? indexing.indexed ?? 0} of ${indexing.sampleSize ?? indexing.totalActive ?? 0} sampled eligible rows (${escapeHtml(indexing.coverageBasis ?? "bounded eligible sample")}; ${escapeHtml(indexing.dimensionsBasis ?? "cache identity validated")}). Pending is shown only when the eligible set was fully sampled.`}</div>
       ${diagnostics.length > 0 ? `<div class="list compact-list coverage-diagnostics"><strong>Recent fallback diagnostics</strong>${diagnostics.map((row) => `<div class="list-item"><span>${escapeHtml(row.reason)}</span><span class="small">count=${escapeHtml(row.count)}</span></div>`).join("")}</div>` : '<div class="small">No fallback diagnostics in the recent trace sample.</div>'}
     </section>
   `
@@ -1020,7 +1026,7 @@ function renderAdministrationPreviewSection(focus) {
     const command = buildPreviewCommand(tool, payload)
     return `
       <article class="list-item admin-command-item">
-        <div class="item-header-row"><strong>${escapeHtml(label)} preview</strong><button type="button" class="action-btn copy-command" data-copy-command="${escapeHtml(command)}" aria-label="Copy ${escapeHtml(label.toLowerCase())} preview command">Copy command</button></div>
+        <div class="item-header-row"><strong>${escapeHtml(label)} preview</strong><button type="button" class="action-btn copy-command" data-copy-kind="preview" data-copy-command="${escapeHtml(command)}" aria-label="Copy ${escapeHtml(label.toLowerCase())} preview command">Copy preview command</button></div>
         <code class="command-preview">${escapeHtml(command)}</code>
         <div class="small copy-feedback" aria-live="polite"></div>
       </article>
@@ -1300,7 +1306,11 @@ document.body.addEventListener("click", (event) => {
   const copyButton = event.target.closest("[data-copy-command]")
   if (copyButton) {
     const command = copyButton.dataset.copyCommand
+    const copyKind = copyButton.dataset.copyKind === "resume" ? "resume" : "preview"
+    const idleLabel = copyKind === "resume" ? "Copy resume command" : "Copy preview command"
+    const copiedLabel = copyKind === "resume" ? "Copied resume command" : "Copied preview command"
     const feedback = copyButton.parentElement?.querySelector?.(".copy-feedback")
+      ?? copyButton.closest?.(".admin-command-item")?.querySelector?.(".copy-feedback")
     if (!command) {
       return
     }
@@ -1309,10 +1319,10 @@ document.body.addEventListener("click", (event) => {
       return
     }
     void navigator.clipboard.writeText(command).then(() => {
-      if (feedback) feedback.textContent = "Copied preview command"
+      if (feedback) feedback.textContent = copiedLabel
       copyButton.textContent = "Copied"
       window.setTimeout(() => {
-        copyButton.textContent = "Copy preview command"
+        copyButton.textContent = idleLabel
         if (feedback) feedback.textContent = ""
       }, 1600)
     }).catch(() => {

--- a/browser/app.js
+++ b/browser/app.js
@@ -194,7 +194,61 @@ function normalizeOverviewData(data) {
     activityRows: asArray(data?.activity),
     workstreams: asArray(data?.activeWorkstreams),
     dueTasks: data?.maintenance?.dueTasks ?? [],
+    captureHealth: asArray(data?.captureHealth),
+    indexing: data?.indexing ?? {},
   }
+}
+
+function renderCaptureHealth(health) {
+  return `
+    <section class="card section-card health-section">
+      <div class="section-head">
+        <div>
+          <h2>Capture health</h2>
+          <div class="small">Last successful capture, pending bytes, and resumable native sessions.</div>
+        </div>
+      </div>
+      <div class="table-wrap">
+        <table class="table">
+          <thead><tr><th>client / session</th><th>last success</th><th>pending</th><th>status</th><th>resume</th></tr></thead>
+          <tbody>
+            ${health.map((row) => `
+              <tr>
+                <td><strong>${escapeHtml(row.client ?? "unknown")}</strong><div class="small">${escapeHtml(row.sessionId ?? "unknown session")}</div><div class="small">repo=${escapeHtml(row.repository ?? "global")}</div></td>
+                <td>${escapeHtml(formatTime(row.lastSuccessAt))}</td>
+                <td>${escapeHtml(row.pendingBytes ?? 0)} bytes</td>
+                <td>${row.failureCode ? `<span class="tag warn">${escapeHtml(row.failureCode)}</span>` : '<span class="tag ok">healthy</span>'}<div class="small">offset=${escapeHtml(row.offset ?? 0)}</div></td>
+                <td>${row.resumeCommand ? `<button type="button" class="action-btn copy-command" data-copy-command="${escapeHtml(row.resumeCommand)}" aria-label="Copy resume command">Copy preview command</button><div class="small copy-feedback" aria-live="polite"></div>` : '<span class="small">No resumable source</span>'}</td>
+              </tr>
+            `).join("") || '<tr><td colspan="5" class="row-muted">No capture checkpoints recorded.</td></tr>'}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  `
+}
+
+function renderIndexingCoverage(indexing) {
+  const diagnostics = asArray(indexing.fallbackDiagnostics)
+  const status = indexing.enabled === false ? "disabled" : `${indexing.coveragePercent ?? 0}% covered`
+  return `
+    <section class="card section-card health-section">
+      <div class="section-head">
+        <div>
+          <h2>Embedding coverage</h2>
+          <div class="small">Cached vectors augment lexical retrieval. Coverage is derived from active memories.</div>
+        </div>
+        <span class="tag ${indexing.enabled === false ? "warn" : "ok"}">${escapeHtml(status)}</span>
+      </div>
+      ${renderMetricGrid([
+        ["Active memories", indexing.totalActive ?? 0],
+        ["Indexed", indexing.indexed ?? 0],
+        ["Pending", indexing.pending ?? 0],
+      ])}
+      <div class="small coverage-note">${indexing.enabled === false ? "Embeddings are disabled in configuration; lexical retrieval remains available." : "Indexing is bounded and incremental; pending rows can be processed during maintenance."}</div>
+      ${diagnostics.length > 0 ? `<div class="list compact-list coverage-diagnostics"><strong>Recent fallback diagnostics</strong>${diagnostics.map((row) => `<div class="list-item"><span>${escapeHtml(row.reason)}</span><span class="small">count=${escapeHtml(row.count)}</span></div>`).join("")}</div>` : '<div class="small">No fallback diagnostics in the recent trace sample.</div>'}
+    </section>
+  `
 }
 
 function renderOverview(data) {
@@ -204,6 +258,8 @@ function renderOverview(data) {
     activityRows,
     workstreams,
     dueTasks,
+    captureHealth,
+    indexing,
   } = normalizeOverviewData(data)
 
   views.overview.innerHTML = `
@@ -219,6 +275,10 @@ function renderOverview(data) {
     ])}
 
     ${renderActivityTable(activityRows)}
+    <div class="health-grid">
+      ${renderCaptureHealth(captureHealth)}
+      ${renderIndexingCoverage(indexing)}
+    </div>
     ${renderWorkstreamsList(workstreams)}
   `
 }
@@ -900,12 +960,89 @@ function renderMemoryMetadataSection(metadata) {
   `
 }
 
-function buildMemoryDetailSections({ focus, provenance, lineage, cluster, improvements }) {
+function renderMemoryLifecycleSection(lifecycle = {}) {
+  const state = lifecycle.state ?? {}
+  const evidence = ensureArray(lifecycle.evidence)
+  const suppressions = ensureArray(lifecycle.suppressions)
+  const timeline = ensureArray(lifecycle.timeline)
+  const stateText = [
+    `memory=${state.memory ?? "unknown"}`,
+    `suppression=${state.suppression ?? "none"}`,
+    `expiry=${state.expiry ?? "none"}`,
+    `correction=${state.correction ?? "none"}`,
+  ].join(" · ")
+  const evidenceHtml = evidence.map((item) => `
+    <article class="list-item provenance-item">
+      <div class="item-header-row"><strong>${escapeHtml(item.sourceKind ?? "evidence")}</strong><span class="tag ${item.retiredAt || item.linkRetiredAt ? "warn" : "ok"}">${item.retiredAt || item.linkRetiredAt ? "retired" : "active"}</span></div>
+      <div class="small">role=${escapeHtml(item.sourceRole ?? "unattributed")} · confidence basis=${escapeHtml(item.confidenceBasis ?? "not recorded")}</div>
+      <div class="small">source ref=${escapeHtml(item.sourceRecordId ?? "not recorded")} · session=${escapeHtml(item.sessionId ?? "not recorded")}</div>
+      <div class="small">evidence key=${escapeHtml(item.key ?? "not recorded")}</div>
+      <div class="small">captured=${escapeHtml(formatTime(item.capturedAt))} · revision=${escapeHtml(item.revision ?? "not recorded")}</div>
+    </article>
+  `).join("")
+  const suppressionHtml = suppressions.map((item) => `
+    <article class="list-item provenance-item">
+      <div class="item-header-row"><strong>Suppression</strong><span class="tag ${item.supersededAt ? "ok" : "warn"}">${item.supersededAt ? "superseded" : "active"}</span></div>
+      <div class="small">actor=${escapeHtml(item.actor ?? "unknown")} · reason=${escapeHtml(item.reason ?? "not recorded")}</div>
+      <div class="small">recorded=${escapeHtml(formatTime(item.createdAt))}</div>
+    </article>
+  `).join("")
+  const timelineHtml = timeline.map((item) => `
+    <li><strong>${escapeHtml(item.label ?? item.kind ?? "event")}</strong><span class="small">${escapeHtml(formatTime(item.at))}</span>${item.sourceRole || item.sourceRecordId ? `<div class="small">${escapeHtml([item.sourceRole ? `role=${item.sourceRole}` : null, item.sourceRecordId ? `source ref=${item.sourceRecordId}` : null].filter(Boolean).join(" · "))}</div>` : ""}</li>
+  `).join("")
+  return `
+    <section class="card section-card lifecycle-section">
+      <div class="section-head"><div><h2>Evidence & lifecycle</h2><div class="small">Attributed source records and state history. Confidence basis is descriptive, not a probability.</div></div><span class="tag">${escapeHtml(stateText)}</span></div>
+      <div class="lifecycle-grid">
+        <div><h3>Source evidence</h3><div class="list compact-list">${evidenceHtml || renderEmptyBlock("No evidence links recorded.")}</div></div>
+        <div><h3>Suppression state</h3><div class="list compact-list">${suppressionHtml || renderEmptyBlock("No suppression recorded.")}</div></div>
+      </div>
+      <h3>Timeline</h3>
+      <ol class="timeline">${timelineHtml || '<li class="row-muted">No lifecycle events recorded.</li>'}</ol>
+    </section>
+  `
+}
+
+function quoteShell(value) {
+  return `'${String(value ?? "").replaceAll("'", "'\"'\"'")}'`
+}
+
+function buildPreviewCommand(tool, payload) {
+  return `printf '%s\\n' ${quoteShell(JSON.stringify({ action: "preview", ...payload }))} | node lore-cli.mjs tool ${tool}`
+}
+
+function renderAdministrationPreviewSection(focus) {
+  const commands = [
+    ["Correct", "memory_correct", { memoryId: focus.id, repository: focus.repository ?? undefined, content: "<replacement>", reason: "<reason>" }],
+    ["Repair", "memory_repair", { memoryIds: [focus.id], repository: focus.repository ?? undefined }],
+    ["Purge", "memory_purge", { memoryIds: [focus.id] }],
+  ].map(([label, tool, payload]) => {
+    const command = buildPreviewCommand(tool, payload)
+    return `
+      <article class="list-item admin-command-item">
+        <div class="item-header-row"><strong>${escapeHtml(label)} preview</strong><button type="button" class="action-btn copy-command" data-copy-command="${escapeHtml(command)}" aria-label="Copy ${escapeHtml(label.toLowerCase())} preview command">Copy command</button></div>
+        <code class="command-preview">${escapeHtml(command)}</code>
+        <div class="small copy-feedback" aria-live="polite"></div>
+      </article>
+    `
+  }).join("")
+  return `
+    <section class="card section-card administration-section">
+      <div class="section-head"><div><h2>Administration previews</h2><div class="small">Copy-only shell commands. Review the report fingerprint before any explicit apply.</div></div><span class="tag warn">preview only</span></div>
+      <div class="list compact-list">${commands}</div>
+      <div class="small">Purge removes selected derived records while retaining raw sources and recovery snapshots; it is not secure erasure.</div>
+    </section>
+  `
+}
+
+function buildMemoryDetailSections({ focus, provenance, lineage, cluster, improvements, lifecycle }) {
   return joinRenderedParts([
     renderSectionList("Provenance & day grouping", buildMemoryProvenanceItems(provenance), "No provenance rows for this memory.", "Session provenance and neighboring episodes on the same day."),
     renderSectionList("Lineage", buildMemoryLineageItems(lineage), "No supersession links for this memory.", "Navigate reinforced and superseded memories from here."),
     renderSectionList("Canonical cluster", buildMemoryClusterItems(cluster, focus.id), "This memory is not part of a canonical cluster.", "Cluster members share the same canonical key."),
     renderSectionList("Linked improvements", improvements.map(renderImprovementRelationItem).join(""), "No improvement artifacts linked to this memory.", "Read-only improvement backlog linkage."),
+    renderMemoryLifecycleSection(lifecycle),
+    renderAdministrationPreviewSection(focus),
     renderMemoryMetadataSection(focus.metadata),
   ])
 }
@@ -1004,6 +1141,7 @@ function renderMemoryDrilldown(data) {
   const lineage = ensureDefaultValue(data?.lineage)
   const cluster = data?.canonicalCluster
   const improvements = ensureArray(data?.linkedImprovements)
+  const lifecycle = ensureDefaultValue(data?.lifecycle)
 
   views.drilldown.innerHTML = renderDrilldownShell({
     title: focus.title,
@@ -1013,7 +1151,7 @@ function renderMemoryDrilldown(data) {
     summaryCards: buildMemorySummaryCards(focus),
     graphDescription: `Read-only graph centered on the selected ${focus.entityType}.`,
     graph: data.graph,
-    detailSections: buildMemoryDetailSections({ focus, provenance, lineage, cluster, improvements }),
+    detailSections: buildMemoryDetailSections({ focus, provenance, lineage, cluster, improvements, lifecycle }),
   })
 
   queueGraphDraw()
@@ -1100,7 +1238,15 @@ async function syncDrilldownFromHash({ activateIfPresent = false } = {}) {
     renderDrilldownEmpty()
     return
   }
-  await loadDrilldown(route.entity, route.id, { activate: activateIfPresent })
+  try {
+    await loadDrilldown(route.entity, route.id, { activate: activateIfPresent })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    renderDrilldownEmpty(`This ${route.entity} is no longer available. The rest of the dashboard remains available; refresh the source view to choose another record.`)
+    setStatus("record unavailable", false)
+    if (activateIfPresent) activateTab("drilldown")
+    console.warn(message)
+  }
 }
 
 async function navigateToDrilldown(entity, id) {
@@ -1151,6 +1297,30 @@ document.getElementById("tabs").addEventListener("click", (event) => {
 })
 
 document.body.addEventListener("click", (event) => {
+  const copyButton = event.target.closest("[data-copy-command]")
+  if (copyButton) {
+    const command = copyButton.dataset.copyCommand
+    const feedback = copyButton.parentElement?.querySelector?.(".copy-feedback")
+    if (!command) {
+      return
+    }
+    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
+      if (feedback) feedback.textContent = "Clipboard unavailable; select the command from the page source."
+      return
+    }
+    void navigator.clipboard.writeText(command).then(() => {
+      if (feedback) feedback.textContent = "Copied preview command"
+      copyButton.textContent = "Copied"
+      window.setTimeout(() => {
+        copyButton.textContent = "Copy preview command"
+        if (feedback) feedback.textContent = ""
+      }, 1600)
+    }).catch(() => {
+      if (feedback) feedback.textContent = "Copy failed; command remains available in the page."
+    })
+    return
+  }
+
   const clearButton = event.target.closest("[data-clear-drilldown]")
   if (clearButton) {
     clearDrilldownSelection()

--- a/browser/app.js
+++ b/browser/app.js
@@ -1014,7 +1014,7 @@ function quoteShell(value) {
 }
 
 function buildPreviewCommand(tool, payload) {
-  return `printf '%s\\n' ${quoteShell(JSON.stringify({ action: "preview", ...payload }))} | node lore-cli.mjs tool ${tool}`
+  return `printf '%s\\n' ${quoteShell(JSON.stringify({ action: "preview", ...payload }))} | node '/absolute/path/to/lore/lore-cli.mjs' tool ${tool}`
 }
 
 function renderAdministrationPreviewSection(focus) {

--- a/browser/server.mjs
+++ b/browser/server.mjs
@@ -4,6 +4,7 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { buildMaintenancePlan } from "../lib/maintenance/maintenance-scheduler.mjs"
+import { embeddingProviderIdentity, validatedCachedEmbeddingVector } from "../lib/memory/semantic-search.mjs"
 import { clampInteger } from "../lib/utils/numeric-utils.mjs"
 import { parseJsonArray } from "../lib/utils/json-array-utils.mjs"
 import { parseJsonObject } from "../lib/utils/json-object-utils.mjs"
@@ -301,17 +302,30 @@ function mapCaptureHealthRow(row) {
   const adapterState = row?.adapterState && typeof row.adapterState === "object" ? row.adapterState : {}
   const sourcePath = typeof adapterState.sourcePath === "string" ? adapterState.sourcePath : null
   const sourceCwd = typeof adapterState.sourceCwd === "string" ? adapterState.sourceCwd : null
+  const pendingBytesValue = Number(row?.health?.pendingBytes)
+  const pendingBytes = Number.isFinite(pendingBytesValue) && pendingBytesValue >= 0 ? pendingBytesValue : 0
+  const pendingWork = {
+    branch: Boolean(adapterState.branchWork),
+    cleanup: Boolean(adapterState.cleanupCursor),
+  }
+  const hasPendingWork = pendingBytes > 0 || pendingWork.branch || pendingWork.cleanup
+  const failureCode = row?.health?.failureCode ?? null
   return {
     client: row?.client ?? null,
     sessionId: row?.sessionId ?? null,
     repository: row?.repository ?? null,
-    offset: Number.isFinite(row?.offset) ? row.offset : 0,
-    pendingBytes: Number.isFinite(row?.health?.pendingBytes) ? row.health.pendingBytes : 0,
-    failureCode: row?.health?.failureCode ?? null,
+    originLabel: row?.repository || "unknown origin",
+    offset: Number.isFinite(Number(row?.offset)) ? Number(row.offset) : 0,
+    pendingBytes,
+    pendingWork,
+    hasPendingWork,
+    status: failureCode ? "failed" : hasPendingWork ? "pending" : "healthy",
+    failureCode,
     lastSuccessAt: row?.health?.lastSuccessAt ?? null,
     updatedAt: row?.updatedAt ?? null,
     sourcePath,
     sourceCwd,
+    resumeEligible: Boolean(sourcePath && sourceCwd),
     resumeCommand: buildResumeCommand({
       client: row?.client,
       sessionId: row?.sessionId,
@@ -333,13 +347,13 @@ function getTraceFallbackDiagnostics(traces) {
   for (const trace of traces) {
     const source = trace && typeof trace === "object" ? trace : {}
     const text = JSON.stringify(source)
-    if (/"fallback"\\s*:\\s*true/i.test(text)) {
+    if (/"fallback"\s*:\s*true/i.test(text)) {
       diagnostics.push({ reason: "deterministic_fallback", at: source.createdAt ?? source.created_at ?? null })
     }
-    if (/"partialCoverage"\\s*:\\s*true/i.test(text)) {
+    if (/"partialCoverage"\s*:\s*true/i.test(text)) {
       diagnostics.push({ reason: "partial_embedding_coverage", at: source.createdAt ?? source.created_at ?? null })
     }
-    if (/"deadline"\\s*:\\s*true/i.test(text)) {
+    if (/"deadline"\s*:\s*true/i.test(text)) {
       diagnostics.push({ reason: "embedding_deadline", at: source.createdAt ?? source.created_at ?? null })
     }
   }
@@ -349,42 +363,48 @@ function getTraceFallbackDiagnostics(traces) {
 }
 
 function queryIndexingCoverage({ db, repository, traces }) {
-  const embeddingsEnabled = db?.config?.embeddings?.enabled === true
-    || db?.config?.localInference?.embeddings?.enabled === true
-  if (!db?.db?.prepare) {
+  const inference = db?.config?.localInference ?? db?.config ?? {}
+  const embeddingConfig = inference?.embeddings ?? {}
+  const embeddingsEnabled = inference?.enabled === true && embeddingConfig.enabled === true
+  if (typeof db?.countSemanticMemoriesForEmbedding !== "function"
+    || typeof db?.listSemanticMemoriesForEmbedding !== "function") {
     return {
       enabled: embeddingsEnabled,
       totalActive: 0,
       indexed: 0,
       pending: 0,
       coveragePercent: 0,
+      sampleSize: 0,
+      indexedSample: 0,
+      coverageBasis: "bounded eligible sample",
       fallbackDiagnostics: getTraceFallbackDiagnostics(traces),
     }
   }
-  const active = db.db.prepare(`
-    SELECT COUNT(*) AS count
-    FROM semantic_memory
-    WHERE superseded_by IS NULL
-      AND (? IS NULL OR repository = ? OR (scope = 'global' AND repository IS NULL))
-  `).get(repository, repository)?.count ?? 0
-  const indexed = tableExists(db.db, "memory_embedding")
-    ? db.db.prepare(`
-      SELECT COUNT(*) AS count
-      FROM semantic_memory sm
-      JOIN memory_embedding me ON me.memory_id = sm.id
-      WHERE sm.superseded_by IS NULL
-        AND (? IS NULL OR sm.repository = ? OR (sm.scope = 'global' AND sm.repository IS NULL))
-        AND me.vector IS NOT NULL AND me.vector != ''
-    `).get(repository, repository)?.count ?? 0
-    : 0
-  const totalActive = Number(active) || 0
-  const indexedCount = Math.min(totalActive, Number(indexed) || 0)
+  const totalActive = db.countSemanticMemoriesForEmbedding({ repository })
+  const candidates = db.listSemanticMemoriesForEmbedding({ repository, limit: 256, offset: 0 })
+  const provider = embeddingProviderIdentity(inference)
+  const model = typeof embeddingConfig.model === "string" ? embeddingConfig.model.trim() : ""
+  const configuredDimensions = Number.isInteger(Number(embeddingConfig.dimensions)) && Number(embeddingConfig.dimensions) > 0
+    ? Number(embeddingConfig.dimensions)
+    : null
+  const indexedSample = candidates.filter((row) => validatedCachedEmbeddingVector(row, {
+    content: row.content,
+    provider,
+    model,
+    dimensions: configuredDimensions ?? Number(row.dimensions),
+  }) !== null).length
+  const sampleSize = candidates.length
+  const coveragePercent = sampleSize > 0 ? Math.round((indexedSample / sampleSize) * 100) : totalActive > 0 ? 0 : 100
   return {
     enabled: embeddingsEnabled,
     totalActive,
-    indexed: indexedCount,
-    pending: Math.max(0, totalActive - indexedCount),
-    coveragePercent: totalActive > 0 ? Math.round((indexedCount / totalActive) * 100) : 100,
+    indexed: indexedSample,
+    pending: sampleSize < totalActive ? null : Math.max(0, totalActive - indexedSample),
+    sampleSize,
+    indexedSample,
+    coveragePercent,
+    coverageBasis: "bounded eligible sample",
+    dimensionsBasis: configuredDimensions === null ? "stored vector dimensions" : "configured dimensions",
     fallbackDiagnostics: getTraceFallbackDiagnostics(traces),
   }
 }
@@ -438,20 +458,45 @@ function buildMemoryLifecycle({ db, memory }) {
       : new Date(expiresAt).getTime() <= Date.now() ? "expired" : "active"
   const timeline = [
     memory.createdAt ? { at: memory.createdAt, kind: "created", label: "Memory created" } : null,
-    ...mappedEvidence.map((item) => item.capturedAt ? {
-      at: item.capturedAt,
-      kind: item.retiredAt ? "evidence_retired" : "evidence",
-      label: item.retiredAt ? "Evidence retired" : "Evidence captured",
-      sourceRole: item.sourceRole,
-      sourceRecordId: item.sourceRecordId,
-    } : null),
-    ...suppressions.map((item) => ({
-      at: item.createdAt,
-      kind: item.supersededAt ? "suppression_superseded" : "suppression",
-      label: item.supersededAt ? "Suppression superseded" : "Suppression recorded",
-      actor: item.actor,
-      reason: item.reason,
-    })),
+    ...mappedEvidence.flatMap((item) => [
+      item.capturedAt ? {
+        at: item.capturedAt,
+        kind: "evidence",
+        label: "Evidence captured",
+        sourceRole: item.sourceRole,
+        sourceRecordId: item.sourceRecordId,
+      } : null,
+      item.retiredAt ? {
+        at: item.retiredAt,
+        kind: "evidence_retired",
+        label: "Evidence retired",
+        sourceRole: item.sourceRole,
+        sourceRecordId: item.sourceRecordId,
+      } : null,
+      item.linkRetiredAt ? {
+        at: item.linkRetiredAt,
+        kind: "evidence_link_retired",
+        label: "Evidence link retired",
+        sourceRole: item.sourceRole,
+        sourceRecordId: item.sourceRecordId,
+      } : null,
+    ]),
+    ...suppressions.flatMap((item) => [
+      item.createdAt ? {
+        at: item.createdAt,
+        kind: "suppression",
+        label: "Suppression recorded",
+        actor: item.actor,
+        reason: item.reason,
+      } : null,
+      item.supersededAt ? {
+        at: item.supersededAt,
+        kind: "suppression_superseded",
+        label: "Suppression superseded",
+        actor: item.actor,
+        reason: item.reason,
+      } : null,
+    ]),
     correction ? {
       at: memory.updatedAt ?? memory.createdAt,
       kind: "correction",

--- a/browser/server.mjs
+++ b/browser/server.mjs
@@ -4,7 +4,7 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { buildMaintenancePlan } from "../lib/maintenance/maintenance-scheduler.mjs"
-import { embeddingProviderIdentity, validatedCachedEmbeddingVector } from "../lib/memory/semantic-search.mjs"
+import { embeddingProviderIdentity, semanticSearchEnabled, validatedCachedEmbeddingVector } from "../lib/memory/semantic-search.mjs"
 import { clampInteger } from "../lib/utils/numeric-utils.mjs"
 import { parseJsonArray } from "../lib/utils/json-array-utils.mjs"
 import { parseJsonObject } from "../lib/utils/json-object-utils.mjs"
@@ -12,6 +12,7 @@ import { normalizeRepository } from "../lib/utils/repository-utils.mjs"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const STATIC_ROOT = __dirname
+const LORE_CLI_PATH = path.resolve(__dirname, "..", "lore-cli.mjs")
 
 const MEMORY_ROW_SELECT = `
   SELECT
@@ -295,7 +296,7 @@ function buildResumeCommand({ client, sessionId, sourceCwd, sourcePath }) {
     ? String(sessionId).slice(String(client).length + 1)
     : sessionId
   const input = JSON.stringify({ cwd: sourceCwd, transcriptPath: sourcePath })
-  return `printf '%s\\n' ${quoteShell(input)} | node lore-cli.mjs capture --resume --client ${quoteShell(client)} --session ${quoteShell(nativeSessionId)}`
+  return `printf '%s\\n' ${quoteShell(input)} | node ${quoteShell(LORE_CLI_PATH)} capture --resume --client ${quoteShell(client)} --session ${quoteShell(nativeSessionId)}`
 }
 
 function mapCaptureHealthRow(row) {
@@ -365,7 +366,7 @@ function getTraceFallbackDiagnostics(traces) {
 function queryIndexingCoverage({ db, repository, traces }) {
   const inference = db?.config?.localInference ?? db?.config ?? {}
   const embeddingConfig = inference?.embeddings ?? {}
-  const embeddingsEnabled = inference?.enabled === true && embeddingConfig.enabled === true
+  const embeddingsEnabled = semanticSearchEnabled(inference)
   if (typeof db?.countSemanticMemoriesForEmbedding !== "function"
     || typeof db?.listSemanticMemoriesForEmbedding !== "function") {
     return {

--- a/browser/server.mjs
+++ b/browser/server.mjs
@@ -277,6 +277,204 @@ function getMemoryById(db, id) {
   return row ? mapMemoryRow(row) : null
 }
 
+function tableExists(db, table) {
+  const statement = db?.prepare?.("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?")
+  return Boolean(statement?.get?.(table))
+}
+
+function quoteShell(value) {
+  return `'${String(value ?? "").replaceAll("'", "'\"'\"'")}'`
+}
+
+function buildResumeCommand({ client, sessionId, sourceCwd, sourcePath }) {
+  if (!client || !sessionId || !sourceCwd || !sourcePath) {
+    return null
+  }
+  const nativeSessionId = String(sessionId).startsWith(`${client}:`)
+    ? String(sessionId).slice(String(client).length + 1)
+    : sessionId
+  const input = JSON.stringify({ cwd: sourceCwd, transcriptPath: sourcePath })
+  return `printf '%s\\n' ${quoteShell(input)} | node lore-cli.mjs capture --resume --client ${quoteShell(client)} --session ${quoteShell(nativeSessionId)}`
+}
+
+function mapCaptureHealthRow(row) {
+  const adapterState = row?.adapterState && typeof row.adapterState === "object" ? row.adapterState : {}
+  const sourcePath = typeof adapterState.sourcePath === "string" ? adapterState.sourcePath : null
+  const sourceCwd = typeof adapterState.sourceCwd === "string" ? adapterState.sourceCwd : null
+  return {
+    client: row?.client ?? null,
+    sessionId: row?.sessionId ?? null,
+    repository: row?.repository ?? null,
+    offset: Number.isFinite(row?.offset) ? row.offset : 0,
+    pendingBytes: Number.isFinite(row?.health?.pendingBytes) ? row.health.pendingBytes : 0,
+    failureCode: row?.health?.failureCode ?? null,
+    lastSuccessAt: row?.health?.lastSuccessAt ?? null,
+    updatedAt: row?.updatedAt ?? null,
+    sourcePath,
+    sourceCwd,
+    resumeCommand: buildResumeCommand({
+      client: row?.client,
+      sessionId: row?.sessionId,
+      sourceCwd,
+      sourcePath,
+    }),
+  }
+}
+
+function listCaptureHealth({ db, repository }) {
+  if (typeof db?.listCaptureHealth !== "function") {
+    return []
+  }
+  return db.listCaptureHealth({ repository }).map(mapCaptureHealthRow)
+}
+
+function getTraceFallbackDiagnostics(traces) {
+  const diagnostics = []
+  for (const trace of traces) {
+    const source = trace && typeof trace === "object" ? trace : {}
+    const text = JSON.stringify(source)
+    if (/"fallback"\\s*:\\s*true/i.test(text)) {
+      diagnostics.push({ reason: "deterministic_fallback", at: source.createdAt ?? source.created_at ?? null })
+    }
+    if (/"partialCoverage"\\s*:\\s*true/i.test(text)) {
+      diagnostics.push({ reason: "partial_embedding_coverage", at: source.createdAt ?? source.created_at ?? null })
+    }
+    if (/"deadline"\\s*:\\s*true/i.test(text)) {
+      diagnostics.push({ reason: "embedding_deadline", at: source.createdAt ?? source.created_at ?? null })
+    }
+  }
+  const counts = new Map()
+  for (const item of diagnostics) counts.set(item.reason, (counts.get(item.reason) ?? 0) + 1)
+  return [...counts.entries()].map(([reason, count]) => ({ reason, count }))
+}
+
+function queryIndexingCoverage({ db, repository, traces }) {
+  const embeddingsEnabled = db?.config?.embeddings?.enabled === true
+    || db?.config?.localInference?.embeddings?.enabled === true
+  if (!db?.db?.prepare) {
+    return {
+      enabled: embeddingsEnabled,
+      totalActive: 0,
+      indexed: 0,
+      pending: 0,
+      coveragePercent: 0,
+      fallbackDiagnostics: getTraceFallbackDiagnostics(traces),
+    }
+  }
+  const active = db.db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM semantic_memory
+    WHERE superseded_by IS NULL
+      AND (? IS NULL OR repository = ? OR (scope = 'global' AND repository IS NULL))
+  `).get(repository, repository)?.count ?? 0
+  const indexed = tableExists(db.db, "memory_embedding")
+    ? db.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM semantic_memory sm
+      JOIN memory_embedding me ON me.memory_id = sm.id
+      WHERE sm.superseded_by IS NULL
+        AND (? IS NULL OR sm.repository = ? OR (sm.scope = 'global' AND sm.repository IS NULL))
+        AND me.vector IS NOT NULL AND me.vector != ''
+    `).get(repository, repository)?.count ?? 0
+    : 0
+  const totalActive = Number(active) || 0
+  const indexedCount = Math.min(totalActive, Number(indexed) || 0)
+  return {
+    enabled: embeddingsEnabled,
+    totalActive,
+    indexed: indexedCount,
+    pending: Math.max(0, totalActive - indexedCount),
+    coveragePercent: totalActive > 0 ? Math.round((indexedCount / totalActive) * 100) : 100,
+    fallbackDiagnostics: getTraceFallbackDiagnostics(traces),
+  }
+}
+
+function buildMemoryLifecycle({ db, memory }) {
+  const evidence = typeof db?.listSemanticEvidence === "function" ? db.listSemanticEvidence(memory.id) : []
+  const mappedEvidence = evidence.map((item) => {
+    const metadata = item.metadata && typeof item.metadata === "object" ? item.metadata : {}
+    const attribution = metadata.sourceAttribution && typeof metadata.sourceAttribution === "object"
+      ? metadata.sourceAttribution
+      : {}
+    return {
+      key: item.key,
+      sessionId: item.sessionId,
+      repository: item.repository,
+      sourceIdentity: item.sourceIdentity,
+      sourceRecordId: item.sourceRecordId ?? attribution.sourceRecordId ?? attribution.recordId ?? null,
+      sourceRole: metadata.sourceRole ?? attribution.sourceRole ?? attribution.role ?? memory.metadata?.sourceRole ?? null,
+      sourceKind: item.sourceKind,
+      confidenceBasis: metadata.confidenceBasis ?? memory.metadata?.confidenceBasis ?? null,
+      revision: item.revision,
+      contentHash: item.contentHash,
+      capturedAt: item.capturedAt,
+      retiredAt: item.retiredAt,
+      linkedAt: item.linkedAt,
+      linkRetiredAt: item.linkRetiredAt,
+    }
+  })
+  const suppressions = tableExists(db?.db, "memory_suppression")
+    ? db.db.prepare(`
+      SELECT suppression_key, actor, reason, created_at, superseded_at, repair_candidate
+      FROM memory_suppression WHERE memory_id = ? ORDER BY created_at ASC
+    `).all(memory.id).map((row) => ({
+      key: row.suppression_key,
+      actor: row.actor,
+      reason: row.reason,
+      createdAt: row.created_at,
+      supersededAt: row.superseded_at,
+      repairCandidate: Boolean(row.repair_candidate),
+    }))
+    : []
+  const activeSuppressions = suppressions.filter((item) => !item.supersededAt)
+  const correction = memory.metadata?.correctionProvenance && typeof memory.metadata.correctionProvenance === "object"
+    ? memory.metadata.correctionProvenance
+    : null
+  const expiresAt = memory.expiresAt ?? null
+  const expiryState = expiresAt === null
+    ? "none"
+    : Number.isNaN(new Date(expiresAt).getTime())
+      ? "invalid"
+      : new Date(expiresAt).getTime() <= Date.now() ? "expired" : "active"
+  const timeline = [
+    memory.createdAt ? { at: memory.createdAt, kind: "created", label: "Memory created" } : null,
+    ...mappedEvidence.map((item) => item.capturedAt ? {
+      at: item.capturedAt,
+      kind: item.retiredAt ? "evidence_retired" : "evidence",
+      label: item.retiredAt ? "Evidence retired" : "Evidence captured",
+      sourceRole: item.sourceRole,
+      sourceRecordId: item.sourceRecordId,
+    } : null),
+    ...suppressions.map((item) => ({
+      at: item.createdAt,
+      kind: item.supersededAt ? "suppression_superseded" : "suppression",
+      label: item.supersededAt ? "Suppression superseded" : "Suppression recorded",
+      actor: item.actor,
+      reason: item.reason,
+    })),
+    correction ? {
+      at: memory.updatedAt ?? memory.createdAt,
+      kind: "correction",
+      label: "Correction recorded",
+      sourceMemoryId: correction.sourceMemoryId ?? null,
+    } : null,
+    expiresAt && expiryState !== "invalid" ? { at: expiresAt, kind: "expiry", label: "Expiry boundary" } : null,
+    memory.updatedAt && memory.updatedAt !== memory.createdAt ? { at: memory.updatedAt, kind: "updated", label: "Memory updated" } : null,
+  ].filter(Boolean).sort((a, b) => String(a.at).localeCompare(String(b.at)))
+  return {
+    evidence: mappedEvidence,
+    suppressions,
+    state: {
+      memory: memory.supersededBy ? "superseded" : "active",
+      suppression: activeSuppressions.length > 0 ? "suppressed" : "none",
+      expiry: expiryState,
+      correction: correction ? "corrected" : "none",
+      activeSuppressionCount: activeSuppressions.length,
+    },
+    timeline,
+  }
+}
+
 function getEpisodeBySessionId(db, sessionId) {
   const row = db.db.prepare(`${EPISODE_ROW_SELECT} WHERE session_id = ?`).get(sessionId)
   return row ? mapEpisodeRow(row) : null
@@ -750,6 +948,7 @@ function buildMemoryDrilldown({ db, id, entityType }) {
   const focus = buildMemoryFocus(memory, entityType)
   const provenance = buildMemoryProvenance({ db, memory })
   const relations = buildMemoryRelations({ db, memory })
+  const lifecycle = buildMemoryLifecycle({ db, memory })
   const centerNode = buildMemoryNode(memory, {
     column: "center",
     entityType,
@@ -773,6 +972,7 @@ function buildMemoryDrilldown({ db, id, entityType }) {
     },
     canonicalCluster: relations.canonicalCluster,
     linkedImprovements: relations.linkedImprovements,
+    lifecycle,
     graph: graph.toJSON(),
   }
 }
@@ -917,6 +1117,9 @@ function queryOverview({ db, repository, traceLimit = 40, maintenanceLimit = 10 
 
   const maintenancePlan = getStatusMaintenancePlan({ db, repository })
 
+  const captureHealth = listCaptureHealth({ db, repository })
+  const indexing = queryIndexingCoverage({ db, repository, traces })
+
   const recentRuns = db.listMaintenanceRuns({
     limit: clampInteger(maintenanceLimit, 10, { min: 1, max: 50 }),
   })
@@ -933,6 +1136,8 @@ function queryOverview({ db, repository, traceLimit = 40, maintenanceLimit = 10 
     },
     latencyTrend: computeLatencyTrend(traces),
     recentTraceSamples: traces.slice(0, 10),
+    captureHealth,
+    indexing,
   }
 }
 

--- a/browser/server.mjs
+++ b/browser/server.mjs
@@ -346,14 +346,14 @@ function getTraceFallbackDiagnostics(traces) {
   const diagnostics = []
   for (const trace of traces) {
     const source = trace && typeof trace === "object" ? trace : {}
-    const text = JSON.stringify(source)
-    if (/"fallback"\s*:\s*true/i.test(text)) {
+    const flags = source.trace && typeof source.trace === "object" ? source.trace : {}
+    if (flags.fallback === true) {
       diagnostics.push({ reason: "deterministic_fallback", at: source.createdAt ?? source.created_at ?? null })
     }
-    if (/"partialCoverage"\s*:\s*true/i.test(text)) {
+    if (flags.partialCoverage === true) {
       diagnostics.push({ reason: "partial_embedding_coverage", at: source.createdAt ?? source.created_at ?? null })
     }
-    if (/"deadline"\s*:\s*true/i.test(text)) {
+    if (flags.deadline === true) {
       diagnostics.push({ reason: "embedding_deadline", at: source.createdAt ?? source.created_at ?? null })
     }
   }

--- a/browser/styles.css
+++ b/browser/styles.css
@@ -265,6 +265,43 @@ main {
   margin: 0;
 }
 
+.health-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  margin-top: 1rem;
+}
+
+.health-section {
+  min-width: 0;
+}
+
+.health-section .table-wrap {
+  margin-top: 0.65rem;
+}
+
+.health-section .summary-grid {
+  margin-top: 0.8rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.health-section .metric-card {
+  min-height: 4.8rem;
+  padding: 0.6rem;
+}
+
+.health-section .metric {
+  font-size: 1.1rem;
+}
+
+.coverage-note {
+  margin: 0.75rem 0;
+}
+
+.coverage-diagnostics {
+  margin-top: 0.8rem;
+}
+
 .detail-grid {
   display: grid;
   gap: 1rem;
@@ -295,6 +332,64 @@ main {
   gap: 0.2rem;
   border-bottom: 1px solid var(--border);
   padding-bottom: 0.45rem;
+}
+
+.lifecycle-section h3 {
+  margin: 0.85rem 0 0.45rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.lifecycle-section {
+  grid-column: 1 / -1;
+}
+
+.lifecycle-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.provenance-item {
+  overflow-wrap: anywhere;
+}
+
+.timeline {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0 0 0 1.35rem;
+}
+
+.timeline li {
+  padding-left: 0.2rem;
+}
+
+.timeline li strong {
+  display: inline-block;
+  margin-right: 0.6rem;
+}
+
+.copy-feedback {
+  min-height: 1.1rem;
+  margin-top: 0.25rem;
+}
+
+.admin-command-item {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.command-preview {
+  display: block;
+  color: var(--text);
+  font: 0.78rem/1.45 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.administration-section {
+  grid-column: 1 / -1;
 }
 
 .graph-shell {
@@ -416,6 +511,37 @@ main {
 
   .detail-grid {
     grid-template-columns: 1fr;
+  }
+
+  .health-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .header-pills {
+    justify-content: flex-start;
+  }
+
+  main {
+    padding-inline: 0.75rem;
+  }
+
+  .tabs {
+    padding-inline: 0.75rem;
+  }
+
+  .health-section .summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .table {
+    min-width: 34rem;
   }
 }
 

--- a/browser/styles.css
+++ b/browser/styles.css
@@ -253,6 +253,16 @@ main {
   gap: 1rem;
 }
 
+.drilldown-shell > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.drilldown-header p,
+.drilldown-header .small {
+  overflow-wrap: anywhere;
+}
+
 .drilldown-header h2 {
   margin: 0;
 }
@@ -308,6 +318,14 @@ main {
   grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
+.detail-grid > * {
+  min-width: 0;
+}
+
+.item-header-row > * {
+  min-width: 0;
+}
+
 .section-card h2 {
   margin: 0;
   font-size: 0.98rem;
@@ -322,6 +340,11 @@ main {
   margin-bottom: 0.15rem;
 }
 
+.relation-item {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
 .kv-list {
   display: grid;
   gap: 0.55rem;
@@ -332,6 +355,11 @@ main {
   gap: 0.2rem;
   border-bottom: 1px solid var(--border);
   padding-bottom: 0.45rem;
+}
+
+.kv-row > * {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .lifecycle-section h3 {
@@ -467,7 +495,11 @@ main {
 
 .graph-lines {
   position: absolute;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: auto;
+  bottom: auto;
+  max-width: 100%;
   pointer-events: none;
 }
 
@@ -538,6 +570,19 @@ main {
 
   .health-section .summary-grid {
     grid-template-columns: 1fr;
+  }
+
+  .summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .section-head {
+    flex-wrap: wrap;
+  }
+
+  .lifecycle-section .tag {
+    white-space: normal;
+    text-align: right;
   }
 
   .table {

--- a/docs/cli-integrations.md
+++ b/docs/cli-integrations.md
@@ -117,7 +117,8 @@ preferences use `lore_retain` with `scope: "global"`.
 
 The CLI also exposes the reliability administration commands
 `memory_correct`, `memory_repair`, and `memory_purge`. They default to a
-read-only preview and accept JSON on stdin:
+read-only preview and accept JSON on stdin. Preview first; applying requires
+the exact returned `planFingerprint` and any selected candidate IDs:
 
 ```sh
 printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node /absolute/lore/lore-cli.mjs tool memory_correct
@@ -125,9 +126,36 @@ printf '%s\n' '{"sessionIds":["<session-id>"]}' | node /absolute/lore/lore-cli.m
 printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/lore/lore-cli.mjs tool memory_purge
 ```
 
-Review the preview fingerprint and retained source or backup consequences before
-an explicit apply. Purge is a derived-record cleanup operation and is not
-secure erasure.
+For a reviewed correction, pass `action: "apply"`, the same selector and
+payload, and the preview fingerprint:
+
+```sh
+printf '%s\n' '{"action":"apply","memoryId":"<id>","content":"<replacement>","reason":"<why>","planFingerprint":"<preview-fingerprint>"}' | node /absolute/lore/lore-cli.mjs tool memory_correct
+```
+
+Repair applies only explicitly selected actionable source-re-extraction or
+repository-mapping candidates from its preview. Source-backed repair scans at
+most 32 MiB and 10,000 turns; unavailable or oversized legacy sources remain
+unresolved. Purge aggregate candidates use typed IDs such as
+`aggregate:episode_digest:<json-primary-key>`. If the initial preview reports
+residual aggregates, run a new preview with `includeDependentAggregates: true`,
+then use that new fingerprint and select every residual aggregate ID to remove. A correction `repository` sets the replacement
+destination; omit it to preserve the existing repository, or use
+`scope: "global", repository: null` explicitly for a global replacement.
+
+Review the preview fingerprint, retained source or backup consequences, and
+unresolved items before an explicit apply. Purge is a derived-record cleanup
+operation and is not secure erasure.
+
+Native capture resume is a separate bounded command. The dashboard only copies
+it; running it performs capture and may write evidence. Each pass reads at most
+4 MiB with a 250 ms cooperative read budget, keeps at most a 1 MiB incomplete record, and reports skipped
+oversized records through categorical health. Its stdin is
+`{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}`:
+
+```sh
+printf '%s\n' '{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}' | node /absolute/lore/lore-cli.mjs capture --resume --client codex --session '<native-session-id>'
+```
 
 ## Compatibility and boundaries
 
@@ -153,9 +181,11 @@ inferred from arbitrary shell output. Automatic recall uses deterministic
 retrieval; explicit `lore_recall` retains the shared tool's optional local query
 expansion and embedding behavior.
 
-Transcript snapshots are capped at 32 MiB and hook input at 1 MiB. Oversized or
-malformed input produces a diagnostic and is not imported. An incomplete final
-JSONL record is deferred until a later capture. Hosts that disable transcript
+Hook-provided transcript snapshots are capped at 32 MiB and hook input at 1
+MiB. Oversized or malformed hook input produces a diagnostic and is not
+imported. The separate native `capture --resume` command handles larger
+transcripts incrementally within its per-pass bounds. An incomplete final JSONL
+record is deferred until a later capture. Hosts that disable transcript
 persistence cannot provide automatic extraction. Hook timeouts are 10 seconds,
 except Codex `SessionEnd` at its 3-second maximum; `Stop` provides the normal
 capture point before shutdown. Hook metrics, automatic maintenance, raw archive

--- a/docs/cli-integrations.md
+++ b/docs/cli-integrations.md
@@ -108,11 +108,26 @@ printf '%s\n' '{}' | node /absolute/lore/lore-cli.mjs tool memory_status
 ```
 
 Available operations are `lore_recall`, `lore_retain`, `lore_onboard`,
-`memory_search`, `memory_save`, `memory_forget`, and `memory_status`, declared in
+`memory_search`, `memory_save`, `memory_forget`, `memory_status`,
+`memory_correct`, `memory_repair`, and `memory_purge`, declared in
 the capability manifest. These are shell-invoked commands, not registered model
 tools. They return a nonzero exit status for failures. Supply an explicit
 `repository` if invoking from a directory other than your project. For global
 preferences use `lore_retain` with `scope: "global"`.
+
+The CLI also exposes the reliability administration commands
+`memory_correct`, `memory_repair`, and `memory_purge`. They default to a
+read-only preview and accept JSON on stdin:
+
+```sh
+printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node /absolute/lore/lore-cli.mjs tool memory_correct
+printf '%s\n' '{"sessionIds":["<session-id>"]}' | node /absolute/lore/lore-cli.mjs tool memory_repair
+printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/lore/lore-cli.mjs tool memory_purge
+```
+
+Review the preview fingerprint and retained source or backup consequences before
+an explicit apply. Purge is a derived-record cleanup operation and is not
+secure erasure.
 
 ## Compatibility and boundaries
 

--- a/docs/cli-integrations.md
+++ b/docs/cli-integrations.md
@@ -181,11 +181,11 @@ inferred from arbitrary shell output. Automatic recall uses deterministic
 retrieval; explicit `lore_recall` retains the shared tool's optional local query
 expansion and embedding behavior.
 
-Hook-provided transcript snapshots are capped at 32 MiB and hook input at 1
-MiB. Oversized or malformed hook input produces a diagnostic and is not
-imported. The separate native `capture --resume` command handles larger
-transcripts incrementally within its per-pass bounds. An incomplete final JSONL
-record is deferred until a later capture. Hosts that disable transcript
+Hook input is capped at 1 MiB. Malformed or oversized hook input produces a
+diagnostic and is not imported. Capture hooks and `capture --resume` both read
+transcripts incrementally, including files larger than 32 MiB, within the
+per-pass bounds above. An incomplete final JSONL record is deferred until a
+later capture. Hosts that disable transcript
 persistence cannot provide automatic extraction. Hook timeouts are 10 seconds,
 except Codex `SessionEnd` at its 3-second maximum; `Stop` provides the normal
 capture point before shutdown. Hook metrics, automatic maintenance, raw archive

--- a/docs/cli-integrations.md
+++ b/docs/cli-integrations.md
@@ -122,7 +122,7 @@ the exact returned `planFingerprint` and any selected candidate IDs:
 
 ```sh
 printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node /absolute/lore/lore-cli.mjs tool memory_correct
-printf '%s\n' '{"sessionIds":["<session-id>"]}' | node /absolute/lore/lore-cli.mjs tool memory_repair
+printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/lore/lore-cli.mjs tool memory_repair
 printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/lore/lore-cli.mjs tool memory_purge
 ```
 

--- a/tests/unit/browser-reliability-dashboard.test.mjs
+++ b/tests/unit/browser-reliability-dashboard.test.mjs
@@ -214,7 +214,7 @@ describe("reliability dashboard renderers", () => {
     db.ensureMemoryEmbeddingTable();
     db.db.prepare(`INSERT OR REPLACE INTO memory_embedding (memory_id, content_hash, provider, model, dimensions, vector, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`)
       .run(activeId, embeddingContentHash("Use the active fixture memory."), "http://127.0.0.1:12434/v1", "fixture-model", 2, "[1,0]", "2026-09-07T08:00:00.000Z");
-    db.writeRetrievalTraceSample({
+    db.insertRetrievalTraceSample({
       id: "trace-coverage",
       repository: "owner/repo",
       scopeType: "repo",
@@ -225,12 +225,12 @@ describe("reliability dashboard renderers", () => {
       latencyMs: 1,
       promptPreview: "fixture",
       sectionTitles: [],
-      promptNeed: JSON.stringify({}),
-      eligibility: JSON.stringify({}),
-      lookups: JSON.stringify({}),
-      omissions: JSON.stringify([]),
-      output: JSON.stringify({}),
-      trace: JSON.stringify({ fallback: true, partialCoverage: true, deadline: true }),
+      promptNeed: {},
+      eligibility: {},
+      lookups: {},
+      omissions: [],
+      output: {},
+      trace: { fallback: true, partialCoverage: true, deadline: true },
       recordedAt: "2026-09-07T08:00:00.000Z",
     });
     const { server } = startLoreBrowserServer({ db, host: "127.0.0.1", port: 0, repository: "owner/repo" });

--- a/tests/unit/browser-reliability-dashboard.test.mjs
+++ b/tests/unit/browser-reliability-dashboard.test.mjs
@@ -136,6 +136,7 @@ describe("reliability dashboard renderers", () => {
     assert.match(html, /memory_correct/);
     assert.match(html, /memory_repair/);
     assert.match(html, /memory_purge/);
+    assert.match(html, /\/absolute\/path\/to\/lore\/lore-cli\.mjs/);
     assert.match(html, /preview only/);
   });
 
@@ -212,6 +213,11 @@ describe("reliability dashboard renderers", () => {
     });
     db.db.prepare("UPDATE semantic_memory SET expires_at = ? WHERE id = ?").run("2020-01-01T00:00:00.000Z", expiredId);
     db.ensureMemoryEmbeddingTable();
+    db.saveIngestionCheckpoint("codex", "session-1", {
+      repository: "owner/repo",
+      adapterState: { sourcePath: "/tmp/transcript.jsonl", sourceCwd: "/tmp/project" },
+      health: { pendingBytes: 128 },
+    });
     db.db.prepare(`INSERT OR REPLACE INTO memory_embedding (memory_id, content_hash, provider, model, dimensions, vector, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`)
       .run(activeId, embeddingContentHash("Use the active fixture memory."), "http://127.0.0.1:12434/v1", "fixture-model", 2, "[1,0]", "2026-09-07T08:00:00.000Z");
     db.insertRetrievalTraceSample({
@@ -255,11 +261,34 @@ describe("reliability dashboard renderers", () => {
       assert.equal(payload.data.indexing.indexed, 1);
       assert.equal(payload.data.indexing.pending, 0);
       assert.equal(payload.data.indexing.dimensionsBasis, "stored vector dimensions");
+      assert.equal(payload.data.captureHealth[0].resumeEligible, true);
+      assert.match(payload.data.captureHealth[0].resumeCommand, /node ['"]?[^ ]*lore-cli\.mjs['"]? capture --resume/);
       assert.deepEqual(payload.data.indexing.fallbackDiagnostics, [
         { reason: "deterministic_fallback", count: 1 },
         { reason: "partial_embedding_coverage", count: 1 },
         { reason: "embedding_deadline", count: 1 },
       ]);
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      db.close();
+    }
+  });
+
+  test("overview disables embedding coverage when the model is missing", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "lore-browser-invalid-embedding-fixture-"));
+    const config = buildFixtureConfig(home, {
+      enabled: true,
+      localInference: { enabled: true, embeddings: { enabled: true, model: "   " } },
+    });
+    const db = new LoreDb(config);
+    db.initialize();
+    const { server } = startLoreBrowserServer({ db, host: "127.0.0.1", port: 0, repository: "owner/repo" });
+    await new Promise((resolve) => server.once("listening", resolve));
+    try {
+      const responseValue = await fetch(`http://127.0.0.1:${server.address().port}/api/overview`);
+      const payload = await responseValue.json();
+      assert.equal(responseValue.status, 200);
+      assert.equal(payload.data.indexing.enabled, false);
     } finally {
       await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
       db.close();

--- a/tests/unit/browser-reliability-dashboard.test.mjs
+++ b/tests/unit/browser-reliability-dashboard.test.mjs
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, test } from "node:test";
+
+import { startLoreBrowserServer } from "../../browser/server.mjs";
+import { LoreDb } from "../../lib/db/db.mjs";
+import { createAppRunner, createBrowserTestEnvironment } from "../helpers/browser-dom.mjs";
+import { enabledConfig } from "../helpers/fixture-config.mjs";
+
+const runApp = createAppRunner();
+
+function response(payload) {
+  return {
+    ok: true,
+    async json() {
+      return payload;
+    },
+  };
+}
+
+async function fixtureFetch(path) {
+  const data = {
+    "/api/health": { repository: "owner/repo" },
+    "/api/overview": {
+      data: {
+        stats: { semanticCount: 1 },
+        captureHealth: [{
+          client: "codex",
+          sessionId: "codex:session-1",
+          repository: "owner/repo",
+          lastSuccessAt: "2026-09-07T08:00:00.000Z",
+          pendingBytes: 128,
+          offset: 1024,
+          resumeCommand: "printf '%s\\n' '{\"cwd\":\"/tmp/project\"}' | node lore-cli.mjs capture --resume --client 'codex' --session 'session-1'",
+        }],
+        indexing: {
+          enabled: true,
+          totalActive: 4,
+          indexed: 3,
+          pending: 1,
+          coveragePercent: 75,
+          fallbackDiagnostics: [{ reason: "partial_embedding_coverage", count: 2 }],
+        },
+      },
+    },
+    "/api/maintenance": { data: {} },
+    "/api/episodes": { data: {} },
+    "/api/memories/filters": { data: {} },
+  };
+  if (data[path]) return response(data[path]);
+  if (path.startsWith("/api/memories?")) {
+    return response({ data: { rows: [] } });
+  }
+  if (path === "/api/drilldown?entity=memory&id=memory-1") {
+    return response({
+      data: {
+        entityType: "memory",
+        focus: {
+          id: "memory-1",
+          entityType: "memory",
+          title: "Use SQLite",
+          content: "Use SQLite for this project.",
+          type: "directive",
+          repository: "owner/repo",
+          scope: "repo",
+          status: "active",
+          reinforcementCount: 1,
+          metadata: {},
+          createdAt: "2026-09-07T07:00:00.000Z",
+          updatedAt: "2026-09-07T07:30:00.000Z",
+        },
+        provenance: {},
+        lineage: {},
+        lifecycle: {
+          state: { memory: "active", suppression: "none", expiry: "none" },
+          evidence: [{
+            sourceKind: "preference",
+            sourceRole: "user",
+            confidenceBasis: "explicit_preference_sentence",
+            sourceRecordId: "turn-4",
+            sessionId: "codex:session-1",
+            revision: "rev-4",
+            capturedAt: "2026-09-07T07:01:00.000Z",
+          }],
+          suppressions: [],
+          timeline: [{ kind: "created", label: "Memory created", at: "2026-09-07T07:00:00.000Z" }],
+        },
+        canonicalCluster: null,
+        linkedImprovements: [],
+        graph: { nodes: [], edges: [] },
+      },
+    });
+  }
+  throw new Error(`Unexpected fixture fetch: ${path}`);
+}
+
+function makeWindow(hash = "") {
+  return {
+    location: { hash, pathname: "/", search: "" },
+    listeners: new Map(),
+    addEventListener(type, handler) {
+      this.listeners.set(type, handler);
+    },
+    requestAnimationFrame(callback) {
+      callback();
+      return 1;
+    },
+    setTimeout,
+  };
+}
+
+describe("reliability dashboard renderers", () => {
+  test("overview exposes capture resume and embedding coverage diagnostics", async () => {
+    const { elements, document, history } = createBrowserTestEnvironment();
+    await runApp(document, makeWindow(), fixtureFetch, history);
+    const html = elements.get("view-overview")?.innerHTML ?? "";
+    assert.match(html, /Capture health/);
+    assert.match(html, /Copy preview command/);
+    assert.match(html, /Embedding coverage/);
+    assert.match(html, /partial_embedding_coverage/);
+  });
+
+  test("memory drilldown exposes attributed evidence and lifecycle state", async () => {
+    const { elements, document, history } = createBrowserTestEnvironment();
+    await runApp(document, makeWindow("#drilldown?entity=memory&id=memory-1"), fixtureFetch, history);
+    const html = elements.get("view-drilldown")?.innerHTML ?? "";
+    assert.match(html, /Evidence & lifecycle/);
+    assert.match(html, /role=user/);
+    assert.match(html, /explicit_preference_sentence/);
+    assert.match(html, /source ref=turn-4/);
+    assert.match(html, /Memory created/);
+    assert.match(html, /memory_correct/);
+    assert.match(html, /memory_repair/);
+    assert.match(html, /memory_purge/);
+    assert.match(html, /preview only/);
+  });
+
+  test("server drilldown returns evidence and lifecycle state from an isolated fixture", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "lore-browser-server-fixture-"));
+    const db = new LoreDb(enabledConfig(home));
+    db.initialize();
+    const [memoryId] = db.reconcileGeneratedMemories({
+      sessionId: "codex:fixture",
+      repository: "owner/repo",
+      memories: [{
+        type: "directive",
+        content: "Use the fixture database.",
+        confidence: 0.9,
+        scope: "repo",
+        metadata: {
+          sourceRole: "user",
+          confidenceBasis: "explicit_preference_sentence",
+        },
+        evidence: {
+          key: "fixture:server-evidence",
+          sourceRecordId: "turn-1",
+          sourceKind: "preference",
+        },
+      }],
+    });
+    const { server } = startLoreBrowserServer({ db, host: "127.0.0.1", port: 0, repository: "owner/repo" });
+    await new Promise((resolve) => server.once("listening", resolve));
+    try {
+      const responseValue = await fetch(`http://127.0.0.1:${server.address().port}/api/drilldown?entity=memory&id=${memoryId}`);
+      const payload = await responseValue.json();
+      assert.equal(responseValue.status, 200);
+      assert.equal(payload.mode, "read_only");
+      assert.equal(payload.data.lifecycle.evidence[0].sourceRole, "user");
+      assert.equal(payload.data.lifecycle.evidence[0].sourceRecordId, "turn-1");
+      assert.equal(payload.data.lifecycle.state.correction, "none");
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      db.close();
+    }
+  });
+});

--- a/tests/unit/browser-reliability-dashboard.test.mjs
+++ b/tests/unit/browser-reliability-dashboard.test.mjs
@@ -6,8 +6,9 @@ import { describe, test } from "node:test";
 
 import { startLoreBrowserServer } from "../../browser/server.mjs";
 import { LoreDb } from "../../lib/db/db.mjs";
+import { embeddingContentHash } from "../../lib/memory/semantic-search.mjs";
 import { createAppRunner, createBrowserTestEnvironment } from "../helpers/browser-dom.mjs";
-import { enabledConfig } from "../helpers/fixture-config.mjs";
+import { buildFixtureConfig, enabledConfig } from "../helpers/fixture-config.mjs";
 
 const runApp = createAppRunner();
 
@@ -117,7 +118,8 @@ describe("reliability dashboard renderers", () => {
     await runApp(document, makeWindow(), fixtureFetch, history);
     const html = elements.get("view-overview")?.innerHTML ?? "";
     assert.match(html, /Capture health/);
-    assert.match(html, /Copy preview command/);
+    assert.match(html, /Copy resume command/);
+    assert.match(html, />pending</);
     assert.match(html, /Embedding coverage/);
     assert.match(html, /partial_embedding_coverage/);
   });
@@ -160,6 +162,11 @@ describe("reliability dashboard renderers", () => {
         },
       }],
     });
+    const evidenceKey = db.listSemanticEvidence(memoryId)[0].key;
+    db.db.prepare("UPDATE session_evidence SET retired_at = ? WHERE evidence_key = ?").run("2026-09-07T09:00:00.000Z", evidenceKey);
+    db.db.prepare("UPDATE memory_evidence SET retired_at = ? WHERE memory_id = ? AND evidence_key = ?").run("2026-09-07T09:05:00.000Z", memoryId, evidenceKey);
+    db.db.prepare(`INSERT INTO memory_suppression (suppression_key, memory_id, scope, repository, actor, reason, created_at, superseded_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run("suppression:fixture", memoryId, "repo", "owner/repo", "fixture", "reviewed test suppression", "2026-09-07T08:30:00.000Z", null);
     const { server } = startLoreBrowserServer({ db, host: "127.0.0.1", port: 0, repository: "owner/repo" });
     await new Promise((resolve) => server.once("listening", resolve));
     try {
@@ -169,7 +176,79 @@ describe("reliability dashboard renderers", () => {
       assert.equal(payload.mode, "read_only");
       assert.equal(payload.data.lifecycle.evidence[0].sourceRole, "user");
       assert.equal(payload.data.lifecycle.evidence[0].sourceRecordId, "turn-1");
-      assert.equal(payload.data.lifecycle.state.correction, "none");
+      assert.equal(payload.data.lifecycle.state.suppression, "suppressed");
+      const evidenceTimeline = payload.data.lifecycle.timeline.filter((item) => item.kind.includes("evidence"));
+      assert.deepEqual(new Set(evidenceTimeline.map((item) => item.kind)), new Set(["evidence", "evidence_retired", "evidence_link_retired"]));
+      assert.equal(evidenceTimeline.find((item) => item.kind === "evidence_retired").at, "2026-09-07T09:00:00.000Z");
+      assert.equal(evidenceTimeline.find((item) => item.kind === "evidence_link_retired").at, "2026-09-07T09:05:00.000Z");
+      assert.deepEqual(payload.data.lifecycle.timeline.find((item) => item.kind === "suppression"), {
+        at: "2026-09-07T08:30:00.000Z",
+        kind: "suppression",
+        label: "Suppression recorded",
+        actor: "fixture",
+        reason: "reviewed test suppression",
+      });
+    } finally {
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      db.close();
+    }
+  });
+
+  test("overview reports valid eligible cache coverage and categorical fallback diagnostics", async () => {
+    const home = await mkdtemp(path.join(os.tmpdir(), "lore-browser-coverage-fixture-"));
+    const config = buildFixtureConfig(home, {
+      enabled: true,
+      localInference: { enabled: true, embeddings: { enabled: true, model: "fixture-model" } },
+    });
+    const db = new LoreDb(config);
+    db.initialize();
+    const [activeId, expiredId] = db.reconcileGeneratedMemories({
+      sessionId: "codex:coverage",
+      repository: "owner/repo",
+      memories: [
+        { type: "user_preference", content: "Use the active fixture memory.", scope: "repo", repository: "owner/repo" },
+        { type: "user_preference", content: "Use the expired fixture memory.", scope: "repo", repository: "owner/repo" },
+      ],
+    });
+    db.db.prepare("UPDATE semantic_memory SET expires_at = ? WHERE id = ?").run("2020-01-01T00:00:00.000Z", expiredId);
+    db.ensureMemoryEmbeddingTable();
+    db.db.prepare(`INSERT OR REPLACE INTO memory_embedding (memory_id, content_hash, provider, model, dimensions, vector, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`)
+      .run(activeId, embeddingContentHash("Use the active fixture memory."), "http://127.0.0.1:12434/v1", "fixture-model", 2, "[1,0]", "2026-09-07T08:00:00.000Z");
+    db.writeRetrievalTraceSample({
+      id: "trace-coverage",
+      repository: "owner/repo",
+      scopeType: "repo",
+      hook: "test",
+      route: "lexical",
+      routeReason: "fallback",
+      contextInjected: false,
+      latencyMs: 1,
+      promptPreview: "fixture",
+      sectionTitles: [],
+      promptNeed: JSON.stringify({}),
+      eligibility: JSON.stringify({}),
+      lookups: JSON.stringify({}),
+      omissions: JSON.stringify([]),
+      output: JSON.stringify({}),
+      trace: JSON.stringify({ fallback: true, partialCoverage: true, deadline: true }),
+      recordedAt: "2026-09-07T08:00:00.000Z",
+    });
+    const { server } = startLoreBrowserServer({ db, host: "127.0.0.1", port: 0, repository: "owner/repo" });
+    await new Promise((resolve) => server.once("listening", resolve));
+    try {
+      const responseValue = await fetch(`http://127.0.0.1:${server.address().port}/api/overview`);
+      const payload = await responseValue.json();
+      assert.equal(responseValue.status, 200);
+      assert.equal(payload.data.indexing.totalActive, 1);
+      assert.equal(payload.data.indexing.sampleSize, 1);
+      assert.equal(payload.data.indexing.indexed, 1);
+      assert.equal(payload.data.indexing.pending, 0);
+      assert.equal(payload.data.indexing.dimensionsBasis, "stored vector dimensions");
+      assert.deepEqual(payload.data.indexing.fallbackDiagnostics, [
+        { reason: "deterministic_fallback", count: 1 },
+        { reason: "partial_embedding_coverage", count: 1 },
+        { reason: "embedding_deadline", count: 1 },
+      ]);
     } finally {
       await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
       db.close();

--- a/tests/unit/browser-reliability-dashboard.test.mjs
+++ b/tests/unit/browser-reliability-dashboard.test.mjs
@@ -233,6 +233,17 @@ describe("reliability dashboard renderers", () => {
       trace: { fallback: true, partialCoverage: true, deadline: true },
       recordedAt: "2026-09-07T08:00:00.000Z",
     });
+    db.insertRetrievalTraceSample({
+      id: "trace-prompt-lookalike",
+      repository: "owner/repo",
+      scopeType: "repo",
+      hook: "test",
+      route: "lexical",
+      routeReason: "primary",
+      promptPreview: 'The prompt contains "fallback": true, "partialCoverage": true, and "deadline": true.',
+      trace: {},
+      recordedAt: "2026-09-07T08:01:00.000Z",
+    });
     const { server } = startLoreBrowserServer({ db, host: "127.0.0.1", port: 0, repository: "owner/repo" });
     await new Promise((resolve) => server.once("listening", resolve));
     try {

--- a/tests/unit/rule-browserserver-hotspots.test.mjs
+++ b/tests/unit/rule-browserserver-hotspots.test.mjs
@@ -20,11 +20,7 @@ async function loadBrowserServerHotspots() {
     const serverPath = path.join(REPO_ROOT, "browser", "server.mjs");
     const serverUrl = pathToFileURL(serverPath).href;
     const source = readFileSync(serverPath, "utf8")
-      .replace(/from "\.\.\/lib\/maintenance\/maintenance-scheduler\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "maintenance", "maintenance-scheduler.mjs")).href}"`)
-      .replace(/from "\.\.\/lib\/utils\/numeric-utils\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "utils", "numeric-utils.mjs")).href}"`)
-      .replace(/from "\.\.\/lib\/utils\/json-array-utils\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "utils", "json-array-utils.mjs")).href}"`)
-      .replace(/from "\.\.\/lib\/utils\/json-object-utils\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "utils", "json-object-utils.mjs")).href}"`)
-      .replace(/from "\.\.\/lib\/utils\/repository-utils\.mjs"/g, `from "${pathToFileURL(path.join(REPO_ROOT, "lib", "utils", "repository-utils.mjs")).href}"`)
+      .replace(/from "(\.\.?\/[^"]+)"/g, (_match, specifier) => `from "${new URL(specifier, serverUrl).href}"`)
       .replace('const __dirname = path.dirname(fileURLToPath(import.meta.url))', `const __dirname = ${JSON.stringify(path.join(REPO_ROOT, "browser"))}`)
       .replace("function buildMemoryDrilldown({ db, id, entityType }) {", "export function buildMemoryDrilldown({ db, id, entityType }) {");
     browserServerHotspotsPromise = import(`data:text/javascript;base64,${Buffer.from(`${source}\n//# sourceURL=${serverUrl}\n`).toString("base64")}`);

--- a/website/src/content/docs/cli-integrations.md
+++ b/website/src/content/docs/cli-integrations.md
@@ -100,7 +100,7 @@ printf '%s\n' '{"prompt":"What is the Lore verification note?"}' | node /absolut
 
 Then start a fresh client session in that project and ask about the verification note. Relevant context should arrive automatically through the prompt hook. Complete a short conversation, then check `memory_status` again to verify session capture. Use synthetic, non-sensitive content for this check.
 
-Explicit operations are **shell-invoked commands**, not registered model tools. Injected context explains how the agent can invoke them through its normal shell permissions. Available names are `lore_recall`, `lore_retain`, `lore_onboard`, `memory_search`, `memory_save`, `memory_forget`, and `memory_status`. Commands accept JSON on stdin and return a nonzero exit status on failure. See [Tools](/guides/tools/#native-cli-commands).
+Explicit operations are **shell-invoked commands**, not registered model tools. Injected context explains how the agent can invoke them through its normal shell permissions. Available names are `lore_recall`, `lore_retain`, `lore_onboard`, `memory_search`, `memory_save`, `memory_forget`, `memory_status`, `memory_correct`, `memory_repair`, and `memory_purge`. Commands accept JSON on stdin and return a nonzero exit status on failure. See [Tools](/guides/tools/#native-cli-commands).
 
 ## What happens during a session
 

--- a/website/src/content/docs/cli-integrations.md
+++ b/website/src/content/docs/cli-integrations.md
@@ -135,10 +135,10 @@ For direct commands run outside your project, pass an explicit `repository` argu
 
 Only the supplied active-session transcript is read; these adapters do not scan archives or import unrelated sessions. Thinking, reasoning, tool output, injected Lore context, and Antigravity prompt metadata are excluded from extraction. Hosts that disable transcript persistence cannot provide automatic capture.
 
-Hook input is limited to 1 MiB and hook-provided transcript snapshots to 32
-MiB. Malformed or oversized hook input is not imported; the separate native
-`capture --resume` command handles larger transcripts incrementally within its
-per-pass bounds. An unfinished final JSONL record is deferred. Hooks have a
+Hook input is limited to 1 MiB; malformed or oversized hook input is not
+imported. Capture hooks and `capture --resume` both handle transcripts larger
+than 32 MiB incrementally within the per-pass bounds above. An unfinished final
+JSONL record is deferred. Hooks have a
 10-second timeout, except Codex `SessionEnd` at 3 seconds; `Stop` is its normal
 capture point.
 

--- a/website/src/content/docs/cli-integrations.md
+++ b/website/src/content/docs/cli-integrations.md
@@ -102,6 +102,16 @@ Then start a fresh client session in that project and ask about the verification
 
 Explicit operations are **shell-invoked commands**, not registered model tools. Injected context explains how the agent can invoke them through its normal shell permissions. Available names are `lore_recall`, `lore_retain`, `lore_onboard`, `memory_search`, `memory_save`, `memory_forget`, `memory_status`, `memory_correct`, `memory_repair`, and `memory_purge`. Commands accept JSON on stdin and return a nonzero exit status on failure. See [Tools](/guides/tools/#native-cli-commands).
 
+The bounded native capture resume command is separate from these administration
+previews. The dashboard only copies it; running it performs capture and may
+write evidence. Each pass reads at most 4 MiB with a 250 ms cooperative read budget, retains at most a 1
+MiB incomplete record, and reports skipped oversized records through
+categorical health:
+
+```sh
+printf '%s\n' '{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}' | node /absolute/path/to/lore/lore-cli.mjs capture --resume --client codex --session '<native-session-id>'
+```
+
 ## What happens during a session
 
 | Purpose | Codex CLI | Claude Code | Antigravity CLI |
@@ -125,7 +135,12 @@ For direct commands run outside your project, pass an explicit `repository` argu
 
 Only the supplied active-session transcript is read; these adapters do not scan archives or import unrelated sessions. Thinking, reasoning, tool output, injected Lore context, and Antigravity prompt metadata are excluded from extraction. Hosts that disable transcript persistence cannot provide automatic capture.
 
-Hook input is limited to 1 MiB and transcript snapshots to 32 MiB. Malformed or oversized input is not imported; an unfinished final JSONL record is deferred. Hooks have a 10-second timeout, except Codex `SessionEnd` at 3 seconds; `Stop` is its normal capture point.
+Hook input is limited to 1 MiB and hook-provided transcript snapshots to 32
+MiB. Malformed or oversized hook input is not imported; the separate native
+`capture --resume` command handles larger transcripts incrementally within its
+per-pass bounds. An unfinished final JSONL record is deferred. Hooks have a
+10-second timeout, except Codex `SessionEnd` at 3 seconds; `Stop` is its normal
+capture point.
 
 Memory storage stays local, but context injected into a conversation goes to the host's configured model. See [Privacy](/guides/privacy/) before using sensitive material.
 

--- a/website/src/content/docs/how-memory-works.md
+++ b/website/src/content/docs/how-memory-works.md
@@ -60,9 +60,11 @@ The shared retrieval concepts are exposed through adapter-specific interfaces:
 
 With local embeddings enabled, `lore_recall` appends meaning-ranked matches to lexical results. Embeddings augment lexical retrieval; they do not replace it, and endpoint failures fall back to lexical search.
 
-The dashboard overview reports active-memory embedding coverage and bounded
-fallback diagnostics so an unavailable or partial embedding index is visible.
-Lexical retrieval remains the deterministic fallback.
+The dashboard overview reports a bounded sample of eligible active-memory
+embedding coverage and bounded fallback diagnostics. It validates cache content
+hash, provider, model, dimensions, vector shape, expiry, scope, suppression,
+and active evidence before counting a sampled row. Lexical retrieval remains
+the deterministic fallback.
 
 ## Writing and retiring memories
 

--- a/website/src/content/docs/how-memory-works.md
+++ b/website/src/content/docs/how-memory-works.md
@@ -36,6 +36,12 @@ Codex CLI, Claude Code, and Antigravity CLI connect through native lifecycle com
 
 The derived store can contain semantic memories, episode and day summaries, commitments, working-profile information, and provenance. A memory may include a repository scope, category, confidence, source, and supersession history.
 
+The local dashboard can open a memory's evidence ledger. Each linked source
+record shows its attributed role, descriptive confidence basis, revision, and
+capture time. The same view shows scope, expiry, suppression, correction state,
+and a chronological lifecycle timeline. These are provenance signals for
+review; a confidence basis is not a calibrated probability.
+
 Lore reads Copilot's raw `session-store.db` for extraction and backfill. It never writes to that raw store. The derived database is `~/.config/lore/lore.db` by default (or `$XDG_CONFIG_HOME/lore/lore.db`).
 
 ## Retrieval and scope
@@ -53,6 +59,10 @@ The shared retrieval concepts are exposed through adapter-specific interfaces:
 | Codex, Claude, Antigravity | `lore_recall` / `memory_search` | Direct shell-invoked recall and keyword search via `lore-cli.mjs tool` |
 
 With local embeddings enabled, `lore_recall` appends meaning-ranked matches to lexical results. Embeddings augment lexical retrieval; they do not replace it, and endpoint failures fall back to lexical search.
+
+The dashboard overview reports active-memory embedding coverage and bounded
+fallback diagnostics so an unavailable or partial embedding index is visible.
+Lexical retrieval remains the deterministic fallback.
 
 ## Writing and retiring memories
 

--- a/website/src/content/docs/maintenance.md
+++ b/website/src/content/docs/maintenance.md
@@ -28,9 +28,12 @@ The in-session equivalent is `maintenance_schedule_run({ dryRun: true })`. Start
 
 The optional [browser dashboard](/guides/troubleshooting/#dashboard-cannot-be-reached)
 keeps this inspection read-only. Its overview shows the last successful native
-capture, pending bytes, resumable source checkpoints, embedding coverage, and
-recent fallback diagnostics. A resume button only copies a command for review;
-it does not run capture from the browser.
+ capture, pending bytes, resumable source checkpoints, embedding coverage, and
+ recent fallback diagnostics. A resume button only copies a command for review;
+ it does not run capture from the browser. Running the copied native
+ `capture --resume` command performs capture and may write evidence. Each pass
+ reads at most 4 MiB with a 250 ms cooperative read budget, retains at most a 1 MiB incomplete record, and
+ reports skipped oversized records through categorical health.
 
 ## Useful task cadence
 
@@ -68,6 +71,10 @@ Use an absolute Node path because cron has a minimal `PATH`. Set `LORE_HOME` or 
 Stale deferred jobs and abandoned maintenance runs are reclaimed after their configured 30-minute defaults. Failed migrations and tasks use forward recovery and leave the database intact. Point maintenance only at the configured Lore database; do not aim it at fixtures or another user's data.
 
 Administrative repair and purge follow the same review boundary: preview first,
-then apply only with the preview fingerprint and explicit candidate IDs. Purge
-removes selected derived records while retaining raw sources and recovery
-snapshots; it is not secure erasure.
+then apply only with the preview fingerprint and explicit candidate IDs. Repair
+candidate IDs are limited to actionable source re-extraction or repository
+mapping candidates. Purge aggregate candidates use typed IDs such as
+`aggregate:episode_digest:<json-primary-key>` and require
+`includeDependentAggregates: true` plus every residual aggregate ID selected
+from the preview. Purge removes selected derived records while retaining raw
+sources and recovery snapshots; it is not secure erasure.

--- a/website/src/content/docs/maintenance.md
+++ b/website/src/content/docs/maintenance.md
@@ -26,6 +26,12 @@ node scripts/run-maintenance.mjs --dry-run
 
 The in-session equivalent is `maintenance_schedule_run({ dryRun: true })`. Start with a dry run when enabling a new task.
 
+The optional [browser dashboard](/guides/troubleshooting/#dashboard-cannot-be-reached)
+keeps this inspection read-only. Its overview shows the last successful native
+capture, pending bytes, resumable source checkpoints, embedding coverage, and
+recent fallback diagnostics. A resume button only copies a command for review;
+it does not run capture from the browser.
+
 ## Useful task cadence
 
 The built-in defaults suggest validation every 12 hours, replay every 24 hours, backlog review every 6 hours, and index upkeep every 12 hours when enabled. `traceCompaction` is hourly and `doctorSnapshot` is daily when their rollout gates are enabled.
@@ -60,3 +66,8 @@ Use an absolute Node path because cron has a minimal `PATH`. Set `LORE_HOME` or 
 ## Recovery and isolation
 
 Stale deferred jobs and abandoned maintenance runs are reclaimed after their configured 30-minute defaults. Failed migrations and tasks use forward recovery and leave the database intact. Point maintenance only at the configured Lore database; do not aim it at fixtures or another user's data.
+
+Administrative repair and purge follow the same review boundary: preview first,
+then apply only with the preview fingerprint and explicit candidate IDs. Purge
+removes selected derived records while retaining raw sources and recovery
+snapshots; it is not secure erasure.

--- a/website/src/content/docs/tools.md
+++ b/website/src/content/docs/tools.md
@@ -76,6 +76,24 @@ These are the supported Copilot CLI tools to build everyday workflows around. Pi
 
 Some experimental tools require rollout flags such as `evolutionLedger`, `loreDoctor`, or `refreshableObservations`. They do not receive the same stability promise as the core.
 
+## Read-only administration previews
+
+The native CLI also registers `memory_correct`, `memory_repair`, and
+`memory_purge`. Each command defaults to a read-only preview and accepts a JSON
+object on stdin. A preview reports its affected derived records and a
+`planFingerprint`; applying a plan requires that exact fingerprint and explicit
+selection of any repair or aggregate candidates.
+
+```sh
+printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_correct
+printf '%s\n' '{"sessionIds":["<session-id>"]}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_repair
+printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_purge
+```
+
+The browser dashboard only generates these preview commands for copying. It
+does not execute them and has no write endpoint. Purge retains raw sources,
+backups, snapshots, and non-plaintext suppression, so it is not secure erasure.
+
 ## Native CLI commands
 
 [Codex CLI, Claude Code, and Antigravity CLI](/guides/cli-integrations/) use experimental native lifecycle hooks for automatic recall and capture. Explicit memory operations run through the shell, not MCP or registered model tools:

--- a/website/src/content/docs/tools.md
+++ b/website/src/content/docs/tools.md
@@ -91,8 +91,24 @@ printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/path/to/lore/lore-cli.mj
 ```
 
 The browser dashboard only generates these preview commands for copying. It
-does not execute them and has no write endpoint. Purge retains raw sources,
-backups, snapshots, and non-plaintext suppression, so it is not secure erasure.
+does not execute them and has no write endpoint. Apply requires the same
+selector and payload, the preview `planFingerprint`, and explicit actionable
+candidate IDs. Repair candidates are limited to source re-extraction and
+repository mappings. Source-backed repair scans at most 32 MiB and 10,000
+turns; unavailable or oversized legacy sources remain unresolved. Purge
+aggregate candidates use typed IDs such as
+`aggregate:episode_digest:<json-primary-key>`. If the initial preview reports
+residual aggregates, run a new preview with `includeDependentAggregates: true`,
+then use that new fingerprint and select every residual aggregate it reports. A correction can set `repository` for the replacement
+destination, or explicitly use `scope: "global", repository: null` for a global
+replacement. Purge retains raw sources, backups, snapshots, and non-plaintext
+suppression, so it is not secure erasure.
+
+The native capture resume command is separate from administration previews. The
+dashboard only copies it; running it performs capture and may write evidence.
+Each pass reads at most 4 MiB with a 250 ms cooperative read budget, retains at most a 1 MiB incomplete
+record, and reports skipped oversized records through categorical health. Its
+stdin is `{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}`.
 
 ## Native CLI commands
 

--- a/website/src/content/docs/tools.md
+++ b/website/src/content/docs/tools.md
@@ -86,7 +86,7 @@ selection of any repair or aggregate candidates.
 
 ```sh
 printf '%s\n' '{"memoryId":"<id>","content":"<replacement>","reason":"<why>"}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_correct
-printf '%s\n' '{"sessionIds":["<session-id>"]}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_repair
+printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_repair
 printf '%s\n' '{"memoryIds":["<id>"]}' | node /absolute/path/to/lore/lore-cli.mjs tool memory_purge
 ```
 

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -41,9 +41,8 @@ For Codex CLI, Claude Code, and Antigravity CLI, check the [installation guide](
 Run `memory_status` and a synthetic `lore_recall` through `lore-cli.mjs tool` from the project directory. If direct recall works but automatic recall does not, inspect the host's hook diagnostics. Lore fails open, so the agent continuing normally is not proof that hooks ran.
 
 For missing hook capture, confirm the host persists and supplies the active
-transcript. Hook-provided snapshots over 32 MiB are not imported; use the
-native `capture --resume` command for larger transcripts, which reads them in
-bounded passes. An unfinished last JSONL record waits for a later capture. The
+transcript. Capture hooks and `capture --resume` both read large transcripts
+in bounded passes. Use the resume command when health reports pending work. An unfinished last JSONL record waits for a later capture. The
 verified host versions and unsupported features are listed in [Compatibility
 and current limits](/guides/cli-integrations/#compatibility-and-current-limits).
 

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -40,7 +40,12 @@ For Codex CLI, Claude Code, and Antigravity CLI, check the [installation guide](
 
 Run `memory_status` and a synthetic `lore_recall` through `lore-cli.mjs tool` from the project directory. If direct recall works but automatic recall does not, inspect the host's hook diagnostics. Lore fails open, so the agent continuing normally is not proof that hooks ran.
 
-For missing capture, confirm the host persists and supplies the active transcript. Malformed or oversized transcripts (over 32 MiB) are not imported; an unfinished last JSONL record waits for a later capture. The verified host versions and unsupported features are listed in [Compatibility and current limits](/guides/cli-integrations/#compatibility-and-current-limits).
+For missing hook capture, confirm the host persists and supplies the active
+transcript. Hook-provided snapshots over 32 MiB are not imported; use the
+native `capture --resume` command for larger transcripts, which reads them in
+bounded passes. An unfinished last JSONL record waits for a later capture. The
+verified host versions and unsupported features are listed in [Compatibility
+and current limits](/guides/cli-integrations/#compatibility-and-current-limits).
 
 ## A database or schema error appears
 
@@ -67,10 +72,15 @@ The browser dashboard is experimental, read-only, unauthenticated, and loopback-
 When it loads, open a memory from the **Memories** table to inspect source
 evidence, role attribution, confidence basis, scope, expiry, suppression, and
 the correction timeline. The overview's **Capture health** table shows pending
-bytes and a copy-only resume preview when a native checkpoint includes both
-`sourcePath` and `sourceCwd`. **Embedding coverage** reports the active indexed
-portion and recent lexical fallback diagnostics. No dashboard control executes
-a command or writes to Lore.
+bytes, pending branch or cleanup work, and a copy-only resume command when a
+native checkpoint includes both `sourcePath` and `sourceCwd`. **Embedding
+coverage** reports a bounded sample of eligible active rows and recent lexical
+fallback diagnostics, so it does not claim that every non-empty cache row is
+valid. No dashboard control executes a command or writes to Lore. Running a
+copied `capture --resume` command performs bounded capture and may write
+evidence; it accepts
+`{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}` on
+stdin.
 
 ## Still stuck?
 

--- a/website/src/content/docs/troubleshooting.md
+++ b/website/src/content/docs/troubleshooting.md
@@ -64,6 +64,14 @@ The Codex, Claude Code, and Antigravity adapters do not run automatic maintenanc
 
 The browser dashboard is experimental, read-only, unauthenticated, and loopback-only. Start it with `npm run browser`; use `127.0.0.1`, `localhost`, or `::1`. It is intentionally not available through a LAN address.
 
+When it loads, open a memory from the **Memories** table to inspect source
+evidence, role attribution, confidence basis, scope, expiry, suppression, and
+the correction timeline. The overview's **Capture health** table shows pending
+bytes and a copy-only resume preview when a native checkpoint includes both
+`sourcePath` and `sourceCwd`. **Embedding coverage** reports the active indexed
+portion and recent lexical fallback diagnostics. No dashboard control executes
+a command or writes to Lore.
+
 ## Still stuck?
 
 Capture the Node version, Lore version or checkout revision, operating system, exact symptom, and output from `memory_status` or `memory_validate`. Do not attach `lore.db`, `lore.json`, or raw session data; they can contain sensitive work details. See the project's support guidance before opening an issue.


### PR DESCRIPTION
## Summary

Adds the read-only provenance dashboard and aligns the repository and website documentation with the reliability interfaces.

## Changes

- Show source evidence, attributed role, confidence basis, scope, expiry, suppression, correction, and lifecycle timelines.
- Report capture health, pending branch/cleanup work, resumable sessions, sampled embedding coverage, and fallback diagnostics.
- Generate shell-safe, copy-only resume and administration preview commands; the dashboard never writes or executes them.
- Document bounded capture, explicit repair/mapping, fingerprinted apply, retained sources/snapshots, and purge limitations.
- Add desktop/mobile dashboard coverage and portable Node 24 fixture tests.

## Testing

- `npm test` — 1,117 tests passed.
- Website `pnpm check`, `pnpm test`, `pnpm build`, and `pnpm check:links` pass: 16 pages and 517 local links/assets.
- Rendered fixture QA covers desktop and 390×844 mobile drill-down, provenance/lifecycle content, all three preview clipboard commands, resume feedback, and no document overflow.

This is the final stacked PR, based on [PR #106](https://github.com/matt-riley/lore/pull/106), after PRs #103, #104, and #105.
