### PR TITLE
fix(db): safely quote SQL identifiers in PRAGMA and ALTER statements

### DIFF
--- a/lib/db/db-migration-runner.mjs
+++ b/lib/db/db-migration-runner.mjs
@@ -321,7 +321,7 @@ export class MigrationRunner {
    * @returns {boolean}
    */
   tableHasColumn(tableName, columnName) {
-    const rows = this.db.prepare(`PRAGMA table_info(${tableName})`).all();
+    const rows = this.db.prepare(`PRAGMA table_info("${tableName.replaceAll('"', '""')}")`).all();
     return rows.some((row) => row.name === columnName);
   }
 
@@ -336,7 +336,7 @@ export class MigrationRunner {
     if (api.tableHasColumn(tableName, columnName)) {
       return;
     }
-    this.db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definitionSql}`);
+    this.db.exec(`ALTER TABLE "${tableName.replaceAll('"', '""')}" ADD COLUMN "${columnName.replaceAll('"', '""')}" ${definitionSql}`);
   }
 
   /**

--- a/lib/db/db-snapshot-lifecycle.mjs
+++ b/lib/db/db-snapshot-lifecycle.mjs
@@ -32,7 +32,7 @@ function schemaInfo(db, dbPath) {
     episode_digest: ["id", "session_id", "summary", "date_key", "created_at", "updated_at"],
   };
   const requiredTables = Object.entries(requiredColumns).every(([table, columns]) => {
-    const actual = new Set(db.prepare(`PRAGMA table_info(${table})`).all().map((column) => column.name));
+    const actual = new Set(db.prepare(`PRAGMA table_info("${table.replaceAll('"', '""')}")`).all().map((column) => column.name));
     return columns.every((column) => actual.has(column));
   });
   return { ...(selected ?? { tableName: null, version: 0 }), requiredTables };

--- a/tests/unit/db-migration-runner.test.mjs
+++ b/tests/unit/db-migration-runner.test.mjs
@@ -6,37 +6,39 @@ import { MigrationRunner } from "../../lib/db/db-migration-runner.mjs";
 describe("db-migration-runner", () => {
   test("tableHasColumn and ensureColumn safely handle reserved words and special characters in identifiers", () => {
     const db = new DatabaseSync(":memory:");
-    const runner = new MigrationRunner(db, {});
+    try {
+      const runner = new MigrationRunner(db, {});
 
-    // Reserved SQL keywords as table and column names
-    db.exec(`CREATE TABLE "order" (id TEXT PRIMARY KEY);`);
-    assert.strictEqual(runner.tableHasColumn("order", "id"), true);
-    assert.strictEqual(runner.tableHasColumn("order", "group"), false);
+      // Reserved SQL keywords as table and column names
+      db.exec(`CREATE TABLE "order" (id TEXT PRIMARY KEY);`);
+      assert.strictEqual(runner.tableHasColumn("order", "id"), true);
+      assert.strictEqual(runner.tableHasColumn("order", "group"), false);
 
-    // ensureColumn with reserved SQL words for table and column
-    runner.ensureColumn("order", "group", "TEXT");
-    assert.strictEqual(runner.tableHasColumn("order", "group"), true);
+      // ensureColumn with reserved SQL words for table and column
+      runner.ensureColumn("order", "group", "TEXT");
+      assert.strictEqual(runner.tableHasColumn("order", "group"), true);
 
-    // ensureColumn is idempotent when column already exists
-    runner.ensureColumn("order", "group", "TEXT");
-    assert.strictEqual(runner.tableHasColumn("order", "group"), true);
+      // ensureColumn is idempotent when column already exists
+      runner.ensureColumn("order", "group", "TEXT");
+      assert.strictEqual(runner.tableHasColumn("order", "group"), true);
 
-    // Identifiers with special characters: spaces, hyphens, and embedded double quotes
-    const trickyTable = `special-table name"with"quotes`;
-    const trickyColumn = `user-column name"with"quotes`;
-    db.exec(`CREATE TABLE "special-table name""with""quotes" (id TEXT PRIMARY KEY);`);
+      // Identifiers with special characters: spaces, hyphens, and embedded double quotes
+      const trickyTable = `special-table name"with"quotes`;
+      const trickyColumn = `user-column name"with"quotes`;
+      db.exec(`CREATE TABLE "special-table name""with""quotes" (id TEXT PRIMARY KEY);`);
 
-    assert.strictEqual(runner.tableHasColumn(trickyTable, "id"), true);
-    assert.strictEqual(runner.tableHasColumn(trickyTable, trickyColumn), false);
+      assert.strictEqual(runner.tableHasColumn(trickyTable, "id"), true);
+      assert.strictEqual(runner.tableHasColumn(trickyTable, trickyColumn), false);
 
-    runner.ensureColumn(trickyTable, trickyColumn, "TEXT DEFAULT 'default-val'");
-    assert.strictEqual(runner.tableHasColumn(trickyTable, trickyColumn), true);
+      runner.ensureColumn(trickyTable, trickyColumn, "TEXT DEFAULT 'default-val'");
+      assert.strictEqual(runner.tableHasColumn(trickyTable, trickyColumn), true);
 
-    // Verify the column was actually added with the proper definition
-    db.exec(`INSERT INTO "special-table name""with""quotes" (id) VALUES ('row-1');`);
-    const row = db.prepare(`SELECT "user-column name""with""quotes" AS val FROM "special-table name""with""quotes" WHERE id = 'row-1'`).get();
-    assert.strictEqual(row.val, "default-val");
-
-    db.close();
+      // Verify the column was actually added with the proper definition
+      db.exec(`INSERT INTO "special-table name""with""quotes" (id) VALUES ('row-1');`);
+      const row = db.prepare(`SELECT "user-column name""with""quotes" AS val FROM "special-table name""with""quotes" WHERE id = 'row-1'`).get();
+      assert.strictEqual(row.val, "default-val");
+    } finally {
+      db.close();
+    }
   });
 });

--- a/tests/unit/db-migration-runner.test.mjs
+++ b/tests/unit/db-migration-runner.test.mjs
@@ -1,0 +1,42 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { MigrationRunner } from "../../lib/db/db-migration-runner.mjs";
+
+describe("db-migration-runner", () => {
+  test("tableHasColumn and ensureColumn safely handle reserved words and special characters in identifiers", () => {
+    const db = new DatabaseSync(":memory:");
+    const runner = new MigrationRunner(db, {});
+
+    // Reserved SQL keywords as table and column names
+    db.exec(`CREATE TABLE "order" (id TEXT PRIMARY KEY);`);
+    assert.strictEqual(runner.tableHasColumn("order", "id"), true);
+    assert.strictEqual(runner.tableHasColumn("order", "group"), false);
+
+    // ensureColumn with reserved SQL words for table and column
+    runner.ensureColumn("order", "group", "TEXT");
+    assert.strictEqual(runner.tableHasColumn("order", "group"), true);
+
+    // ensureColumn is idempotent when column already exists
+    runner.ensureColumn("order", "group", "TEXT");
+    assert.strictEqual(runner.tableHasColumn("order", "group"), true);
+
+    // Identifiers with special characters: spaces, hyphens, and embedded double quotes
+    const trickyTable = `special-table name"with"quotes`;
+    const trickyColumn = `user-column name"with"quotes`;
+    db.exec(`CREATE TABLE "special-table name""with""quotes" (id TEXT PRIMARY KEY);`);
+
+    assert.strictEqual(runner.tableHasColumn(trickyTable, "id"), true);
+    assert.strictEqual(runner.tableHasColumn(trickyTable, trickyColumn), false);
+
+    runner.ensureColumn(trickyTable, trickyColumn, "TEXT DEFAULT 'default-val'");
+    assert.strictEqual(runner.tableHasColumn(trickyTable, trickyColumn), true);
+
+    // Verify the column was actually added with the proper definition
+    db.exec(`INSERT INTO "special-table name""with""quotes" (id) VALUES ('row-1');`);
+    const row = db.prepare(`SELECT "user-column name""with""quotes" AS val FROM "special-table name""with""quotes" WHERE id = 'row-1'`).get();
+    assert.strictEqual(row.val, "default-val");
+
+    db.close();
+  });
+});

--- a/tests/unit/db-snapshot-lifecycle.test.mjs
+++ b/tests/unit/db-snapshot-lifecycle.test.mjs
@@ -1,0 +1,108 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+
+import { inspectDatabase, validateCanonicalShape } from "../../lib/db/db-snapshot-lifecycle.mjs";
+import { SCHEMA_STATEMENTS, SCHEMA_VERSION } from "../../lib/db/schema.mjs";
+
+function makeTempDir() {
+  return mkdtempSync(path.join(os.tmpdir(), "lore-snapshot-test-"));
+}
+
+describe("db-snapshot-lifecycle", () => {
+  test("validateCanonicalShape handles databases with reserved words and special characters in table names", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      for (const statement of SCHEMA_STATEMENTS) {
+        db.exec(statement);
+      }
+
+      // Add extra tables and views with reserved words, spaces, hyphens, and quotes
+      db.exec(`
+        CREATE TABLE "order" (id TEXT PRIMARY KEY, status TEXT);
+        CREATE TABLE "group" (id TEXT PRIMARY KEY, "where" TEXT);
+        CREATE TABLE "table with spaces" (id TEXT PRIMARY KEY);
+        CREATE TABLE "table-with-dashes" (id TEXT PRIMARY KEY);
+        CREATE TABLE "table""with""quotes" (id TEXT PRIMARY KEY, "col""quote" TEXT);
+        CREATE VIEW "view with spaces" AS SELECT id FROM "order";
+      `);
+
+      // validateCanonicalShape inspects schemaShape for all tables/views via PRAGMA table_info
+      // It should safely quote all identifiers without throwing a SQL syntax error
+      assert.doesNotThrow(() => {
+        validateCanonicalShape(db);
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  test("validateCanonicalShape detects missing canonical tables even with unusual table names present", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      db.exec(`
+        CREATE TABLE "order" (id TEXT PRIMARY KEY);
+        CREATE TABLE "special table" (id TEXT PRIMARY KEY);
+      `);
+
+      assert.throws(
+        () => validateCanonicalShape(db),
+        /snapshot is not a complete Lore database/,
+      );
+    } finally {
+      db.close();
+    }
+  });
+
+  test("inspectDatabase safely handles databases containing reserved words and special character tables", () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "test.db");
+    try {
+      const db = new DatabaseSync(dbPath);
+      for (const statement of SCHEMA_STATEMENTS) {
+        db.exec(statement);
+      }
+      db.exec(`
+        CREATE TABLE "order" (id TEXT PRIMARY KEY, "desc" TEXT);
+        CREATE TABLE "table-with-dashes" (id TEXT PRIMARY KEY);
+        CREATE TABLE "table with spaces""and quotes" (id TEXT PRIMARY KEY);
+        INSERT INTO lore_schema_version (version) VALUES (${SCHEMA_VERSION});
+      `);
+      db.close();
+
+      const result = inspectDatabase(dbPath);
+      assert.strictEqual(result.exists, true);
+      assert.strictEqual(result.integrity, "ok");
+      assert.strictEqual(result.schemaVersion, SCHEMA_VERSION);
+      assert.strictEqual(result.schemaTable, "lore_schema_version");
+      assert.strictEqual(result.requiredTables, true);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("inspectDatabase reports requiredTables as false when required columns are missing", () => {
+    const tempDir = makeTempDir();
+    const dbPath = path.join(tempDir, "incomplete.db");
+    try {
+      const db = new DatabaseSync(dbPath);
+      db.exec(`
+        CREATE TABLE "order" (id TEXT PRIMARY KEY);
+        CREATE TABLE lore_schema_version (version INTEGER);
+        INSERT INTO lore_schema_version (version) VALUES (${SCHEMA_VERSION});
+        CREATE TABLE semantic_memory (id TEXT PRIMARY KEY);
+      `);
+      db.close();
+
+      const result = inspectDatabase(dbPath);
+      assert.strictEqual(result.exists, true);
+      assert.strictEqual(result.integrity, "ok");
+      assert.strictEqual(result.requiredTables, false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/db-snapshot-lifecycle.test.mjs
+++ b/tests/unit/db-snapshot-lifecycle.test.mjs
@@ -62,16 +62,19 @@ describe("db-snapshot-lifecycle", () => {
     const dbPath = path.join(tempDir, "test.db");
     try {
       const db = new DatabaseSync(dbPath);
-      for (const statement of SCHEMA_STATEMENTS) {
-        db.exec(statement);
+      try {
+        for (const statement of SCHEMA_STATEMENTS) {
+          db.exec(statement);
+        }
+        db.exec(`
+          CREATE TABLE "order" (id TEXT PRIMARY KEY, "desc" TEXT);
+          CREATE TABLE "table-with-dashes" (id TEXT PRIMARY KEY);
+          CREATE TABLE "table with spaces""and quotes" (id TEXT PRIMARY KEY);
+          INSERT INTO lore_schema_version (version) VALUES (${SCHEMA_VERSION});
+        `);
+      } finally {
+        db.close();
       }
-      db.exec(`
-        CREATE TABLE "order" (id TEXT PRIMARY KEY, "desc" TEXT);
-        CREATE TABLE "table-with-dashes" (id TEXT PRIMARY KEY);
-        CREATE TABLE "table with spaces""and quotes" (id TEXT PRIMARY KEY);
-        INSERT INTO lore_schema_version (version) VALUES (${SCHEMA_VERSION});
-      `);
-      db.close();
 
       const result = inspectDatabase(dbPath);
       assert.strictEqual(result.exists, true);
@@ -89,13 +92,16 @@ describe("db-snapshot-lifecycle", () => {
     const dbPath = path.join(tempDir, "incomplete.db");
     try {
       const db = new DatabaseSync(dbPath);
-      db.exec(`
-        CREATE TABLE "order" (id TEXT PRIMARY KEY);
-        CREATE TABLE lore_schema_version (version INTEGER);
-        INSERT INTO lore_schema_version (version) VALUES (${SCHEMA_VERSION});
-        CREATE TABLE semantic_memory (id TEXT PRIMARY KEY);
-      `);
-      db.close();
+      try {
+        db.exec(`
+          CREATE TABLE "order" (id TEXT PRIMARY KEY);
+          CREATE TABLE lore_schema_version (version INTEGER);
+          INSERT INTO lore_schema_version (version) VALUES (${SCHEMA_VERSION});
+          CREATE TABLE semantic_memory (id TEXT PRIMARY KEY);
+        `);
+      } finally {
+        db.close();
+      }
 
       const result = inspectDatabase(dbPath);
       assert.strictEqual(result.exists, true);


### PR DESCRIPTION
## Summary

Safely quotes SQL table and column identifiers in `PRAGMA table_info` and `ALTER TABLE ADD COLUMN` statements across database migration and snapshot lifecycle modules to guard against reserved words and special characters.

## Motivation / related issue

Unquoted table and column identifiers interpolated directly into `PRAGMA table_info(...)` and `ALTER TABLE ... ADD COLUMN ...` statements caused SQL syntax errors when identifiers matched SQL reserved keywords (e.g. `order`, `group`, `desc`) or contained special characters like hyphens, spaces, or embedded double quotes.

## Changes

- `lib/db/db-migration-runner.mjs`:
  - Quoted table name safely in `tableHasColumn`: `PRAGMA table_info(\"${tableName.replaceAll('"', '""')}\")`.
  - Quoted table and column names safely in `ensureColumn`: `ALTER TABLE \"${tableName.replaceAll('"', '""')}\" ADD COLUMN \"${columnName.replaceAll('"', '""')}\" ${definitionSql}`.
- `lib/db/db-snapshot-lifecycle.mjs`:
  - Quoted table name safely in `schemaInfo` required tables check: `PRAGMA table_info(\"${table.replaceAll('"', '""')}\")`.
- `tests/unit/db-migration-runner.test.mjs`:
  - Added unit tests verifying `tableHasColumn` and `ensureColumn` handle SQL reserved keywords and special characters (spaces, dashes, quotes).
- `tests/unit/db-snapshot-lifecycle.test.mjs`:
  - Added unit tests verifying `validateCanonicalShape` and `inspectDatabase` handle tables and views with SQL reserved words and special characters.

## Testing

Verified with:
- `node --test tests/unit/db-*.test.mjs` (all 80 tests passing)
- `node --test tests/smoke/cli-administration.test.mjs` (all 4 tests passing)
- `npm test` (all 1152 tests passing)
- `npm run lint` (0 warnings, 0 errors)
- `npm run validate-schema`:

```
✓ Schema and config defaults are in parity.
```

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run validate-schema` passes
- [ ] Docs updated if behaviour changed