### PR TITLE
fix(extraction): eliminate false-positive directive capture and semantic drift

### DIFF
--- a/lib/memory/memory-scope.mjs
+++ b/lib/memory/memory-scope.mjs
@@ -43,11 +43,10 @@ const TRANSFERABLE_PATTERNS = [
 ];
 
 const GLOBAL_PREFERENCE_PATTERNS = [
-  /\bstyle\b/i,
-  /\btone\b/i,
-  /\bvoice\b/i,
-  /\brespond\b/i,
-  /\breply\b/i,
+  /\b(?:response|reply)\s+style\b/i,
+  /\btone\s+of\s+voice\b/i,
+  /\bstyle\s+preference\b/i,
+  /\b(?:voice\s+and\s+tone|tone\s+and\s+voice)\b/i,
   /\bhow you\b/i,
   /\bwhen i call you\b/i,
   /\bassistant\b/i,

--- a/lib/sessions/extraction-grammar.mjs
+++ b/lib/sessions/extraction-grammar.mjs
@@ -57,15 +57,17 @@ function isQuotedSentence(text) {
 }
 
 export function isNonDirectiveSentence(text, { allowConditions = false } = {}) {
-  return !text
-    || text.endsWith("?")
-    || isQuotedSentence(text)
-    || /^(?:suppose|imagine|assuming|should we|could we|would you|could you|can you|what if)\b/i.test(text)
-    || (!allowConditions && /^(?:if|unless|when)\b/i.test(text))
-    || /\b(?:don't|do not|never|not)\s+(?:really\s+)?prefer\b/i.test(text)
-    || /\bprefer\s+not\s+to\b/i.test(text)
-    || /\bi\s+meant\s+to\s+(?:ask|know|understand)\b/i.test(text)
-    || /\b(?:would|could|might|may)\s+(?:prefer|use|choose|avoid)\b/i.test(text);
+  const trimmed = String(text || "").trim();
+  return !trimmed
+    || trimmed.endsWith("?")
+    || /\?[^\w]*$/u.test(trimmed)
+    || isQuotedSentence(trimmed)
+    || /^(?:please\s+)?(?:suppose|imagine|assuming|should we|could we|would you|could you|can you|am i able|can i|what do i|how do i|is there|would there be|were the|what if)\b/i.test(trimmed)
+    || (!allowConditions && /^(?:if|unless|when)\b/i.test(trimmed))
+    || /\b(?:don't|do not|never|not)\s+(?:really\s+)?prefer\b/i.test(trimmed)
+    || /\bprefer\s+not\s+to\b/i.test(trimmed)
+    || /\bi\s+meant\s+to\s+(?:ask|know|understand)\b/i.test(trimmed)
+    || /\b(?:would|could|might|may)\s+(?:prefer|use|choose|avoid)\b/i.test(trimmed);
 }
 
 const EXPLICIT_SCOPE_PREAMBLE_PATTERN = /^(?:(?:for|in)\s+(?:this|the current)(?:\s+[a-z][a-z0-9_-]*){0,2}\s+(?:repo(?:sitory)?|project|app)|for\s+[a-z][a-z0-9_-]*(?:\s+[a-z][a-z0-9_-]*){0,4}|(?:across|in|for)\s+(?:all\s+)?(?:of\s+)?(?:my\s+)?(?:projects|repositories|repos)|make\s+(?:this\s+)?rule\s+global\s+across\s+(?:all\s+)?(?:projects|repositories|repos)|globally)\s*(?:,|:)\s*/i;
@@ -82,6 +84,9 @@ export function isHypotheticalDirectiveSentence(text) {
   return /\b(?:if|when|unless)\b[^.!?;]*\b(?:ever|were\s+to)\b|\b(?:might|could|would|may)\s+(?:prefer|use|choose|avoid)|\b(?:hypothetical|only\s+a\s+scenario|not\s+current\s+guidance)\b/i.test(text);
 }
 
+const TASK_CONSTRAINT_PATTERN = /\b(?:do not|don't)\s+(?:edit\s+(?:any\s+)?files?|make\s+(?:any\s+)?(?:code\s+)?changes?|run\s+(?:git\s+)?commit|run\s+git\b|commit(?:\s+(?:any\s+)?changes?)?|modify\s+(?:any\s+)?files?|change\s+(?:any\s+)?files?|touch\s+(?:any\s+)?files?)\b/i;
+const TASK_REQUEST_START_PATTERN = /^(?:please\s+)?(?:review|draft|audit|inspect|check\s+(?:if|whether|for|the|this|that|a|an|all)\b|find|search|analyze|examine|look\s+at|generate|write\s+(?:a|an)\s+(?:[a-z-]+\s+)?(?:commit|bug\s+report|reproduction|summary|test|script|function|draft|response|report|description|message|note|doc|review|patch)\b|explain\s+(?:how|what|why|the|this|that|to\s+me|whether|where)\b|tell\s+me\s+if|summarize)\b/i;
+
 // A topic (payments, failures, logging) does not make a request temporary.
 // Explicit duration wins; otherwise distinguish a particular incident artifact
 // from a standing rule about a class of work.
@@ -92,11 +97,17 @@ export function isOneOffDirectiveRequest(text) {
     || /^(?:for|during)\s+this\s+(?:incident|run|request|response|reply|answer|attempt|reproduction|session|task)\b/i.test(text)) {
     return true;
   }
+  if (TASK_CONSTRAINT_PATTERN.test(body) || TASK_CONSTRAINT_PATTERN.test(text)) {
+    return true;
+  }
   if (/^(?:as\s+(?:a\s+)?policy|in\s+(?:the\s+)?future|going\s+forward|from\s+now\s+on)\b/i.test(scopedText)
     || /^(?:please\s+)?(?:(?:i|we)\s+)?(?:always|never|prefer)\b/i.test(body)
     || /^(?:i|we)\s+(?:really\s+)?prefer\b|^my\s+preference\s+is\b|^remember\b/i.test(body)
     || /\b(?:each|every)\s+[a-z]|\b(?:all|future)\s+(?:requests|responses|reports|incidents|mutations|reviews|commits|runs|projects)\b/i.test(body)) {
     return false;
+  }
+  if (TASK_REQUEST_START_PATTERN.test(body) || TASK_REQUEST_START_PATTERN.test(text)) {
+    return true;
   }
   const target = body.split(/\s+(?:before|after|when|because|so)\s+/i)[0];
   return /\b(?:a|an|this|that|the)\s+(?:[a-z-]+\s+){0,2}(?:attachment|report|reproduction|request|response|incident|issue)\b(?=\s+(?:to|for|in|into|from|open|closed|updated|and|but)\b|[.,;]|$)/i.test(target)
@@ -111,12 +122,14 @@ export function isOneOffDirectiveRequest(text) {
 const POLICY_VERBS = "use|keep|require|preserve|redact|validate|run|schedule|key|read|sample|expose|represent|chain|store|fall back|send|write|version|name|classify|fail|return|rotate|encrypt|publish|renew|cap|inject|index|move|pause|distinguish|set|propagate|invalidate|limit|process|record|infer|retain|restore|parse|tell|link|label|acknowledge|explain|put|format|include|split|ask|check|make";
 const IMPERATIVE_RULE = new RegExp(`^(?:please\\s+)?(?:always\\s+)?(?:${POLICY_VERBS})\\s+.+$`, "i");
 const PROHIBITION_VERBS = `${POLICY_VERBS}|retry|commit|push|delete|merge|overwrite|ignore|assume|rely|start|choose|concatenate|cast|truncate|emit|print|drop|remove|disable`;
-const PROHIBITION = new RegExp(`^(?:please\\s+)?(?:do not|don't|never)\\s+(?:[a-z]+ly\\s+|ever\\s+)?(?:${PROHIBITION_VERBS})\\s+.+$`, "i");
+const PROHIBITION = new RegExp(`^(?:please\\s+)?(?:do not|don't|never)\\s+(?:[a-z]+ly\\s+|ever\\s+)?(?!(?:forget)\\b)(?:${PROHIBITION_VERBS})\\s+.+$`, "i");
 const SUBJECT_REQUIREMENT = /^[a-z][a-z0-9 ,'-]{1,90}?\s+(?:must|should)\s+(?:(?:not|never)\s+)?[a-z]+\b/i;
 
 export function standingDirectiveType(text) {
+  if (isNonDirectiveSentence(text, { allowConditions: true })) return null;
   const body = directiveBody(text);
-  if (PROHIBITION.test(body) || /^(?:please\s+)?(?:reject|avoid|stop)\s+.+/i.test(body)) return "rejected_approach";
+  const isDontForget = /^(?:please\s+)?(?:do not|don't)\s+forget\b/i.test(body);
+  if (!isDontForget && (PROHIBITION.test(body) || /^(?:please\s+)?(?:reject|avoid|stop)\s+.+/i.test(body))) return "rejected_approach";
   const mainClause = body.split(/\s+(?:because|so|before|after|when)\s+/i)[0];
   if (/\b(?:says|said|asked|whether|claims|claimed|suggests|suggested|proposes|proposed)\b/i.test(mainClause)) return null;
   if (SUBJECT_REQUIREMENT.test(mainClause)) {

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -79,7 +79,7 @@ const EXPLICIT_PREFERENCE_PATTERNS = [
 ];
 
 const EXPLICIT_REJECTION_PATTERNS = [
-  /^(?:please\s+)?(?:do not|don't|never)\s+(?:ever\s+)?(?:use|store|include|show|run|write|ask|check|preserve|make|put|retain|drop|remove|retry|commit|push|delete|merge|overwrite|ignore|assume|send|expose|log|add|change|modify|rely|return|start)\b.+$/i,
+  /^(?:please\s+)?(?:do not|don't|never)\s+(?:ever\s+)?(?!(?:forget)\b)(?:use|store|include|show|run|write|ask|check|preserve|make|put|retain|drop|remove|retry|commit|push|delete|merge|overwrite|ignore|assume|send|expose|log|add|change|modify|rely|return|start)\b.+$/i,
   /^(?:please\s+)?avoid\s+.+$/i,
   /^(?:please\s+)?stop\s+.+$/i,
   /^(?:i|we)\s+(?:do not|don't|never)\s+(?:want|like|use|need|store|include|see)\s+.+$/i,
@@ -90,6 +90,9 @@ const EXPLICIT_GLOBAL_SCOPE_PATTERN = /\b(?:for\s+all\s+work|(?:in|for)\s+(?:any
 function hasExplicitDirective(text, patterns) {
   const body = directiveBody(text);
   const correctionLead = /^actually\s*,?\s*(?:that(?:'s| is)\s+wrong\s*:\s*)/i.test(text);
+  if (patterns === EXPLICIT_REJECTION_PATTERNS && /^(?:please\s+)?(?:do not|don't)\s+forget\b/i.test(body)) {
+    return false;
+  }
   return !isNonDirectiveSentence(text, { allowConditions: true })
     && !isHypotheticalDirectiveSentence(text)
     && !isOneOffDirectiveRequest(text)
@@ -137,9 +140,13 @@ function buildDirectiveMemory({ sentence, scopeText = sentence, type, repository
 
 export function extractDirectiveMemoriesFromTurn({ turn, text, repository, sessionId, sourceRole }) {
   const memories = [];
+  const turnMessage = turn?.user_message ? normalizeTurnText(turn.user_message) : "";
+  const isTurnOneOff = Boolean(turnMessage && isOneOffDirectiveRequest(turnMessage));
   for (const rawSentence of splitSentences(text, { splitSemicolons: false })) {
     if (isNonDirectiveSentence(rawSentence, { allowConditions: true })
-      || isHypotheticalDirectiveSentence(rawSentence) || isOneOffDirectiveRequest(rawSentence)) {
+      || isHypotheticalDirectiveSentence(rawSentence)
+      || isOneOffDirectiveRequest(rawSentence)
+      || (isTurnOneOff && !/^(?:as\s+(?:a\s+)?policy|in\s+(?:the\s+)?future|going\s+forward|from\s+now\s+on)\b/i.test(rawSentence) && !/^(?:please\s+)?(?:(?:i|we)\s+)?(?:always|never|prefer)\b/i.test(rawSentence))) {
       continue;
     }
     const clauses = splitDirectiveClauses(rawSentence);
@@ -834,6 +841,13 @@ function extractAssistantGoalMemories(turns, repository, sessionId, config = nul
   return memories;
 }
 
+function cleanMistakeText(value) {
+  return normalizeText(value)
+    .replace(/^[\s.:,;'"“”‘’`-]+/, "")
+    .replace(/[\s.:,;'"“”‘’`-]+$/, "")
+    .trim();
+}
+
 function extractRecurringMistakeMemories(turns, repository, sessionId, config = null) {
   const memories = [];
   const seen = new Set();
@@ -846,8 +860,16 @@ function extractRecurringMistakeMemories(turns, repository, sessionId, config = 
       const match = body.match(/^(?:you keep|you are repeating|you(?:'re| are) making the same mistake)\b[:\s-]*(.+)$/i)
         ?? (/^you always\b/i.test(body) && /\b(?:ignor(?:e|ing)|forget(?:ting)?|fail(?:ing)?|wrong|stale|incorrect|broken|mistakes?)\b/i.test(body)
           ? body.match(/^you always\b[:\s-]*(.+)$/i) : null);
-      const mistake = normalizeText(match?.[1] ?? "");
-      if (mistake.length < 8) continue;
+      const rawMistake = match?.[1] ?? "";
+      const mistake = cleanMistakeText(rawMistake);
+      if (!mistake || mistake.length < 12) continue;
+      if (mistake.includes("?")) continue;
+      const mistakeWords = mistake.toLowerCase().split(/\s+/).filter(Boolean);
+      if (new Set(mistakeWords).size < 3) continue;
+      if (/^(?:sad\s+times|bad\s+times|oh\s+well|never\s+mind|ugh|oops|yikes|haha|lol|sigh)\b/i.test(mistake)) continue;
+      if (!/\b(?:[a-z]+ing|[a-z]+ed|break|fail|forget|ignore|miss|drop|delete|change|modify|revert|use|create|add|run|stop|make|edit|write|commit|push|overwrite|assume|leave|skip|lose|cause|rely|repeat|introduce|do|did|does)\b/i.test(mistake)) {
+        continue;
+      }
       const key = mistake.toLowerCase();
       if (seen.has(key)) continue;
       seen.add(key);

--- a/tests/unit/extraction-grammar.test.mjs
+++ b/tests/unit/extraction-grammar.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  isNonDirectiveSentence,
+  isOneOffDirectiveRequest,
+  standingDirectiveType,
+} from "../../lib/sessions/extraction-grammar.mjs";
+
+describe("extraction grammar accuracy", () => {
+  test("identifies question forms as non-directive sentences", () => {
+    assert.equal(isNonDirectiveSentence("what do I prefer?"), true);
+    assert.equal(isNonDirectiveSentence("what do I prefer"), true);
+    assert.equal(isNonDirectiveSentence("Am I able to toggle it on and off?"), true);
+    assert.equal(isNonDirectiveSentence("can I use tabs instead of spaces?"), true);
+    assert.equal(isNonDirectiveSentence("how do I configure local storage?"), true);
+    assert.equal(isNonDirectiveSentence("is there a cached build available?"), true);
+    assert.equal(isNonDirectiveSentence("would there be a better language to use rather than Go"), true);
+    assert.equal(isNonDirectiveSentence("were the chinese language ones useful though?"), true);
+  });
+
+  test("does not classify questions as standing directives", () => {
+    assert.equal(standingDirectiveType("what do I prefer?"), null);
+    assert.equal(standingDirectiveType("Am I able to toggle it on and off?"), null);
+    assert.equal(standingDirectiveType("is there a way to override this?"), null);
+  });
+
+  test("treats don't forget as a positive reminder and never a prohibition", () => {
+    assert.notEqual(standingDirectiveType("Don't forget to monitor for review comments too"), "rejected_approach");
+    assert.notEqual(standingDirectiveType("Do not forget to run migrations"), "rejected_approach");
+  });
+
+  test("detects task requests and negative task constraints as one-off directives", () => {
+    assert.equal(isOneOffDirectiveRequest("Review git diff --cached... Do not edit files."), true);
+    assert.equal(isOneOffDirectiveRequest("Do not edit files."), true);
+    assert.equal(isOneOffDirectiveRequest("Draft a conventional commit message... do not run git commit."), true);
+    assert.equal(isOneOffDirectiveRequest("do not run git commit."), true);
+    assert.equal(isOneOffDirectiveRequest("do not make any code changes"), true);
+    assert.equal(isOneOffDirectiveRequest("Audit the authentication flow and report back."), true);
+    assert.equal(isOneOffDirectiveRequest("Inspect the error logs from the latest run."), true);
+    assert.equal(isOneOffDirectiveRequest("Check if all endpoints are responding."), true);
+    assert.equal(isOneOffDirectiveRequest("Find all usages of deprecated methods."), true);
+    assert.equal(isOneOffDirectiveRequest("Search for broken links across documentation."), true);
+    assert.equal(isOneOffDirectiveRequest("Analyze the performance bottleneck in database queries."), true);
+    assert.equal(isOneOffDirectiveRequest("Examine the commit history for regressions."), true);
+    assert.equal(isOneOffDirectiveRequest("Look at the PR review feedback."), true);
+    assert.equal(isOneOffDirectiveRequest("Generate a summary table of test results."), true);
+    assert.equal(isOneOffDirectiveRequest("Write a unit test covering this edge case."), true);
+    assert.equal(isOneOffDirectiveRequest("Explain how the memory subsystem works."), true);
+    assert.equal(isOneOffDirectiveRequest("Tell me if any tests failed."), true);
+    assert.equal(isOneOffDirectiveRequest("Summarize the main changes on this branch."), true);
+  });
+
+  test("preserves standing policies despite task verb presence", () => {
+    assert.equal(isOneOffDirectiveRequest("As a policy, always check test coverage before PRs."), false);
+    assert.equal(isOneOffDirectiveRequest("In future, always review all pull requests."), false);
+    assert.equal(isOneOffDirectiveRequest("Going forward, never commit secrets to the repository."), false);
+  });
+});

--- a/tests/unit/rule-extractor.test.mjs
+++ b/tests/unit/rule-extractor.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import { extractSessionMemories } from "../../lib/sessions/rule-extractor.mjs";
+import { MEMORY_SCOPE, classifySemanticMemory } from "../../lib/memory/memory-scope.mjs";
+
+function extractTurn(userMessage, { repository = "owner/repo", sessionId = "test-session" } = {}) {
+  return extractSessionMemories({
+    sessionId,
+    repository,
+    sessionArtifacts: {
+      session: {
+        repository,
+        branch: "main",
+        summary: "Test session",
+        updated_at: "2026-09-07T12:00:00.000Z",
+      },
+      checkpoints: [],
+      files: [],
+      refs: [],
+      turns: [{
+        turn_index: 1,
+        user_message: userMessage,
+        assistant_response: "Understood.",
+      }],
+    },
+    workspace: { workspace: null },
+  });
+}
+
+describe("rule-extractor extraction accuracy and scoping", () => {
+  test("Review git diff --cached... Do not edit files. is NOT extracted as a rejected_approach or standing directive", () => {
+    const result = extractTurn("Review git diff --cached, falling back to git diff if nothing is staged. Return every actionable finding as path:line with severity, covering logic bugs, security issues, error-handling gaps, and edge cases. Do not edit files.");
+    const directives = result.semanticMemories.filter((m) =>
+      m.type === "rejected_approach" || m.type === "user_preference"
+    );
+    assert.deepEqual(directives, []);
+  });
+
+  test("Draft a conventional commit message... do not run git commit. is NOT extracted as a rejected_approach", () => {
+    const result = extractTurn("Draft a conventional commit message for the staged changes, but do not run git commit.");
+    const rejections = result.semanticMemories.filter((m) => m.type === "rejected_approach");
+    assert.deepEqual(rejections, []);
+  });
+
+  test("Don't forget to monitor for review comments too is NOT extracted as a rejected_approach", () => {
+    const result = extractTurn("Don't forget to monitor for review comments too");
+    const rejections = result.semanticMemories.filter((m) => m.type === "rejected_approach");
+    assert.deepEqual(rejections, []);
+  });
+
+  test("what do I prefer? is NOT extracted as a user_preference", () => {
+    const result = extractTurn("what do I prefer?");
+    const preferences = result.semanticMemories.filter((m) => m.type === "user_preference");
+    assert.deepEqual(preferences, []);
+  });
+
+  test("Am I able to toggle it on and off? is NOT extracted as a rejected_approach", () => {
+    const result = extractTurn("Am I able to toggle it on and off?");
+    const rejections = result.semanticMemories.filter((m) => m.type === "rejected_approach");
+    assert.deepEqual(rejections, []);
+  });
+
+  test(". Sad times or stopping? is NOT extracted as a recurring_mistake", () => {
+    const result1 = extractTurn("You keep: . Sad times");
+    const mistakes1 = result1.semanticMemories.filter((m) => m.type === "recurring_mistake");
+    assert.deepEqual(mistakes1, []);
+
+    const result2 = extractTurn("You keep stopping?");
+    const mistakes2 = result2.semanticMemories.filter((m) => m.type === "recurring_mistake");
+    assert.deepEqual(mistakes2, []);
+
+    const result3 = extractTurn("You keep - 'menace' maybe?");
+    const mistakes3 = result3.semanticMemories.filter((m) => m.type === "recurring_mistake");
+    assert.deepEqual(mistakes3, []);
+  });
+
+  test("legitimate recurring mistake feedback is still extracted", () => {
+    const result = extractTurn("You keep using semicolons in this Python repository.");
+    const mistakes = result.semanticMemories.filter((m) => m.type === "recurring_mistake");
+    assert.equal(mistakes.length, 1);
+    assert.equal(mistakes[0].content, "Recurring mistake to avoid: using semicolons in this Python repository");
+    assert.equal(mistakes[0].scope, MEMORY_SCOPE.REPO);
+  });
+
+  test("Repository preferences mentioning respond do NOT get promoted to global scope without explicit cross-project wording", () => {
+    const repoPref = classifySemanticMemory({
+      type: "user_preference",
+      repository: "owner/my-repo",
+      content: "Always respond with typed response models in this API.",
+    });
+    assert.equal(repoPref.scope, MEMORY_SCOPE.REPO);
+    assert.equal(repoPref.repository, "owner/my-repo");
+
+    const globalPref = classifySemanticMemory({
+      type: "user_preference",
+      repository: "owner/my-repo",
+      content: "Across all projects, always respond with typed response models.",
+    });
+    assert.equal(globalPref.scope, MEMORY_SCOPE.GLOBAL);
+    assert.equal(globalPref.repository, null);
+
+    const phraseGlobalPref = classifySemanticMemory({
+      type: "user_preference",
+      repository: "owner/my-repo",
+      content: "My response style should be concise and direct.",
+    });
+    assert.equal(phraseGlobalPref.scope, MEMORY_SCOPE.GLOBAL);
+    assert.equal(phraseGlobalPref.repository, null);
+  });
+});


### PR DESCRIPTION
## Summary

Eliminates false-positive directive extraction and global scope escalation caused by task instructions with negative constraints, question sentences, and generic communicative words.

## Motivation / related issue

Fixes several false-positive extraction bugs:
1. Task prompts with negative constraints (e.g. `Review git diff... Return every actionable finding... Do not edit files.`) were being extracted as standing `rejected_approach` rules.
2. Question sentences (e.g. `With the lore extension, is the personality part of the context always passed to the model?`) were being extracted as directives due to containing words like `always`.
3. Question sentences containing generic words like `response` were erroneously escalating to global scope.
4. "Don't forget" reminders (e.g. `Don't forget to check the error log.`) were incorrectly classified as `rejected_approach` prohibitions.
5. Conversational task commands in user turns were leaking into standing rule extractions.
6. Casual utterances and sentence fragments were captured as recurring mistakes without proper validation.

## Changes

- `lib/sessions/extraction-grammar.mjs`:
  - Extended `isNonDirectiveSentence` to reject question forms (ending with `?`, or starting with question intros like `am i able`, `can i`, `what do i`, `how do i`, `is there`, `would there be`, `were the`, `suppose`, `what if`).
  - Extended `isOneOffDirectiveRequest` to identify task prompts and negative constraints (`do not edit files`, `do not make code changes`, `do not run git commit`, etc.) and task request verbs (`review`, `draft`, `audit`, `inspect`, `check`, `find`, `search`, `analyze`, `examine`, `look at`, `generate`, `write a [commit|test|script|summary...]`, `explain`, `tell me if`, `summarize`).
  - Guarded `PROHIBITION` and `standingDirectiveType` so "don't forget" is never treated as a `rejected_approach`.
  - Added `{ allowConditions: true }` support when checking non-directive sentences in `standingDirectiveType` to preserve conditional standing rules.
- `lib/sessions/rule-extractor.mjs`:
  - Updated `EXPLICIT_REJECTION_PATTERNS` and `hasExplicitDirective` to reject `don't forget` patterns.
  - In `extractDirectiveMemoriesFromTurn`, checked whether the overall turn is a one-off task request (`isTurnOneOff`) so incidental imperative sentences in a task prompt are not extracted as standing rules unless explicitly marked with policy markers.
  - In `extractRecurringMistakeMemories`, added cleaner punctuation stripping, minimum character/unique word thresholds, question rejection, conversational filler filters, and action/state verb requirements.
- `lib/memory/memory-scope.mjs`:
  - Tightened `GLOBAL_PREFERENCE_PATTERNS` to remove bare single-word triggers (`respond`, `reply`, `style`, `voice`, `tone`), replacing them with phrase-level triggers (`response/reply style`, `tone of voice`, `style preference`, `voice and tone`).
- Added unit tests:
  - `tests/unit/extraction-grammar.test.mjs`
  - `tests/unit/rule-extractor.test.mjs`

## Testing

```
✓ Schema and config defaults are in parity.
```

- `npm run lint`: 0 warnings, 0 errors.
- `npm run validate-schema`: passed.
- `npm test`: 1,160 passing tests across 220 suites (0 failures).

## Checklist

- [x] PR title follows Conventional Commits
- [x] `npm run validate-schema` passes
- [ ] Docs updated if behaviour changed