### PR TITLE
docs: list all native cli commands

### DIFF
--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -33,7 +33,8 @@ This document defines which surfaces are **supported**, **experimental**, or **u
 Codex, Claude Code, and Antigravity use `lore-cli.mjs`, not MCP. Native hooks provide automatic recall
 and transcript capture. The direct shell commands are `lore_recall`,
 `lore_retain`, `lore_onboard`, `memory_search`, `memory_save`, `memory_forget`,
-and `memory_status`. The canonical lists are `LORE_CLIENT_HOOKS` and
+`memory_status`, `memory_correct`, `memory_repair`, and `memory_purge`. The
+canonical lists are `LORE_CLIENT_HOOKS` and
 `LORE_CLI_TOOL_NAMES` in `lib/capabilities/capability-manifest.mjs`.
 See [installation, verification, and boundaries](cli-integrations.md).
 

--- a/website/src/content/docs/tools.md
+++ b/website/src/content/docs/tools.md
@@ -118,9 +118,9 @@ stdin is `{"cwd":"<source-cwd>","transcriptPath":"<absolute-transcript-path>"}`.
 printf '%s\n' '{"prompt":"What did we decide about storage?"}' | node /absolute/path/to/lore/lore-cli.mjs tool lore_recall
 ```
 
-The available commands are `lore_recall`, `lore_retain`, `lore_onboard`, `memory_search`, `memory_save`, `memory_forget`, and `memory_status`. They accept JSON arguments on stdin and signal failures with a nonzero exit status. Run from your project or supply an explicit `repository` argument. Injected context explains these commands to the agent, but normal host shell permissions still apply.
+The available commands are `lore_recall`, `lore_retain`, `lore_onboard`, `memory_search`, `memory_save`, `memory_forget`, `memory_status`, `memory_correct`, `memory_repair`, and `memory_purge`. They accept JSON arguments on stdin and signal failures with a nonzero exit status. Run from your project or supply an explicit `repository` argument. Injected context explains these commands to the agent, but normal host shell permissions still apply.
 
-These adapters do not expose the full Copilot tool set: `memory_explain`, `memory_validate`, and the experimental Copilot tools above are not CLI commands. See the [native lifecycle table](/guides/cli-integrations/#what-happens-during-a-session) for each client's events and limits.
+These adapters do not expose the full Copilot tool set: `memory_explain`, `memory_validate`, `memory_skill_validate`, and Copilot-only experimental tools such as `lore_reflect` and `memory_backfill` are not CLI commands. The administration commands listed above are available through the native CLI. See the [native lifecycle table](/guides/cli-integrations/#what-happens-during-a-session) for each client's events and limits.
 
 ## Copilot CLI hooks
 


### PR DESCRIPTION
## Problem
The native CLI documentation listed only the core commands even though `memory_correct`, `memory_repair`, and `memory_purge` are also registered. The website wording also described those administration commands as unavailable.

## Change
- list all ten native CLI commands in the support matrix and Tools guide
- clarify that Copilot-only diagnostics and experimental tools remain unavailable to native CLI adapters

## Validation
- `npm run validate-schema`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `pnpm check:links` (517 local links/assets across 16 pages)
