### PR TITLE
fix: close memory scope and recovery gaps

### DIFF
--- a/lib/db/db-improvement-artifacts.mjs
+++ b/lib/db/db-improvement-artifacts.mjs
@@ -176,8 +176,8 @@ export function buildImprovementArtifactEpisode(artifact, repository) {
   // artifact created elsewhere. Legacy artifacts are eligible only when their
   // own stored provenance names one unambiguous repository.
   const normalizedRepository = uniqueRepositories.length === 1 ? uniqueRepositories[0] : null;
-  if (uniqueRepositories.length !== 1) return null;
-  if (repository && normalizedRepository !== normalizeRepository(repository)) return null;
+  const requestRepository = normalizeRepository(repository);
+  if (!requestRepository || uniqueRepositories.length !== 1 || normalizedRepository !== requestRepository) return null;
   const decisions = buildEpisodeDecisions(title, summary, rankedOutcome, missCategory, expectedSnippets);
   const actions = buildEpisodeActions(prompt, caseId, artifact.source_kind);
   return {

--- a/lib/db/db-improvement-artifacts.mjs
+++ b/lib/db/db-improvement-artifacts.mjs
@@ -127,6 +127,7 @@ export function buildImprovementArtifactFilters({
   reviewState,
   hasProposal,
   updatedBefore,
+  repository,
 }) {
   const where = [];
   const params = [];
@@ -135,6 +136,15 @@ export function buildImprovementArtifactFilters({
   addStringFilter(where, params, "source_case_id", sourceCaseId);
   addStringFilter(where, params, "status", status, (v) => normalizeImprovementStatus(v, IMPROVEMENT_STATUS.ACTIVE));
   addStringFilter(where, params, "review_state", reviewState, normalizeImprovementReviewState);
+  if (repository !== undefined) {
+    const normalizedRepository = normalizeRepository(repository);
+    if (normalizedRepository) {
+      where.push("repository = ?");
+      params.push(normalizedRepository);
+    } else {
+      where.push("(repository IS NULL OR repository = '')");
+    }
+  }
   if (hasProposal === true) {
     where.push("proposal_path IS NOT NULL");
   } else if (hasProposal === false) {
@@ -155,7 +165,19 @@ export function buildImprovementArtifactEpisode(artifact, repository) {
   const title = normalizeText(artifact.title);
   const updatedAt = artifact.updated_at ?? nowIso();
   const dateKey = String(updatedAt).slice(0, 10);
-  const normalizedRepository = normalizeRepository(repository);
+  const evidenceRepositories = [
+    artifact.repository,
+    artifact.evidence?.repository,
+    artifact.evidence?.originRepository,
+    artifact.trace?.repository,
+  ].map(normalizeRepository).filter(Boolean);
+  const uniqueRepositories = [...new Set(evidenceRepositories)];
+  // A retrieval request must never lend its repository identity to an
+  // artifact created elsewhere. Legacy artifacts are eligible only when their
+  // own stored provenance names one unambiguous repository.
+  const normalizedRepository = uniqueRepositories.length === 1 ? uniqueRepositories[0] : null;
+  if (uniqueRepositories.length !== 1) return null;
+  if (repository && normalizedRepository !== normalizeRepository(repository)) return null;
   const decisions = buildEpisodeDecisions(title, summary, rankedOutcome, missCategory, expectedSnippets);
   const actions = buildEpisodeActions(prompt, caseId, artifact.source_kind);
   return {
@@ -193,6 +215,7 @@ export function upsertImprovementArtifactImpl(db, {
   evidence = {},
   trace = {},
   linkedMemoryId = null,
+  repository = null,
 }) {
   const normalizedSourceCaseId = validateRequiredStringField(sourceCaseId, "sourceCaseId");
   const normalizedTitle = validateRequiredStringField(title, "title");
@@ -216,6 +239,7 @@ export function upsertImprovementArtifactImpl(db, {
           evidence_json = ?,
           trace_json = ?,
           linked_memory_id = COALESCE(?, linked_memory_id),
+          repository = COALESCE(?, repository),
           updated_at = ?
       WHERE id = ?
     `).run(
@@ -224,6 +248,7 @@ export function upsertImprovementArtifactImpl(db, {
       JSON.stringify(evidence ?? {}),
       JSON.stringify(trace ?? {}),
       linkedMemoryId ?? null,
+      repository ?? null,
       timestamp,
       activeExisting.id,
     );
@@ -234,8 +259,8 @@ export function upsertImprovementArtifactImpl(db, {
   db.prepare(`
     INSERT INTO improvement_backlog (
       id, source_case_id, source_kind, title, summary, evidence_json, trace_json,
-      status, linked_memory_id, superseded_by, created_at, updated_at, resolved_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, NULL, ?, ?, NULL)
+      status, linked_memory_id, repository, superseded_by, created_at, updated_at, resolved_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, NULL, ?, ?, NULL)
   `).run(
     artifactId,
     normalizedSourceCaseId,
@@ -245,6 +270,7 @@ export function upsertImprovementArtifactImpl(db, {
     JSON.stringify(evidence ?? {}),
     JSON.stringify(trace ?? {}),
     linkedMemoryId ?? null,
+    repository ?? null,
     timestamp,
     timestamp,
   );

--- a/lib/db/db-improvement-artifacts.mjs
+++ b/lib/db/db-improvement-artifacts.mjs
@@ -81,7 +81,8 @@ function nowIso() {
 }
 
 function parseEpisodeEvidenceFields(artifact) {
-  const evidence = parseJsonObject(artifact.evidence_json);
+  const evidence = parseArtifactObject(artifact, "evidence", "evidence_json");
+  const trace = parseArtifactObject(artifact, "trace", "trace_json");
   const expectedEvidence = typeof evidence.expectedEvidence === "object"
     && evidence.expectedEvidence !== null
     && !Array.isArray(evidence.expectedEvidence)
@@ -99,6 +100,21 @@ function parseEpisodeEvidenceFields(artifact) {
     rankedOutcome: normalizeText(evidence.rankingOutcome),
     missCategory: normalizeText(evidence.missCategory),
     prompt: normalizeText(evidence.prompt),
+    evidenceRepositories: [
+      artifact.repository,
+      evidence.repository,
+      evidence.originRepository,
+      trace.repository,
+      trace.originRepository,
+    ].map(normalizeRepository).filter(Boolean),
+  };
+}
+
+function parseArtifactObject(artifact, directKey, persistedKey) {
+  const direct = artifact?.[directKey];
+  return {
+    ...parseJsonObject(artifact?.[persistedKey]),
+    ...(direct && typeof direct === "object" && !Array.isArray(direct) ? direct : {}),
   };
 }
 
@@ -159,18 +175,12 @@ export function buildImprovementArtifactFilters({
 }
 
 export function buildImprovementArtifactEpisode(artifact, repository) {
-  const { expectedSnippets, rankedOutcome, missCategory, prompt } = parseEpisodeEvidenceFields(artifact);
+  const { expectedSnippets, rankedOutcome, missCategory, prompt, evidenceRepositories } = parseEpisodeEvidenceFields(artifact);
   const caseId = normalizeText(artifact.source_case_id);
   const summary = normalizeText(artifact.summary);
   const title = normalizeText(artifact.title);
   const updatedAt = artifact.updated_at ?? nowIso();
   const dateKey = String(updatedAt).slice(0, 10);
-  const evidenceRepositories = [
-    artifact.repository,
-    artifact.evidence?.repository,
-    artifact.evidence?.originRepository,
-    artifact.trace?.repository,
-  ].map(normalizeRepository).filter(Boolean);
   const uniqueRepositories = [...new Set(evidenceRepositories)];
   // A retrieval request must never lend its repository identity to an
   // artifact created elsewhere. Legacy artifacts are eligible only when their

--- a/lib/db/db-memory-lifecycle.mjs
+++ b/lib/db/db-memory-lifecycle.mjs
@@ -1,4 +1,5 @@
 import crypto from "node:crypto";
+import { collectRetiredDecisionEvidenceKeys } from "../sessions/decision-subject.mjs";
 
 function normalizeLifecycleText(value) {
   const text = String(value ?? "").trim();
@@ -219,6 +220,28 @@ export function reconcileGeneratedMemories(owner, { sessionId, repository, memor
     return owner.withSemanticMemoryTransaction(() => reconcileGeneratedMemories(owner, { sessionId, repository, memories, retiredEvidenceKeys }));
   }
   const timestamp = new Date().toISOString();
+  // Reversals can arrive after bounded transcript capture has evicted the
+  // original decision. Resolve against persisted evidence from this session.
+  const persistedDecisions = owner.db.prepare(`
+    SELECT sm.type, sm.content, sm.source_turn_index, sm.scope, sm.repository,
+      sm.metadata_json, me.evidence_key
+    FROM semantic_memory sm
+    JOIN memory_evidence me ON me.memory_id = sm.id AND me.retired_at IS NULL
+    JOIN session_evidence se ON se.evidence_key = me.evidence_key AND se.retired_at IS NULL
+    WHERE se.session_id = ? AND sm.type = 'decision' AND sm.superseded_by IS NULL
+      AND (sm.repository = ? OR (sm.repository IS NULL AND ? IS NULL))
+  `).all(sessionId, repository ?? null, repository ?? null).map((row) => ({
+    ...row,
+    metadata: parseJson(row.metadata_json) ?? {},
+    evidence: { key: row.evidence_key },
+  }));
+  const resolvedRetiredEvidenceKeys = new Set([
+    ...(Array.isArray(retiredEvidenceKeys) ? retiredEvidenceKeys : []),
+    ...collectRetiredDecisionEvidenceKeys([
+      ...persistedDecisions,
+      ...(Array.isArray(memories) ? memories : []),
+    ]),
+  ]);
   const linked = [];
   for (const memory of Array.isArray(memories) ? memories : []) {
     const evidence = normalizeEvidence({ sessionId, memory, repository });
@@ -273,7 +296,7 @@ export function reconcileGeneratedMemories(owner, { sessionId, repository, memor
     `).run(memoryId, evidence.key, timestamp);
     linked.push(memoryId);
   }
-  for (const key of Array.isArray(retiredEvidenceKeys) ? retiredEvidenceKeys : []) {
+  for (const key of resolvedRetiredEvidenceKeys) {
     if (typeof key !== "string" || !key.trim()) continue;
     owner.db.prepare("UPDATE session_evidence SET retired_at = ? WHERE evidence_key = ?").run(timestamp, key);
     owner.db.prepare("UPDATE memory_evidence SET retired_at = ? WHERE evidence_key = ?").run(timestamp, key);

--- a/lib/db/db.mjs
+++ b/lib/db/db.mjs
@@ -2302,6 +2302,7 @@ export class LoreDb {
     evidence = {},
     trace = {},
     linkedMemoryId = null,
+    repository = null,
   }) {
     this.ensureOpen();
     return upsertImprovementArtifactImpl(this.db, {
@@ -2312,6 +2313,7 @@ export class LoreDb {
       evidence,
       trace,
       linkedMemoryId,
+      repository,
     });
   }
 
@@ -2370,6 +2372,7 @@ export class LoreDb {
         trace_json,
         status,
         linked_memory_id,
+        repository,
         superseded_by,
         proposal_type,
         proposal_path,
@@ -2429,6 +2432,7 @@ export class LoreDb {
     reviewState,
     hasProposal,
     updatedBefore,
+    repository,
     sort = "updated_desc",
     limit = 10,
   } = {}) {
@@ -2440,6 +2444,7 @@ export class LoreDb {
       reviewState,
       hasProposal,
       updatedBefore,
+      repository,
     });
     params.push(limit);
     const rows = this.db.prepare(`
@@ -2453,6 +2458,7 @@ export class LoreDb {
         trace_json,
         status,
         linked_memory_id,
+        repository,
         superseded_by,
         proposal_type,
         proposal_path,
@@ -4464,7 +4470,8 @@ export class LoreDb {
         const evidence = parseJsonObject(artifact.evidence_json);
         return evidence.caseType === "ranking_target";
       })
-      .map((artifact) => buildImprovementArtifactEpisode(artifact, repository));
+      .map((artifact) => buildImprovementArtifactEpisode(artifact, repository))
+      .filter(Boolean);
     const rawExactMatches = this.searchEpisodes({
       query: lexicalQuery, repository, includeOtherRepositories, scopes, limit: Math.max(limit * 2, 8),
     });

--- a/lib/inference/local-inference.mjs
+++ b/lib/inference/local-inference.mjs
@@ -100,6 +100,9 @@ async function requestLocalInference({
         "content-type": "application/json",
       },
       body: JSON.stringify(body(normalized)),
+      // The endpoint is required to remain loopback-only. Following a
+      // redirect could send private prompts or memory content elsewhere.
+      redirect: "error",
       signal: controller.signal,
     });
     const abortPromise = signal

--- a/lib/maintenance/diagnostics.mjs
+++ b/lib/maintenance/diagnostics.mjs
@@ -671,6 +671,7 @@ function persistValidationFailureArtifact({ runtime, definition, evaluation, exp
     title: definition.title,
     summary,
     linkedMemoryId,
+    repository: definition.repository ?? runtime.repository ?? null,
     evidence: {
       mode: definition.mode,
       prompt: definition.prompt,
@@ -732,6 +733,7 @@ function persistReplayFailureArtifact({
     title: definition.title,
     summary: summaryParts.join(" | "),
     linkedMemoryId,
+    repository: definition.repository ?? runtime.repository ?? null,
     evidence: buildReplayFailureEvidence({
       definition,
       explanation,

--- a/lib/runtime/session-source.mjs
+++ b/lib/runtime/session-source.mjs
@@ -27,19 +27,25 @@ export class EpisodeSessionSource extends SessionSource {
       return [];
     }
     const numericLimit = Math.max(1, Number(limit) || 5);
-    const scoped = Boolean(repository) && includeOtherRepositories !== true;
-    const sql = scoped
+    const scoped = includeOtherRepositories !== true;
+    const sql = scoped && repository
       ? `SELECT session_id, repository, branch, summary, created_at, updated_at
          FROM episode_digest
-         WHERE date_key = ? AND (repository = ? OR repository IS NULL)
+         WHERE date_key = ? AND (repository = ? OR (scope = 'global' AND (repository IS NULL OR repository = '')))
          ORDER BY updated_at DESC, created_at DESC
          LIMIT ?`
+      : scoped
+        ? `SELECT session_id, repository, branch, summary, created_at, updated_at
+           FROM episode_digest
+           WHERE date_key = ? AND scope = 'global' AND (repository IS NULL OR repository = '')
+           ORDER BY updated_at DESC, created_at DESC
+           LIMIT ?`
       : `SELECT session_id, repository, branch, summary, created_at, updated_at
          FROM episode_digest
          WHERE date_key = ?
          ORDER BY updated_at DESC, created_at DESC
          LIMIT ?`;
-    const params = scoped ? [dateKey, repository, numericLimit] : [dateKey, numericLimit];
+    const params = scoped && repository ? [dateKey, repository, numericLimit] : [dateKey, numericLimit];
     try {
       const rows = this.db.db.prepare(sql).all(...params);
       return rows.map((row) => ({
@@ -69,7 +75,7 @@ export class EpisodeSessionSource extends SessionSource {
     const numericLimit = Math.max(1, Number(limit) || 5);
     try {
       if (typeof this.db.searchEpisodes === "function") {
-        const rows = this.db.searchEpisodes({ query: prompt, repository, limit: numericLimit });
+        const rows = this.db.searchEpisodes({ query: prompt, repository, includeOtherRepositories: false, limit: numericLimit });
         return rows.map((row) => ({
           session_id: row.session_id ?? row.id,
           repository: row.repository ?? null,

--- a/lib/sessions/backfill.mjs
+++ b/lib/sessions/backfill.mjs
@@ -4,6 +4,8 @@ import { enhanceSessionExtractionWithLocalInference } from "../inference/local-i
 import { setTimeout as delay } from "node:timers/promises";
 import { clampInteger } from "../core/config.mjs";
 import { readAutoWriteImprovementGoalsEnabled } from "../rollout/rollout-flags.mjs";
+import { fileURLToPath } from "node:url";
+import { shellQuote } from "../clients/cli-hook-config.mjs";
 
 /**
  * Generate a lightweight unique token for deferred extraction lease ownership.
@@ -103,6 +105,7 @@ function buildSessionImprovementArtifact({ sessionId, memory, episodeDigest, lin
     title: `${sourceLabel} ${descriptor.title}`,
     summary: `${descriptor.summaryLabel}: ${descriptor.detailValue}`,
     linkedMemoryId,
+    repository,
     evidence: buildSessionImprovementEvidence({
       sessionId,
       repository,
@@ -789,10 +792,17 @@ export function restoreControlledBackfillRun({
   if (!run.snapshot_path) {
     throw new Error(`backfill run ${runId} does not have a snapshot path`);
   }
-  const restored = db.restoreFromBackup(run.snapshot_path);
+  const recoveryScript = fileURLToPath(new URL("../../scripts/recover.mjs", import.meta.url));
+  const target = db.config?.paths?.derivedStorePath ?? "~/.local/share/lore/lore.db";
   return {
     runId,
     snapshotPath: run.snapshot_path,
-    ...restored,
+    recoveryCommand: [
+      shellQuote(process.execPath), shellQuote(recoveryScript), "restore",
+      "--from", shellQuote(run.snapshot_path),
+      "--derived-store-path", shellQuote(target),
+      "--write", "--clients-stopped",
+    ].join(" "),
+    offline: true,
   };
 }

--- a/lib/sessions/backfill.mjs
+++ b/lib/sessions/backfill.mjs
@@ -3,6 +3,7 @@ import { extractSessionMemories } from "./rule-extractor.mjs";
 import { enhanceSessionExtractionWithLocalInference } from "../inference/local-inference-extraction.mjs";
 import { setTimeout as delay } from "node:timers/promises";
 import { clampInteger } from "../core/config.mjs";
+import { resolveLorePaths } from "../core/lore-paths.mjs";
 import { readAutoWriteImprovementGoalsEnabled } from "../rollout/rollout-flags.mjs";
 import { fileURLToPath } from "node:url";
 import { shellQuote } from "../clients/cli-hook-config.mjs";
@@ -793,7 +794,7 @@ export function restoreControlledBackfillRun({
     throw new Error(`backfill run ${runId} does not have a snapshot path`);
   }
   const recoveryScript = fileURLToPath(new URL("../../scripts/recover.mjs", import.meta.url));
-  const target = db.config?.paths?.derivedStorePath ?? "~/.local/share/lore/lore.db";
+  const target = db.config?.paths?.derivedStorePath ?? resolveLorePaths().derivedStorePath;
   return {
     runId,
     snapshotPath: run.snapshot_path,

--- a/lib/sessions/backfill.mjs
+++ b/lib/sessions/backfill.mjs
@@ -794,7 +794,10 @@ export function restoreControlledBackfillRun({
     throw new Error(`backfill run ${runId} does not have a snapshot path`);
   }
   const recoveryScript = fileURLToPath(new URL("../../scripts/recover.mjs", import.meta.url));
-  const target = db.config?.paths?.derivedStorePath ?? resolveLorePaths().derivedStorePath;
+  const configuredTarget = db.config?.paths?.derivedStorePath;
+  const target = typeof configuredTarget === "string" && configuredTarget.trim()
+    ? configuredTarget
+    : resolveLorePaths().derivedStorePath;
   return {
     runId,
     snapshotPath: run.snapshot_path,

--- a/lib/sessions/extraction-grammar.mjs
+++ b/lib/sessions/extraction-grammar.mjs
@@ -62,13 +62,12 @@ function isQuotedSentence(text) {
 
 export function directiveSentences(text, options = {}) {
   const withoutFencedCode = String(text || "").replace(/```[\s\S]*?```/gu, "\n");
-  const lines = withoutFencedCode.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean);
-  const bullets = lines
-    .map((line) => line.match(/^(?:[-*+]\s+|\d+[.)]\s+)(.+)$/u)?.[1])
-    .filter(Boolean);
-  return bullets.length > 0
-    ? bullets.flatMap((line) => splitSentences(line, options))
-    : splitSentences(withoutFencedCode, options);
+  return withoutFencedCode
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .flatMap((line) => [line.match(/^(?:[-*+]\s+|\d+[.)]\s+)(.+)$/u)?.[1] ?? line])
+    .flatMap((line) => splitSentences(line, options));
 }
 
 export function isNonDirectiveSentence(text, { allowConditions = false } = {}) {

--- a/lib/sessions/extraction-grammar.mjs
+++ b/lib/sessions/extraction-grammar.mjs
@@ -53,7 +53,22 @@ export function splitDirectiveClauses(sentence) {
 }
 
 function isQuotedSentence(text) {
-  return /["“”‘`]|(?:^|[\s:(])'/.test(text);
+  // Inline code is often part of a direct instruction (for example,
+  // "Always use `node:test`"). Only quote delimiters make a sentence an
+  // example rather than guidance; fenced code is filtered by the caller.
+  return /["“”‘]|(?:^|[\s:(])'/.test(text)
+    || (/`[^`]+`/u.test(text) && /\b(?:says?|said|quote|quoted|example|guide)\b/i.test(text));
+}
+
+export function directiveSentences(text, options = {}) {
+  const withoutFencedCode = String(text || "").replace(/```[\s\S]*?```/gu, "\n");
+  const lines = withoutFencedCode.split(/\r?\n/u).map((line) => line.trim()).filter(Boolean);
+  const bullets = lines
+    .map((line) => line.match(/^(?:[-*+]\s+|\d+[.)]\s+)(.+)$/u)?.[1])
+    .filter(Boolean);
+  return bullets.length > 0
+    ? bullets.flatMap((line) => splitSentences(line, options))
+    : splitSentences(withoutFencedCode, options);
 }
 
 export function isNonDirectiveSentence(text, { allowConditions = false } = {}) {

--- a/lib/sessions/rule-extractor.mjs
+++ b/lib/sessions/rule-extractor.mjs
@@ -11,6 +11,7 @@ import { collectRetiredDecisionEvidenceKeys } from "./decision-subject.mjs";
 import { stripInjectedContext } from "../memory/retention-sanitizer.mjs";
 import {
   directiveBody,
+  directiveSentences,
   isHypotheticalDirectiveSentence,
   isNonDirectiveSentence,
   isOneOffDirectiveRequest,
@@ -548,9 +549,12 @@ function extractSemanticMemoriesFromTurns(turns, repository, sessionId, config =
   const recentTurns = turns;
 
   for (const turn of recentTurns) {
-    const userMessage = normalizeTurnText(turn.user_message, config);
+    const rawUserMessage = readRetentionSanitizationEnabled(config)
+      ? stripInjectedContext(turn.user_message)
+      : String(turn.user_message || "");
+    const userMessage = normalizeText(rawUserMessage);
     if (userMessage) {
-      for (const sentence of splitSentences(userMessage, { splitSemicolons: false })) {
+      for (const sentence of directiveSentences(rawUserMessage, { splitSemicolons: false })) {
         const interactionStyleMemory = extractInteractionStyleMemory({
           message: sentence,
           repository,

--- a/lib/tools/builders/memory-tool-builder-memory-portable-bundle.mjs
+++ b/lib/tools/builders/memory-tool-builder-memory-portable-bundle.mjs
@@ -29,6 +29,7 @@ export function buildMemoryPortableBundleTool(getRuntime, context) {
       const improvementArtifacts = runtime.db.listImprovementArtifacts({
         reviewState: "approved",
         hasProposal: true,
+        repository: request.repository,
         limit: request.limit,
       });
 

--- a/lib/tools/memory-tools-backfill-report.mjs
+++ b/lib/tools/memory-tools-backfill-report.mjs
@@ -145,9 +145,9 @@ function runControlledBackfillRestore(runtime, args) {
     runId,
   });
   return [
-    `Restored lore.db from snapshot for run ${runId}.`,
+    `Prepared offline lore.db restore for run ${runId}. Stop all Lore clients, then run the recovery command below.`,
     `snapshotPath: ${restored.snapshotPath}`,
-    `schemaVersion: ${restored.schemaVersion}`,
+    `recoveryCommand: ${restored.recoveryCommand}`,
   ].join("\n");
 }
 

--- a/lib/tools/memory-tools-evolution.mjs
+++ b/lib/tools/memory-tools-evolution.mjs
@@ -145,6 +145,7 @@ export function captureEvolutionSignal(runtime, args) {
     },
     trace: ensureObject(args.trace, "trace"),
     linkedMemoryId: readOptionalTrimmedString(args.linkedMemoryId),
+    repository: runtime.repository ?? null,
   });
   return `Captured evolution signal ${artifactId} (${signalType}).`;
 }

--- a/lib/tools/memory-tools-okf-bundle.mjs
+++ b/lib/tools/memory-tools-okf-bundle.mjs
@@ -1,7 +1,12 @@
-import { lstat, mkdir, rename, rm, writeFile, chmod } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
+import { lstat } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+
+import {
+  ensurePrivateDirectory,
+  safeExportPath,
+  writePrivateAtomicFile,
+} from "./private-export-writer.mjs";
 
 const OKF_VERSION = "0.1";
 const OKF_SPEC_URL = "https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md";
@@ -33,25 +38,11 @@ export async function writeOkfBundle(bundleDir, documents) {
   if (existingDir?.isSymbolicLink() || (existingDir && !existingDir.isDirectory())) {
     throw new Error("OKF bundle directory must be a real directory, not a symlink");
   }
-  await mkdir(bundleDir, { recursive: true, mode: 0o700 });
-  await chmod(bundleDir, 0o700);
+  await ensurePrivateDirectory(bundleDir);
   for (const doc of documents) {
-    const fullPath = path.join(bundleDir, doc.relativePath);
-    const relative = path.relative(bundleDir, fullPath);
-    if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
-      throw new Error("OKF document path must stay within the bundle directory");
-    }
-    await mkdir(path.dirname(fullPath), { recursive: true });
-    const existing = await lstat(fullPath).catch(() => null);
-    if (existing?.isSymbolicLink() || (existing && !existing.isFile())) throw new Error("OKF export destination must be a regular file, not a symlink");
-    const temporary = `${fullPath}.lore-export-${randomUUID()}.tmp`;
-    try {
-      await writeFile(temporary, doc.contents, { encoding: "utf8", mode: 0o600, flag: "wx" });
-      await chmod(temporary, 0o600);
-      await rename(temporary, fullPath);
-    } finally {
-      await rm(temporary, { force: true }).catch(() => {});
-    }
+    const fullPath = safeExportPath(bundleDir, doc.relativePath);
+    await ensurePrivateDirectory(path.dirname(fullPath), bundleDir);
+    await writePrivateAtomicFile(fullPath, doc.contents);
   }
 }
 

--- a/lib/tools/memory-tools-okf-bundle.mjs
+++ b/lib/tools/memory-tools-okf-bundle.mjs
@@ -1,4 +1,5 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { lstat, mkdir, rename, rm, writeFile, chmod } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -28,10 +29,29 @@ export async function writeOkfBundle(bundleDir, documents) {
   if (!bundleDir) {
     return;
   }
+  const existingDir = await lstat(bundleDir).catch(() => null);
+  if (existingDir?.isSymbolicLink() || (existingDir && !existingDir.isDirectory())) {
+    throw new Error("OKF bundle directory must be a real directory, not a symlink");
+  }
+  await mkdir(bundleDir, { recursive: true, mode: 0o700 });
+  await chmod(bundleDir, 0o700);
   for (const doc of documents) {
     const fullPath = path.join(bundleDir, doc.relativePath);
+    const relative = path.relative(bundleDir, fullPath);
+    if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+      throw new Error("OKF document path must stay within the bundle directory");
+    }
     await mkdir(path.dirname(fullPath), { recursive: true });
-    await writeFile(fullPath, doc.contents, "utf8");
+    const existing = await lstat(fullPath).catch(() => null);
+    if (existing?.isSymbolicLink() || (existing && !existing.isFile())) throw new Error("OKF export destination must be a regular file, not a symlink");
+    const temporary = `${fullPath}.lore-export-${randomUUID()}.tmp`;
+    try {
+      await writeFile(temporary, doc.contents, { encoding: "utf8", mode: 0o600, flag: "wx" });
+      await chmod(temporary, 0o600);
+      await rename(temporary, fullPath);
+    } finally {
+      await rm(temporary, { force: true }).catch(() => {});
+    }
   }
 }
 

--- a/lib/tools/memory-tools-portable-bundle.mjs
+++ b/lib/tools/memory-tools-portable-bundle.mjs
@@ -1,5 +1,6 @@
 import crypto from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
+import { lstat, mkdir, rename, rm, writeFile, chmod } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -61,7 +62,16 @@ export async function writePortableBundle(bundlePath, portableBundle) {
     return;
   }
   await mkdir(path.dirname(bundlePath), { recursive: true });
-  await writeFile(bundlePath, `${JSON.stringify(portableBundle, null, 2)}\n`, "utf8");
+  const existing = await lstat(bundlePath).catch(() => null);
+  if (existing?.isSymbolicLink() || (existing && !existing.isFile())) throw new Error("bundlePath must be a regular file, not a symlink");
+  const temporary = `${bundlePath}.lore-export-${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, `${JSON.stringify(portableBundle, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    await chmod(temporary, 0o600);
+    await rename(temporary, bundlePath);
+  } finally {
+    await rm(temporary, { force: true }).catch(() => {});
+  }
 }
 
 export function formatPortableBundleResult({ portableBundle, bundlePath, repository }) {
@@ -109,6 +119,7 @@ export function mapImprovementArtifactRow(row) {
     id: row.id,
     sourceCaseId: row.source_case_id,
     sourceKind: row.source_kind,
+    repository: row.repository ?? null,
     title: row.title,
     summary: row.summary,
     status: row.status,

--- a/lib/tools/memory-tools-portable-bundle.mjs
+++ b/lib/tools/memory-tools-portable-bundle.mjs
@@ -1,6 +1,5 @@
 import crypto from "node:crypto";
-import { lstat, mkdir, rename, rm, writeFile, chmod } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -8,6 +7,7 @@ import {
   resolveRepositoryArg,
   ensureLimit,
 } from "./memory-tools-utils.mjs";
+import { writePrivateAtomicFile } from "./private-export-writer.mjs";
 
 const PORTABLE_BUNDLE_EXPORT_ACTION = "export";
 const PORTABLE_BUNDLE_IMPORT_ACTION = "import";
@@ -62,16 +62,7 @@ export async function writePortableBundle(bundlePath, portableBundle) {
     return;
   }
   await mkdir(path.dirname(bundlePath), { recursive: true });
-  const existing = await lstat(bundlePath).catch(() => null);
-  if (existing?.isSymbolicLink() || (existing && !existing.isFile())) throw new Error("bundlePath must be a regular file, not a symlink");
-  const temporary = `${bundlePath}.lore-export-${randomUUID()}.tmp`;
-  try {
-    await writeFile(temporary, `${JSON.stringify(portableBundle, null, 2)}\n`, { encoding: "utf8", mode: 0o600, flag: "wx" });
-    await chmod(temporary, 0o600);
-    await rename(temporary, bundlePath);
-  } finally {
-    await rm(temporary, { force: true }).catch(() => {});
-  }
+  await writePrivateAtomicFile(bundlePath, `${JSON.stringify(portableBundle, null, 2)}\n`);
 }
 
 export function formatPortableBundleResult({ portableBundle, bundlePath, repository }) {

--- a/lib/tools/private-export-writer.mjs
+++ b/lib/tools/private-export-writer.mjs
@@ -1,0 +1,98 @@
+import { randomUUID } from "node:crypto";
+import { chmod, lstat, mkdir, rename, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const REPLACE_RETRY_CODES = new Set(["EEXIST", "EPERM", "ENOTEMPTY"]);
+
+/**
+ * Ensures a directory and every path component below root are real, private
+ * directories. Missing components are created with owner-only permissions;
+ * existing components below root are tightened to 0700.
+ */
+export async function ensurePrivateDirectory(directory, root = directory) {
+  const resolvedDirectory = path.resolve(directory);
+  const resolvedRoot = path.resolve(root);
+  const relative = path.relative(resolvedRoot, resolvedDirectory);
+  if (resolvedRoot === path.parse(resolvedRoot).root
+    || (!relative && resolvedDirectory !== resolvedRoot)
+    || relative.startsWith(`..${path.sep}`)
+    || path.isAbsolute(relative)) {
+    throw new Error("private export directory must stay below its configured root");
+  }
+
+  const missing = [];
+  let current = resolvedDirectory;
+  while (true) {
+    const stat = await lstat(current).catch(() => null);
+    if (stat) {
+      if (stat.isSymbolicLink() || !stat.isDirectory()) {
+        throw new Error("private export directory must be a real directory, not a symlink");
+      }
+      break;
+    }
+    missing.push(current);
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  for (const missingDirectory of missing.reverse()) {
+    await mkdir(missingDirectory, { mode: 0o700 });
+  }
+
+  await chmod(resolvedRoot, 0o700);
+  let child = resolvedRoot;
+  for (const segment of relative ? relative.split(path.sep) : []) {
+    child = path.join(child, segment);
+    const stat = await lstat(child).catch(() => null);
+    if (!stat || stat.isSymbolicLink() || !stat.isDirectory()) {
+      throw new Error("private export directory must be a real directory, not a symlink");
+    }
+    await chmod(child, 0o700);
+  }
+}
+
+/** Resolves a bundle-relative path while rejecting traversal and absolute paths. */
+export function safeExportPath(root, relativePath) {
+  if (typeof relativePath !== "string" || !relativePath.trim()) {
+    throw new Error("export document path must be a non-empty relative path");
+  }
+  const resolvedRoot = path.resolve(root);
+  const fullPath = path.resolve(resolvedRoot, relativePath);
+  const relative = path.relative(resolvedRoot, fullPath);
+  if (!relative || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+    throw new Error("export document path must stay within the bundle directory");
+  }
+  return fullPath;
+}
+
+/** Writes a private file without following a symlink at the destination. */
+export async function writePrivateAtomicFile(filePath, contents) {
+  const existing = await lstat(filePath).catch(() => null);
+  if (existing?.isSymbolicLink() || (existing && !existing.isFile())) {
+    throw new Error("export destination must be a regular file, not a symlink");
+  }
+
+  const temporary = `${filePath}.lore-export-${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, contents, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    await chmod(temporary, 0o600);
+    try {
+      await rename(temporary, filePath);
+    } catch (error) {
+      if (!REPLACE_RETRY_CODES.has(error?.code)) {
+        throw error;
+      }
+      const replacement = await lstat(filePath).catch(() => null);
+      if (!replacement || replacement.isSymbolicLink() || !replacement.isFile()) {
+        throw error;
+      }
+      await rm(filePath);
+      await rename(temporary, filePath);
+    }
+  } finally {
+    await rm(temporary, { force: true }).catch(() => {});
+  }
+}

--- a/scripts/reliability-quality.mjs
+++ b/scripts/reliability-quality.mjs
@@ -99,7 +99,30 @@ function candidateMemories(extraction) {
     content,
     provenance: "episode_digest",
   }));
-  return [...semantic, ...decisions];
+  const merged = [...semantic, ...decisions];
+  const byDecisionChoice = new Map();
+  const result = [];
+  for (const memory of merged) {
+    if (memory.type !== "decision") {
+      result.push(memory);
+      continue;
+    }
+    const choice = String(memory.metadata?.decisionChoice
+      || memory.content?.replace(/^(?:Assistant reported|User stated):\s*/i, "").replace(/^Decision:\s*/i, "").split(/\s+because\s+/i)[0]
+      || "").trim().toLowerCase();
+    if (!choice) {
+      result.push(memory);
+      continue;
+    }
+    const priorIndex = byDecisionChoice.get(choice);
+    if (priorIndex === undefined) {
+      byDecisionChoice.set(choice, result.length);
+      result.push(memory);
+    } else if (String(memory.content || "").length > String(result[priorIndex].content || "").length) {
+      result[priorIndex] = memory;
+    }
+  }
+  return result;
 }
 
 export function normalizeRecallEvidence(rows) {
@@ -258,7 +281,17 @@ async function runScenario(scenario) {
         workspace,
         extraction,
       });
-      retainedRows = fixture.db.db.prepare("SELECT id, type, content, scope, repository, source_session_id, metadata_json, superseded_by FROM semantic_memory WHERE source_session_id = ? AND superseded_by IS NULL").all(scenario.sessionId);
+      retainedRows = fixture.db.db.prepare(`
+        SELECT sm.id, sm.type, sm.content, sm.scope, sm.repository, sm.source_session_id, sm.metadata_json, sm.superseded_by
+        FROM semantic_memory sm
+        WHERE sm.source_session_id = ? AND sm.superseded_by IS NULL
+          AND (NOT EXISTS (SELECT 1 FROM memory_evidence me WHERE me.memory_id = sm.id)
+            OR EXISTS (
+              SELECT 1 FROM memory_evidence me
+              JOIN session_evidence se ON se.evidence_key = me.evidence_key
+              WHERE me.memory_id = sm.id AND me.retired_at IS NULL AND se.retired_at IS NULL
+            ))
+      `).all(scenario.sessionId);
     }
 
     const recall = await recallMemory({ db: fixture.db, prompt: scenario.query, repository: scenario.repository, limit: 12 });

--- a/tests/unit/backfill-controlled.test.mjs
+++ b/tests/unit/backfill-controlled.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import path from "node:path";
 import { describe, test } from "node:test";
 
 import {
@@ -291,5 +292,19 @@ describe("backfill controlled operations", { concurrency: false }, () => {
     } finally {
       cleanup();
     }
+  });
+
+  test("restoreControlledBackfillRun emits an absolute configured default target", () => {
+    const result = restoreControlledBackfillRun({
+      db: {
+        config: {},
+        getBackfillRun: () => ({ snapshot_path: "/tmp/lore-backfill-snapshot.db" }),
+      },
+      runId: "run-with-snapshot",
+    });
+    const target = result.recoveryCommand.split("--derived-store-path ", 2)[1]?.split(" ", 1)[0];
+    assert.ok(target, "expected a derived-store-path argument");
+    assert.ok(path.isAbsolute(target.replace(/^["']|["']$/gu, "")));
+    assert.doesNotMatch(result.recoveryCommand, /(?:^|\s)["']?~\//u);
   });
 });

--- a/tests/unit/local-inference.test.mjs
+++ b/tests/unit/local-inference.test.mjs
@@ -53,6 +53,20 @@ test("requestLocalInferenceJson calls the configured loopback chat-completions e
   });
 });
 
+test("local inference rejects redirects to preserve the loopback boundary", async () => {
+  await assert.rejects(
+    requestLocalInferenceJson({
+      config: { enabled: true, baseUrl: "http://127.0.0.1:12434/v1", model: "fixture", timeoutMs: 1000 },
+      messages: [{ role: "user", content: "test" }],
+      fetchImpl: async (_url, init) => {
+        assert.equal(init.redirect, "error");
+        throw new Error("redirect blocked");
+      },
+    }),
+    /redirect blocked/,
+  );
+});
+
 test("requestLocalInferenceEmbeddings returns vectors from the configured loopback endpoint", async () => {
   const calls = [];
   const vectors = await requestLocalInferenceEmbeddings({
@@ -267,5 +281,4 @@ test("local inference does not append dangling colon when error body is only whi
     },
   );
 });
-
 

--- a/tests/unit/memory-tools-okf-bundle.test.mjs
+++ b/tests/unit/memory-tools-okf-bundle.test.mjs
@@ -18,7 +18,7 @@
 
 import { it, describe } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, existsSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, existsSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -165,6 +165,30 @@ describe("writeOkfBundle", () => {
       const symlinkPath = path.join(tmpDir, "linked-bundle");
       symlinkSync(symlinkTarget, symlinkPath);
       await assert.rejects(() => writeOkfBundle(symlinkPath, []), /real directory/u);
+
+      const nestedBundle = path.join(tmpDir, "nested-bundle");
+      await writeOkfBundle(nestedBundle, [{ relativePath: "subdir/artifact.md", contents: "nested" }]);
+      assert.strictEqual(statSync(path.join(nestedBundle, "subdir")).mode & 0o777, 0o700);
+      const escapedDir = path.join(tmpDir, "escaped");
+      mkdirSync(escapedDir);
+      const linkedSubdir = path.join(nestedBundle, "linked-subdir");
+      symlinkSync(escapedDir, linkedSubdir);
+      await assert.rejects(
+        () => writeOkfBundle(nestedBundle, [{ relativePath: "linked-subdir/escape.md", contents: "x" }]),
+        /real directory|symlink/u,
+      );
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("replaces an existing document when exporting the same bundle again", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const bundleDir = path.join(tmpDir, "bundle");
+      await writeOkfBundle(bundleDir, [{ relativePath: "index.md", contents: "first" }]);
+      await writeOkfBundle(bundleDir, [{ relativePath: "index.md", contents: "second" }]);
+      assert.equal(readFileSync(path.join(bundleDir, "index.md"), "utf8"), "second");
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/tests/unit/memory-tools-okf-bundle.test.mjs
+++ b/tests/unit/memory-tools-okf-bundle.test.mjs
@@ -18,7 +18,7 @@
 
 import { it, describe } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, existsSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -149,6 +149,25 @@ describe("writeOkfBundle", () => {
 
   it("is a no-op when bundleDir is falsy", async () => {
     await assert.doesNotReject(() => writeOkfBundle(null, [{ relativePath: "index.md", contents: "x" }]));
+  });
+
+  it("writes private modes and rejects symlink or traversal destinations", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const bundleDir = path.join(tmpDir, "bundle");
+      await writeOkfBundle(bundleDir, [{ relativePath: "index.md", contents: "x" }]);
+      assert.strictEqual(statSync(bundleDir).mode & 0o777, 0o700);
+      assert.strictEqual(statSync(path.join(bundleDir, "index.md")).mode & 0o777, 0o600);
+      await assert.rejects(() => writeOkfBundle(bundleDir, [{ relativePath: "../escape.md", contents: "x" }]), /within the bundle/u);
+
+      const symlinkTarget = path.join(tmpDir, "target");
+      writeFileSync(symlinkTarget, "original");
+      const symlinkPath = path.join(tmpDir, "linked-bundle");
+      symlinkSync(symlinkTarget, symlinkPath);
+      await assert.rejects(() => writeOkfBundle(symlinkPath, []), /real directory/u);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/tests/unit/memory-tools-portable-bundle.test.mjs
+++ b/tests/unit/memory-tools-portable-bundle.test.mjs
@@ -33,7 +33,9 @@ import { createMemoryTools } from "../../lib/tools/memory-tools.mjs";
 import {
   buildPortableBundleRequest,
   mapImprovementArtifactRow,
+  writePortableBundle,
 } from "../../lib/tools/memory-tools-portable-bundle.mjs";
+import { buildImprovementArtifactEpisode } from "../../lib/db/db-improvement-artifacts.mjs";
 import { FTS5_AVAILABLE, withFixtureDb } from "../helpers/fixture-db.mjs";
 import { findTool } from "../helpers/tool-helpers.mjs";
 
@@ -132,7 +134,42 @@ describe("mapImprovementArtifactRow", () => {
   });
 });
 
+describe("buildImprovementArtifactEpisode", () => {
+  const artifact = {
+    id: "artifact-replay-1",
+    source_case_id: "case-replay-1",
+    source_kind: "replay",
+    repository: "other-repo",
+    title: "Keep replay evidence scoped",
+    summary: "Do not mix repositories during retrieval.",
+    evidence_json: JSON.stringify({ caseType: "ranking_target" }),
+    updated_at: "2026-01-01T00:00:00.000Z",
+  };
+
+  test("does not synthesize a repository-specific episode for an unknown request", () => {
+    assert.equal(buildImprovementArtifactEpisode(artifact, null), null);
+    assert.equal(buildImprovementArtifactEpisode(artifact, ""), null);
+  });
+
+  test("only synthesizes the episode for the artifact's exact repository", () => {
+    assert.equal(buildImprovementArtifactEpisode(artifact, "fixture-repo"), null);
+    assert.equal(buildImprovementArtifactEpisode(artifact, "other-repo")?.repository, "other-repo");
+  });
+});
+
 describe("memory_portable_bundle tool handler", () => {
+  test("replaces an existing JSON bundle when exporting the same path again", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const bundlePath = path.join(tmpDir, "bundle.json");
+      await writePortableBundle(bundlePath, { bundleVersion: 1, marker: "first" });
+      await writePortableBundle(bundlePath, { bundleVersion: 1, marker: "second" });
+      assert.equal(JSON.parse(readFileSync(bundlePath, "utf8")).marker, "second");
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   test("format=json exports approved artifacts using the mapped camelCase shape", { skip: SKIP_NO_FTS5 }, async () => {
     const { db, tools, cleanup } = await setupFixtureTools({ enabled: true });
     const tmpDir = makeTmpDir();

--- a/tests/unit/memory-tools-portable-bundle.test.mjs
+++ b/tests/unit/memory-tools-portable-bundle.test.mjs
@@ -155,6 +155,17 @@ describe("buildImprovementArtifactEpisode", () => {
     assert.equal(buildImprovementArtifactEpisode(artifact, "fixture-repo"), null);
     assert.equal(buildImprovementArtifactEpisode(artifact, "other-repo")?.repository, "other-repo");
   });
+
+  test("reads legacy repository provenance from persisted evidence and trace JSON", () => {
+    const legacyArtifact = {
+      ...artifact,
+      repository: null,
+      evidence_json: JSON.stringify({ caseType: "ranking_target", originRepository: "legacy-repo" }),
+      trace_json: JSON.stringify({}),
+    };
+    assert.equal(buildImprovementArtifactEpisode(legacyArtifact, null), null);
+    assert.equal(buildImprovementArtifactEpisode(legacyArtifact, "legacy-repo")?.repository, "legacy-repo");
+  });
 });
 
 describe("memory_portable_bundle tool handler", () => {

--- a/tests/unit/memory-tools-portable-bundle.test.mjs
+++ b/tests/unit/memory-tools-portable-bundle.test.mjs
@@ -71,6 +71,7 @@ function seedApprovedArtifact(db) {
   const id = db.upsertImprovementArtifact({
     sourceCaseId: "case-portable-1",
     sourceKind: "session_review",
+    repository: "fixture-repo",
     title: "Tighten retry backoff",
     summary: "Reduce retry storms during transient network errors.",
     evidence: { occurrences: 3 },
@@ -91,6 +92,7 @@ describe("mapImprovementArtifactRow", () => {
       id: "artifact-1",
       source_case_id: "case-1",
       source_kind: "session_review",
+      repository: "acme/widgets",
       title: "Tighten retry backoff",
       summary: "Reduce retry storms.",
       status: "active",
@@ -107,6 +109,7 @@ describe("mapImprovementArtifactRow", () => {
       id: "artifact-1",
       sourceCaseId: "case-1",
       sourceKind: "session_review",
+      repository: "acme/widgets",
       title: "Tighten retry backoff",
       summary: "Reduce retry storms.",
       status: "active",
@@ -121,6 +124,7 @@ describe("mapImprovementArtifactRow", () => {
 
   test("defaults reviewState to 'none' and proposal fields to null when absent", () => {
     const mapped = mapImprovementArtifactRow({ id: "artifact-2", title: "No proposal yet" });
+    assert.equal(mapped.repository, null);
     assert.equal(mapped.reviewState, "none");
     assert.deepEqual(mapped.proposal, { type: null, path: null, hash: null });
     assert.deepEqual(mapped.evidence, {});
@@ -145,6 +149,36 @@ describe("memory_portable_bundle tool handler", () => {
       assert.equal(artifact.sourceCaseId, "case-portable-1");
       assert.equal(artifact.proposal.path, "docs/proposals/retry.md");
       assert.ok(artifact.updatedAt || artifact.createdAt);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+      cleanup();
+    }
+  });
+
+  test("scopes approved exports to the active repository", { skip: SKIP_NO_FTS5 }, async () => {
+    const { db, tools, cleanup } = await setupFixtureTools({ enabled: true });
+    const tmpDir = makeTmpDir();
+    try {
+      seedApprovedArtifact(db);
+      const foreignId = db.upsertImprovementArtifact({
+        sourceCaseId: "case-foreign",
+        sourceKind: "replay",
+        repository: "other-repo",
+        title: "Foreign artifact",
+        summary: "Must not cross the repository boundary.",
+      });
+      db.setImprovementArtifactProposal({
+        id: foreignId,
+        proposalType: "diff",
+        proposalPath: "docs/proposals/foreign.md",
+        proposalHash: "foreign",
+        reviewState: "approved",
+      });
+      const tool = findTool(tools, "memory_portable_bundle");
+      const bundlePath = path.join(tmpDir, "bundle.json");
+      await tool.handler({ bundlePath, format: "json" }, { sessionId: "portable-scope" });
+      const bundle = JSON.parse(readFileSync(bundlePath, "utf8"));
+      assert.deepEqual(bundle.data.improvementArtifacts.map((artifact) => artifact.repository), ["fixture-repo"]);
     } finally {
       rmSync(tmpDir, { recursive: true, force: true });
       cleanup();

--- a/tests/unit/rule-extractor.test.mjs
+++ b/tests/unit/rule-extractor.test.mjs
@@ -33,6 +33,8 @@ test("directives survive inline code and Markdown list formatting", () => {
   assert.ok(inline.semanticMemories.some((memory) => memory.type === "user_preference"));
   const markdown = extractTurn("Preferences:\n- Always use node:test for tests.\n- Prefer small patches.");
   assert.equal(markdown.semanticMemories.filter((memory) => memory.type === "user_preference").length, 2);
+  const mixed = extractTurn("Always preserve the original context.\n- Always use node:test for tests.\n- Prefer small patches.");
+  assert.equal(mixed.semanticMemories.filter((memory) => memory.type === "user_preference").length, 3);
   const fenced = extractTurn("```\nAlways use node:test for tests.\n```");
   assert.equal(fenced.semanticMemories.some((memory) => memory.type === "user_preference"), false);
 });

--- a/tests/unit/rule-extractor.test.mjs
+++ b/tests/unit/rule-extractor.test.mjs
@@ -28,6 +28,15 @@ function extractTurn(userMessage, { repository = "owner/repo", sessionId = "test
   });
 }
 
+test("directives survive inline code and Markdown list formatting", () => {
+  const inline = extractTurn("Always use `node:test` for tests.");
+  assert.ok(inline.semanticMemories.some((memory) => memory.type === "user_preference"));
+  const markdown = extractTurn("Preferences:\n- Always use node:test for tests.\n- Prefer small patches.");
+  assert.equal(markdown.semanticMemories.filter((memory) => memory.type === "user_preference").length, 2);
+  const fenced = extractTurn("```\nAlways use node:test for tests.\n```");
+  assert.equal(fenced.semanticMemories.some((memory) => memory.type === "user_preference"), false);
+});
+
 describe("rule-extractor extraction accuracy and scoping", () => {
   test("Review git diff --cached... Do not edit files. is NOT extracted as a rejected_approach or standing directive", () => {
     const result = extractTurn("Review git diff --cached, falling back to git diff if nothing is staged. Return every actionable finding as path:line with severity, covering logic bugs, security issues, error-handling gaps, and edge cases. Do not edit files.");

--- a/tests/unit/session-source.test.mjs
+++ b/tests/unit/session-source.test.mjs
@@ -69,6 +69,19 @@ describe("SessionSource and EpisodeSessionSource", () => {
     }
   });
 
+  test("unknown repository identity returns global history only", async () => {
+    const { db, cleanup } = await import("../helpers/fixture-db.mjs").then(({ withFixtureDb }) => withFixtureDb());
+    try {
+      db.db.prepare(`INSERT INTO episode_digest (session_id, repository, scope, date_key, summary, created_at, updated_at)
+        VALUES ('foreign', 'private-repo', 'repo', '2026-06-04', 'PRIVATE_MARKER', '2026-06-04', '2026-06-04')`).run();
+      const source = new EpisodeSessionSource(db);
+      const rows = source.findSessionsByDate({ dateKey: "2026-06-04", repository: null });
+      assert.equal(rows.some((row) => row.summary === "PRIVATE_MARKER"), false);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("EpisodeSessionSource.findRelevantSessions searches episodes", () => {
     const tempHome = makeTempDir();
     try {


### PR DESCRIPTION
## Summary

Closes the remaining memory scope, replay, decision lifecycle, restore, extraction, inference, and export-safety gaps from the reliability audit.

## Changes

- Keep unknown-repository session history global-only and enforce repository identity on episode and improvement-artifact retrieval.
- Persist artifact repository provenance and scope approved portable exports to the active repository.
- Reconcile decision reversals against persisted session evidence beyond the bounded capture window.
- Return an offline recovery command for controlled backfill restore so active clients cannot race a live database replacement.
- Preserve direct instructions containing inline code and Markdown lists while excluding fenced examples.
- Refuse local-inference redirects.
- Write exports atomically with private permissions and reject symlink/path-traversal destinations.
- Normalize the reliability evaluator so role-attributed episode decisions are deduplicated correctly.

## Testing

- `npm test` — 1,279 passed, 1 skipped.
- `npm run test:smoke` — 91 passed.
- `npm run test:quality` — 48/48 passed.
- `npm run test:reliability` — 780 scenarios passed; 100% extraction precision and zero safety failures.
- `npm run lint` and `npm run validate-schema` — passed.

## Scope

This is the first stack layer. The documentation and dependency refresh is stacked on top in the follow-up PR.
