### PR TITLE
perf(website): tree-shake lazy three runtime

### DIFF
--- a/website/src/scripts/archive.ts
+++ b/website/src/scripts/archive.ts
@@ -21,8 +21,8 @@ document.querySelectorAll<HTMLElement>("[data-archive]").forEach((element) => {
     button.textContent = "Opening the archive…";
     let cleanupOnFailure: (() => void) | undefined;
     try {
-      const [THREE, { GLTFLoader }, { RoomEnvironment }, { OrbitControls }] = await Promise.all([
-        import("three"),
+      const [{ THREE }, { GLTFLoader }, { RoomEnvironment }, { OrbitControls }] = await Promise.all([
+        import("./three-runtime"),
         import("three/addons/loaders/GLTFLoader.js"),
         import("three/addons/environments/RoomEnvironment.js"),
         import("three/addons/controls/OrbitControls.js"),

--- a/website/src/scripts/three-runtime.ts
+++ b/website/src/scripts/three-runtime.ts
@@ -1,0 +1,37 @@
+// Keep the archive's optional 3D runtime lazy while letting Vite tree-shake
+// Three.js to the classes this scene actually uses.
+import {
+  ACESFilmicToneMapping,
+  Box3,
+  DirectionalLight,
+  Group,
+  HemisphereLight,
+  Mesh,
+  MeshStandardMaterial,
+  PCFShadowMap,
+  PerspectiveCamera,
+  PlaneGeometry,
+  PMREMGenerator,
+  Scene,
+  ShadowMaterial,
+  Vector3,
+  WebGLRenderer,
+} from "three";
+
+export const THREE = {
+  ACESFilmicToneMapping,
+  Box3,
+  DirectionalLight,
+  Group,
+  HemisphereLight,
+  Mesh,
+  MeshStandardMaterial,
+  PCFShadowMap,
+  PerspectiveCamera,
+  PlaneGeometry,
+  PMREMGenerator,
+  Scene,
+  ShadowMaterial,
+  Vector3,
+  WebGLRenderer,
+};


### PR DESCRIPTION
## Problem
The website build emitted a Vite warning because the optional archive interaction pulled the entire Three.js namespace into a 724 KB lazy chunk.

## Change
- expose only the Three.js classes used by the archive through a small lazy runtime module
- keep the 3D feature deferred until the user opens it
- preserve the existing archive behavior and fallback path

The largest generated chunk is now 344 KB, and the warning is gone. The combined Three.js payload is about 21% smaller when gzip compressed.

## Validation
- `pnpm check`
- `pnpm test`
- `pnpm build` (no Vite chunk-size warning; 16 pages)
- `pnpm check:links` (517 local links/assets)
- `npm run lint`
- Browser smoke: opened `/guides/how-memory-works/`, activated the 3D archive, confirmed `3D archive ready` and no console errors.
