### PR TITLE
fix(security): prevent DNS rebinding and protect static dashboard assets

### DIFF
--- a/browser/server.mjs
+++ b/browser/server.mjs
@@ -122,7 +122,7 @@ const SECURITY_HEADERS = Object.freeze({
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
   "Referrer-Policy": "no-referrer",
-  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+  "Content-Security-Policy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
 })
 
 const ALLOWED_LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"])

--- a/browser/server.mjs
+++ b/browser/server.mjs
@@ -118,12 +118,60 @@ function computeLatencyTrend(rows) {
   }
 }
 
+const SECURITY_HEADERS = Object.freeze({
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "no-referrer",
+  "Content-Security-Policy": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+})
+
+const ALLOWED_LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"])
+
+export function isAllowedHostHeader(hostHeader) {
+  if (typeof hostHeader !== "string") {
+    return false
+  }
+  const rawHost = hostHeader.trim().toLowerCase()
+  if (!rawHost) {
+    return false
+  }
+  if (rawHost.startsWith("[")) {
+    const closing = rawHost.indexOf("]")
+    if (closing === -1) {
+      return false
+    }
+    const ip = rawHost.slice(0, closing + 1)
+    const remainder = rawHost.slice(closing + 1)
+    if (remainder.length > 0 && !/^:\d+$/.test(remainder)) {
+      return false
+    }
+    return ip === "[::1]"
+  }
+  if (rawHost === "::1") {
+    return true
+  }
+  const colonIndex = rawHost.indexOf(":")
+  if (colonIndex !== -1) {
+    if (rawHost.indexOf(":", colonIndex + 1) !== -1) {
+      return false
+    }
+    const hostname = rawHost.slice(0, colonIndex)
+    const portPart = rawHost.slice(colonIndex + 1)
+    if (!/^\d+$/.test(portPart)) {
+      return false
+    }
+    return hostname === "localhost" || hostname === "127.0.0.1"
+  }
+  return ALLOWED_LOOPBACK_HOSTS.has(rawHost)
+}
+
 function jsonResponse(res, statusCode, payload) {
   const body = JSON.stringify(payload, null, 2)
   res.writeHead(statusCode, {
     "Content-Type": "application/json; charset=utf-8",
     "Cache-Control": "no-store",
     "Content-Length": Buffer.byteLength(body),
+    ...SECURITY_HEADERS,
   })
   res.end(body)
 }
@@ -149,23 +197,40 @@ function buildReadOnlyPayload(payload = {}) {
   }
 }
 
+const STATIC_CONTENT_TYPES = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".css", "text/css; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".svg", "image/svg+xml"],
+  [".ico", "image/x-icon"],
+  [".png", "image/png"],
+  [".json", "application/json; charset=utf-8"],
+  [".woff", "font/woff"],
+  [".woff2", "font/woff2"],
+])
+
+const ALLOWED_STATIC_EXTENSIONS = new Set(STATIC_CONTENT_TYPES.keys())
+
 function getStaticContentType(filePath) {
-  if (filePath.endsWith(".html")) {
-    return "text/html; charset=utf-8"
-  }
-  if (filePath.endsWith(".css")) {
-    return "text/css; charset=utf-8"
-  }
-  if (filePath.endsWith(".js")) {
-    return "text/javascript; charset=utf-8"
-  }
-  return "text/plain; charset=utf-8"
+  const ext = path.extname(filePath).toLowerCase()
+  return STATIC_CONTENT_TYPES.get(ext) ?? "text/plain; charset=utf-8"
 }
 
 async function serveStatic(res, pathname) {
   const candidate = pathname === "/" ? "/index.html" : pathname
   const resolved = path.resolve(STATIC_ROOT, `.${candidate}`)
-  if (!resolved.startsWith(STATIC_ROOT)) {
+  const relative = path.relative(STATIC_ROOT, resolved)
+  if (
+    (!resolved.startsWith(STATIC_ROOT + path.sep) && resolved !== STATIC_ROOT) ||
+    relative.startsWith("..") ||
+    path.isAbsolute(relative)
+  ) {
+    notFound(res)
+    return
+  }
+
+  const ext = path.extname(resolved).toLowerCase()
+  if (!ALLOWED_STATIC_EXTENSIONS.has(ext)) {
     notFound(res)
     return
   }
@@ -176,12 +241,10 @@ async function serveStatic(res, pathname) {
       "Content-Type": getStaticContentType(resolved),
       "Cache-Control": "no-store",
       "Content-Length": content.length,
+      ...SECURITY_HEADERS,
     })
     res.end(content)
   } catch {
-    if (candidate !== "/index.html") {
-      return serveStatic(res, "/index.html")
-    }
     notFound(res)
   }
 }
@@ -1438,6 +1501,15 @@ export function startLoreBrowserServer({
   const normalizedRepository = normalizeRepository(repository)
 
   const server = createServer(async (req, res) => {
+    if (!isAllowedHostHeader(req.headers?.host)) {
+      jsonResponse(res, 403, {
+        ok: false,
+        error: "forbidden",
+        message: "Invalid host header",
+      })
+      return
+    }
+
     if (req.method !== "GET") {
       methodNotAllowed(res)
       return

--- a/tests/smoke/browser-network.test.mjs
+++ b/tests/smoke/browser-network.test.mjs
@@ -158,7 +158,7 @@ test("dashboard server rejects invalid and rebinding host headers with 403", () 
     assert.equal(res.headers["x-content-type-options"], "nosniff");
     assert.equal(res.headers["x-frame-options"], "DENY");
     assert.equal(res.headers["referrer-policy"], "no-referrer");
-    assert.equal(res.headers["content-security-policy"], "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'");
+    assert.equal(res.headers["content-security-policy"], "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'");
   }
 });
 
@@ -345,7 +345,7 @@ test("dashboard server includes security headers in static and api responses", (
     assert.equal(res.headers["referrer-policy"], "no-referrer", `${key} Referrer-Policy`);
     assert.equal(
       res.headers["content-security-policy"],
-      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+      "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
       `${key} Content-Security-Policy`
     );
   }

--- a/tests/smoke/browser-network.test.mjs
+++ b/tests/smoke/browser-network.test.mjs
@@ -71,3 +71,282 @@ test("dashboard server API rejects non-loopback hosts before creating a listener
   `);
   assert.equal(output, "ok");
 });
+
+test("dashboard server rejects invalid and rebinding host headers with 403", () => {
+  const output = runServerCheck(`
+    import { once } from "node:events";
+    import http from "node:http";
+    import net from "node:net";
+    import { startLoreBrowserServer } from ${JSON.stringify(serverUrl)};
+    const { server } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = server.address().port;
+
+    async function checkHost(hostHeader) {
+      return new Promise((resolve, reject) => {
+        const req = http.request({
+          hostname: "127.0.0.1",
+          port,
+          path: "/api/health",
+          headers: { host: hostHeader },
+        }, (res) => {
+          let data = "";
+          res.on("data", chunk => { data += chunk; });
+          res.on("end", () => resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: JSON.parse(data),
+          }));
+        });
+        req.on("error", reject);
+        req.end();
+      });
+    }
+
+    async function checkMissingHost() {
+      return new Promise((resolve, reject) => {
+        const socket = net.connect(port, "127.0.0.1", () => {
+          socket.write("GET /api/health HTTP/1.0\\r\\n\\r\\n");
+        });
+        let raw = "";
+        socket.on("data", chunk => { raw += chunk.toString(); });
+        socket.on("end", () => {
+          const [headerPart, ...bodyParts] = raw.split("\\r\\n\\r\\n");
+          const [statusLine, ...headerLines] = headerPart.split("\\r\\n");
+          const statusCode = Number(statusLine.split(" ")[1]);
+          const headers = {};
+          for (const line of headerLines) {
+            const idx = line.indexOf(":");
+            if (idx !== -1) {
+              headers[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim();
+            }
+          }
+          resolve({
+            status: statusCode,
+            headers,
+            body: JSON.parse(bodyParts.join("\\r\\n\\r\\n")),
+          });
+        });
+        socket.on("error", reject);
+      });
+    }
+
+    try {
+      const evilRes = await checkHost("evil.com:43111");
+      const attackerRes = await checkHost("attacker.com");
+      const subdomainRes = await checkHost("localhost.evil.com");
+      const ipSubdomainRes = await checkHost("127.0.0.1.evil.com");
+      const missingRes = await checkMissingHost();
+
+      console.log(JSON.stringify({
+        evil: evilRes,
+        attacker: attackerRes,
+        subdomain: subdomainRes,
+        ipSubdomain: ipSubdomainRes,
+        missing: missingRes,
+      }));
+    } finally {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+  `);
+
+  const results = JSON.parse(output);
+  for (const [key, res] of Object.entries(results)) {
+    assert.equal(res.status, 403, `${key} should return 403`);
+    assert.deepEqual(res.body, { ok: false, error: "forbidden", message: "Invalid host header" });
+    assert.equal(res.headers["x-content-type-options"], "nosniff");
+    assert.equal(res.headers["x-frame-options"], "DENY");
+    assert.equal(res.headers["referrer-policy"], "no-referrer");
+    assert.equal(res.headers["content-security-policy"], "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'");
+  }
+});
+
+test("dashboard server accepts valid loopback host headers", () => {
+  const output = runServerCheck(`
+    import { once } from "node:events";
+    import http from "node:http";
+    import { startLoreBrowserServer } from ${JSON.stringify(serverUrl)};
+    const { server: serverIpv4 } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+    await once(serverIpv4, "listening");
+    const portIpv4 = serverIpv4.address().port;
+
+    const { server: serverIpv6 } = startLoreBrowserServer({ db: { config: {} }, host: "::1", port: 0 });
+    await once(serverIpv6, "listening");
+    const portIpv6 = serverIpv6.address().port;
+
+    async function checkHost(hostname, port, hostHeader) {
+      return new Promise((resolve, reject) => {
+        const req = http.request({
+          hostname,
+          port,
+          path: "/api/health",
+          headers: { host: hostHeader },
+        }, (res) => {
+          let data = "";
+          res.on("data", chunk => { data += chunk; });
+          res.on("end", () => resolve({
+            status: res.statusCode,
+            body: JSON.parse(data),
+          }));
+        });
+        req.on("error", reject);
+        req.end();
+      });
+    }
+
+    try {
+      const localhostWithPort = await checkHost("127.0.0.1", portIpv4, "localhost:" + portIpv4);
+      const ipv4WithPort = await checkHost("127.0.0.1", portIpv4, "127.0.0.1:" + portIpv4);
+      const localhostWithoutPort = await checkHost("127.0.0.1", portIpv4, "localhost");
+      const ipv4WithoutPort = await checkHost("127.0.0.1", portIpv4, "127.0.0.1");
+      const ipv6WithPort = await checkHost("::1", portIpv6, "[::1]:" + portIpv6);
+      const ipv6WithoutPort = await checkHost("::1", portIpv6, "[::1]");
+
+      console.log(JSON.stringify({
+        localhostWithPort,
+        ipv4WithPort,
+        localhostWithoutPort,
+        ipv4WithoutPort,
+        ipv6WithPort,
+        ipv6WithoutPort,
+      }));
+    } finally {
+      serverIpv4.closeAllConnections();
+      serverIpv6.closeAllConnections();
+      await Promise.all([
+        new Promise(resolve => serverIpv4.close(resolve)),
+        new Promise(resolve => serverIpv6.close(resolve)),
+      ]);
+    }
+  `);
+
+  const results = JSON.parse(output);
+  for (const [key, res] of Object.entries(results)) {
+    assert.equal(res.status, 200, `${key} should return 200`);
+    assert.equal(res.body.ok, true, `${key} should be ok`);
+  }
+});
+
+test("dashboard server refuses to serve server.mjs and disallowed static files", () => {
+  const output = runServerCheck(`
+    import { once } from "node:events";
+    import http from "node:http";
+    import { startLoreBrowserServer } from ${JSON.stringify(serverUrl)};
+    const { server } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = server.address().port;
+
+    async function fetchPath(path) {
+      return new Promise((resolve, reject) => {
+        const req = http.request({
+          hostname: "127.0.0.1",
+          port,
+          path,
+        }, (res) => {
+          let data = "";
+          res.on("data", chunk => { data += chunk; });
+          res.on("end", () => resolve({
+            status: res.statusCode,
+            contentType: res.headers["content-type"],
+            headers: res.headers,
+            body: data,
+          }));
+        });
+        req.on("error", reject);
+        req.end();
+      });
+    }
+
+    try {
+      const serverMjs = await fetchPath("/server.mjs");
+      const traversal = await fetchPath("/../package.json");
+      const indexHtml = await fetchPath("/index.html");
+      const rootHtml = await fetchPath("/");
+      const stylesCss = await fetchPath("/styles.css");
+      const appJs = await fetchPath("/app.js");
+
+      console.log(JSON.stringify({
+        serverMjs: { status: serverMjs.status, body: JSON.parse(serverMjs.body) },
+        traversal: { status: traversal.status, body: JSON.parse(traversal.body) },
+        indexHtml: { status: indexHtml.status, contentType: indexHtml.contentType },
+        rootHtml: { status: rootHtml.status, contentType: rootHtml.contentType },
+        stylesCss: { status: stylesCss.status, contentType: stylesCss.contentType },
+        appJs: { status: appJs.status, contentType: appJs.contentType },
+      }));
+    } finally {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+  `);
+
+  const results = JSON.parse(output);
+  assert.equal(results.serverMjs.status, 404);
+  assert.deepEqual(results.serverMjs.body, { ok: false, error: "not_found" });
+  assert.equal(results.traversal.status, 404);
+  assert.deepEqual(results.traversal.body, { ok: false, error: "not_found" });
+  assert.equal(results.indexHtml.status, 200);
+  assert.equal(results.indexHtml.contentType, "text/html; charset=utf-8");
+  assert.equal(results.rootHtml.status, 200);
+  assert.equal(results.rootHtml.contentType, "text/html; charset=utf-8");
+  assert.equal(results.stylesCss.status, 200);
+  assert.equal(results.stylesCss.contentType, "text/css; charset=utf-8");
+  assert.equal(results.appJs.status, 200);
+  assert.equal(results.appJs.contentType, "text/javascript; charset=utf-8");
+});
+
+test("dashboard server includes security headers in static and api responses", () => {
+  const output = runServerCheck(`
+    import { once } from "node:events";
+    import http from "node:http";
+    import { startLoreBrowserServer } from ${JSON.stringify(serverUrl)};
+    const { server } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+    await once(server, "listening");
+    const port = server.address().port;
+
+    async function getHeaders(path) {
+      return new Promise((resolve, reject) => {
+        const req = http.request({
+          hostname: "127.0.0.1",
+          port,
+          path,
+        }, (res) => {
+          res.resume();
+          res.on("end", () => resolve({
+            status: res.statusCode,
+            headers: res.headers,
+          }));
+        });
+        req.on("error", reject);
+        req.end();
+      });
+    }
+
+    try {
+      const staticRes = await getHeaders("/");
+      const apiRes = await getHeaders("/api/health");
+      const notFoundRes = await getHeaders("/nonexistent.js");
+
+      console.log(JSON.stringify({
+        staticRes,
+        apiRes,
+        notFoundRes,
+      }));
+    } finally {
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+  `);
+
+  const results = JSON.parse(output);
+  for (const [key, res] of Object.entries(results)) {
+    assert.equal(res.headers["x-content-type-options"], "nosniff", `${key} X-Content-Type-Options`);
+    assert.equal(res.headers["x-frame-options"], "DENY", `${key} X-Frame-Options`);
+    assert.equal(res.headers["referrer-policy"], "no-referrer", `${key} Referrer-Policy`);
+    assert.equal(
+      res.headers["content-security-policy"],
+      "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+      `${key} Content-Security-Policy`
+    );
+  }
+});

--- a/tests/unit/browser-security.test.mjs
+++ b/tests/unit/browser-security.test.mjs
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import http from "node:http";
-import net from "node:net";
 import { describe, test } from "node:test";
 
 import { isAllowedHostHeader, startLoreBrowserServer } from "../../browser/server.mjs";
@@ -84,7 +83,7 @@ describe("browser dashboard security hardening", () => {
         assert.equal(response.headers["referrer-policy"], "no-referrer");
         assert.equal(
           response.headers["content-security-policy"],
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
         );
       } finally {
         server.closeAllConnections();
@@ -189,7 +188,7 @@ describe("browser dashboard security hardening", () => {
         assert.equal(response.headers["referrer-policy"], "no-referrer");
         assert.equal(
           response.headers["content-security-policy"],
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
         );
       } finally {
         server.closeAllConnections();
@@ -228,7 +227,7 @@ describe("browser dashboard security hardening", () => {
         assert.equal(response.headers["referrer-policy"], "no-referrer");
         assert.equal(
           response.headers["content-security-policy"],
-          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
         );
       } finally {
         server.closeAllConnections();

--- a/tests/unit/browser-security.test.mjs
+++ b/tests/unit/browser-security.test.mjs
@@ -1,0 +1,239 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import net from "node:net";
+import { describe, test } from "node:test";
+
+import { isAllowedHostHeader, startLoreBrowserServer } from "../../browser/server.mjs";
+
+describe("browser dashboard security hardening", () => {
+  describe("isAllowedHostHeader", () => {
+    test("accepts valid loopback hostnames with or without ports", () => {
+      assert.equal(isAllowedHostHeader("localhost"), true);
+      assert.equal(isAllowedHostHeader("localhost:43111"), true);
+      assert.equal(isAllowedHostHeader("LOCALHOST:80"), true);
+      assert.equal(isAllowedHostHeader("127.0.0.1"), true);
+      assert.equal(isAllowedHostHeader("127.0.0.1:43111"), true);
+      assert.equal(isAllowedHostHeader("127.0.0.1:8080"), true);
+      assert.equal(isAllowedHostHeader("::1"), true);
+      assert.equal(isAllowedHostHeader("[::1]"), true);
+      assert.equal(isAllowedHostHeader("[::1]:43111"), true);
+      assert.equal(isAllowedHostHeader("[::1]:8080"), true);
+      assert.equal(isAllowedHostHeader("  localhost:43111  "), true);
+    });
+
+    test("rejects unauthorized hostnames and rebinding attempts", () => {
+      assert.equal(isAllowedHostHeader("evil.com"), false);
+      assert.equal(isAllowedHostHeader("evil.com:43111"), false);
+      assert.equal(isAllowedHostHeader("attacker.com"), false);
+      assert.equal(isAllowedHostHeader("localhost.evil.com"), false);
+      assert.equal(isAllowedHostHeader("127.0.0.1.nip.io"), false);
+      assert.equal(isAllowedHostHeader("127.0.0.1.evil.com:43111"), false);
+      assert.equal(isAllowedHostHeader("0.0.0.0"), false);
+      assert.equal(isAllowedHostHeader("192.168.1.1"), false);
+      assert.equal(isAllowedHostHeader("[::2]"), false);
+      assert.equal(isAllowedHostHeader("[::2]:43111"), false);
+      assert.equal(isAllowedHostHeader(""), false);
+      assert.equal(isAllowedHostHeader("   "), false);
+      assert.equal(isAllowedHostHeader(null), false);
+      assert.equal(isAllowedHostHeader(undefined), false);
+      assert.equal(isAllowedHostHeader(123), false);
+      assert.equal(isAllowedHostHeader({}), false);
+    });
+
+    test("rejects malformed port specifications", () => {
+      assert.equal(isAllowedHostHeader("localhost:"), false);
+      assert.equal(isAllowedHostHeader("localhost:abc"), false);
+      assert.equal(isAllowedHostHeader("127.0.0.1:"), false);
+      assert.equal(isAllowedHostHeader("127.0.0.1:abc"), false);
+      assert.equal(isAllowedHostHeader("[::1]:"), false);
+      assert.equal(isAllowedHostHeader("[::1]:abc"), false);
+      assert.equal(isAllowedHostHeader("[::1"), false);
+    });
+  });
+
+  describe("HTTP server security enforcement", () => {
+    test("rejects requests with unauthorized host header with 403 Forbidden", async () => {
+      const { server } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+      await new Promise((resolve) => server.once("listening", resolve));
+      const port = server.address().port;
+
+      try {
+        const response = await new Promise((resolve, reject) => {
+          const req = http.request({
+            hostname: "127.0.0.1",
+            port,
+            path: "/api/health",
+            headers: { host: "evil.com:43111" },
+          }, (res) => {
+            let data = "";
+            res.on("data", (chunk) => { data += chunk; });
+            res.on("end", () => resolve({
+              status: res.statusCode,
+              headers: res.headers,
+              body: JSON.parse(data),
+            }));
+          });
+          req.on("error", reject);
+          req.end();
+        });
+
+        assert.equal(response.status, 403);
+        assert.deepEqual(response.body, { ok: false, error: "forbidden", message: "Invalid host header" });
+        assert.equal(response.headers["x-content-type-options"], "nosniff");
+        assert.equal(response.headers["x-frame-options"], "DENY");
+        assert.equal(response.headers["referrer-policy"], "no-referrer");
+        assert.equal(
+          response.headers["content-security-policy"],
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+        );
+      } finally {
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+      }
+    });
+
+    test("refuses to serve server.mjs returning 404", async () => {
+      const { server } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+      await new Promise((resolve) => server.once("listening", resolve));
+      const port = server.address().port;
+
+      try {
+        const response = await new Promise((resolve, reject) => {
+          const req = http.request({
+            hostname: "127.0.0.1",
+            port,
+            path: "/server.mjs",
+          }, (res) => {
+            let data = "";
+            res.on("data", (chunk) => { data += chunk; });
+            res.on("end", () => resolve({
+              status: res.statusCode,
+              headers: res.headers,
+              body: JSON.parse(data),
+            }));
+          });
+          req.on("error", reject);
+          req.end();
+        });
+
+        assert.equal(response.status, 404);
+        assert.deepEqual(response.body, { ok: false, error: "not_found" });
+        assert.equal(response.headers["x-content-type-options"], "nosniff");
+      } finally {
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+      }
+    });
+
+    test("refuses path traversal attempts outside static root returning 404", async () => {
+      const { server } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+      await new Promise((resolve) => server.once("listening", resolve));
+      const port = server.address().port;
+
+      try {
+        const response = await new Promise((resolve, reject) => {
+          const req = http.request({
+            hostname: "127.0.0.1",
+            port,
+            path: "/../package.json",
+          }, (res) => {
+            let data = "";
+            res.on("data", (chunk) => { data += chunk; });
+            res.on("end", () => resolve({
+              status: res.statusCode,
+              body: JSON.parse(data),
+            }));
+          });
+          req.on("error", reject);
+          req.end();
+        });
+
+        assert.equal(response.status, 404);
+        assert.deepEqual(response.body, { ok: false, error: "not_found" });
+      } finally {
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+      }
+    });
+
+    test("serves allowed static files with security headers", async () => {
+      const { server } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+      await new Promise((resolve) => server.once("listening", resolve));
+      const port = server.address().port;
+
+      try {
+        const response = await new Promise((resolve, reject) => {
+          const req = http.request({
+            hostname: "127.0.0.1",
+            port,
+            path: "/index.html",
+          }, (res) => {
+            let data = "";
+            res.on("data", (chunk) => { data += chunk; });
+            res.on("end", () => resolve({
+              status: res.statusCode,
+              contentType: res.headers["content-type"],
+              headers: res.headers,
+              body: data,
+            }));
+          });
+          req.on("error", reject);
+          req.end();
+        });
+
+        assert.equal(response.status, 200);
+        assert.equal(response.contentType, "text/html; charset=utf-8");
+        assert.match(response.body, /<!doctype html>/i);
+        assert.equal(response.headers["x-content-type-options"], "nosniff");
+        assert.equal(response.headers["x-frame-options"], "DENY");
+        assert.equal(response.headers["referrer-policy"], "no-referrer");
+        assert.equal(
+          response.headers["content-security-policy"],
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+        );
+      } finally {
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+      }
+    });
+
+    test("includes security headers in JSON API responses", async () => {
+      const { server } = startLoreBrowserServer({ db: { config: {} }, host: "127.0.0.1", port: 0 });
+      await new Promise((resolve) => server.once("listening", resolve));
+      const port = server.address().port;
+
+      try {
+        const response = await new Promise((resolve, reject) => {
+          const req = http.request({
+            hostname: "127.0.0.1",
+            port,
+            path: "/api/health",
+          }, (res) => {
+            let data = "";
+            res.on("data", (chunk) => { data += chunk; });
+            res.on("end", () => resolve({
+              status: res.statusCode,
+              headers: res.headers,
+              body: JSON.parse(data),
+            }));
+          });
+          req.on("error", reject);
+          req.end();
+        });
+
+        assert.equal(response.status, 200);
+        assert.equal(response.body.ok, true);
+        assert.equal(response.headers["x-content-type-options"], "nosniff");
+        assert.equal(response.headers["x-frame-options"], "DENY");
+        assert.equal(response.headers["referrer-policy"], "no-referrer");
+        assert.equal(
+          response.headers["content-security-policy"],
+          "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'",
+        );
+      } finally {
+        server.closeAllConnections();
+        await new Promise((resolve) => server.close(resolve));
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the browser dashboard HTTP server against DNS rebinding, restricts static file serving to an explicit asset allowlist, prevents arbitrary file disclosure (such as `/server.mjs`) and path traversal, and adds standard HTTP security headers across all responses.

## Motivation / related issue

The local browser dashboard HTTP server previously accepted any `Host` header, exposing it to potential DNS rebinding attacks from malicious sites visited in the user's browser. Additionally, `serveStatic` served `.mjs` source files (including `server.mjs`) and lacked defense-in-depth static asset filtering and security response headers.

## Changes

- **DNS Rebinding Protection (`browser/server.mjs`)**: Added incoming `Host` header validation in `createServer`. Rejects missing or non-loopback hostnames with `403 Forbidden` (`{ ok: false, error: "forbidden", message: "Invalid host header" }`) before any routing or processing occurs.
- **Static Asset Allowlist & Path Traversal Guard (`browser/server.mjs`)**: Restricted static file serving to an explicit allowlist (`.html`, `.css`, `.js`, `.svg`, `.ico`, `.png`, `.json`, `.woff`, `.woff2`). Disallowed `.mjs` files (specifically `/server.mjs` returns 404), and strictly enforced path containment within `STATIC_ROOT`.
- **HTTP Security Headers (`browser/server.mjs`)**: Added `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`, and `Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'` to both JSON API responses and static file responses.
- **Automated Verification**:
  - Updated `tests/smoke/browser-network.test.mjs` with tests for invalid/rebinding host rejection (403), valid loopback host acceptance, `/server.mjs` blocking (404), path traversal blocking, and presence of security headers.
  - Added unit test suite `tests/unit/browser-security.test.mjs` for granular in-process verification of `isAllowedHostHeader`, static asset restrictions, and response security headers.

## Testing

Verified with `npm run validate-schema`, `npm run lint`, `node --test tests/smoke/browser-network.test.mjs`, `node --test tests/unit/browser-security.test.mjs`, and full `npm test` (1159 tests passing).

```
npm notice run lore@0.15.1 validate-schema
npm notice run node scripts/validate-config-schema.mjs
✓ Schema and config defaults are in parity.
```

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run validate-schema` passes
- [x] Docs updated if behaviour changed