### PR TITLE
refactor: split lib/db/db.mjs into focused domain modules

### DIFF
--- a/lib/db/db-activity-state.mjs
+++ b/lib/db/db-activity-state.mjs
@@ -3,7 +3,7 @@ import { jsonText } from "../utils/json-text-utils.mjs";
 import { normalizeRepository } from "../utils/repository-utils.mjs";
 import { nowIso } from "./db-shared.mjs";
 
-export const ACTIVITY_SUCCESS_VALUE_FIELDS = Object.freeze([
+const ACTIVITY_SUCCESS_VALUE_FIELDS = Object.freeze([
   ["lastContextInjectionAt", "last_context_injection_at"],
   ["lastContextInjectionHook", "last_context_injection_hook"],
   ["lastContextInjectionTraceId", "last_context_injection_trace_id"],
@@ -16,7 +16,7 @@ export const ACTIVITY_SUCCESS_VALUE_FIELDS = Object.freeze([
   ["lastTraceId", "last_trace_id"],
 ]);
 
-export function mergeActivitySuccessValues(updates, existing) {
+function mergeActivitySuccessValues(updates, existing) {
   return Object.fromEntries(
     ACTIVITY_SUCCESS_VALUE_FIELDS.map(([updateKey, existingKey]) => [
       updateKey,
@@ -25,25 +25,25 @@ export function mergeActivitySuccessValues(updates, existing) {
   );
 }
 
-export function mergeActivitySuccessSections(updates, existing) {
+function mergeActivitySuccessSections(updates, existing) {
   return Array.isArray(updates.lastContextInjectionSections)
     ? updates.lastContextInjectionSections.slice(0, 8)
     : parseJsonArray(existing?.last_context_injection_sections_json);
 }
 
-export function mergeActivitySuccessDuration(updates, existing) {
+function mergeActivitySuccessDuration(updates, existing) {
   return Number.isFinite(updates.lastContextInjectionDurationMs)
     ? Math.round(updates.lastContextInjectionDurationMs)
     : (existing?.last_context_injection_duration_ms ?? null);
 }
 
-export function mergeActivitySuccessExtractionRepository(updates, existing, repo) {
+function mergeActivitySuccessExtractionRepository(updates, existing, repo) {
   return normalizeRepository(updates.lastExtractionRepository)
     ?? existing?.last_extraction_repository
     ?? repo;
 }
 
-export function buildActivitySuccessState({ updates, existing, repo }) {
+function buildActivitySuccessState({ updates, existing, repo }) {
   return {
     ...mergeActivitySuccessValues(updates, existing),
     lastContextInjectionSections: mergeActivitySuccessSections(updates, existing),

--- a/lib/db/db-activity-state.mjs
+++ b/lib/db/db-activity-state.mjs
@@ -1,0 +1,417 @@
+import { parseJsonArray } from "../utils/json-array-utils.mjs";
+import { jsonText } from "../utils/json-text-utils.mjs";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { nowIso } from "./db-shared.mjs";
+
+export const ACTIVITY_SUCCESS_VALUE_FIELDS = Object.freeze([
+  ["lastContextInjectionAt", "last_context_injection_at"],
+  ["lastContextInjectionHook", "last_context_injection_hook"],
+  ["lastContextInjectionTraceId", "last_context_injection_trace_id"],
+  ["lastExtractionCompletionAt", "last_extraction_completion_at"],
+  ["lastMaintenanceCompletionAt", "last_maintenance_completion_at"],
+  ["lastMaintenanceStatus", "last_maintenance_status"],
+  ["lastMaintenanceRunId", "last_maintenance_run_id"],
+  ["lastTraceRecordedAt", "last_trace_recorded_at"],
+  ["lastTraceHook", "last_trace_hook"],
+  ["lastTraceId", "last_trace_id"],
+]);
+
+export function mergeActivitySuccessValues(updates, existing) {
+  return Object.fromEntries(
+    ACTIVITY_SUCCESS_VALUE_FIELDS.map(([updateKey, existingKey]) => [
+      updateKey,
+      updates[updateKey] ?? existing?.[existingKey] ?? null,
+    ]),
+  );
+}
+
+export function mergeActivitySuccessSections(updates, existing) {
+  return Array.isArray(updates.lastContextInjectionSections)
+    ? updates.lastContextInjectionSections.slice(0, 8)
+    : parseJsonArray(existing?.last_context_injection_sections_json);
+}
+
+export function mergeActivitySuccessDuration(updates, existing) {
+  return Number.isFinite(updates.lastContextInjectionDurationMs)
+    ? Math.round(updates.lastContextInjectionDurationMs)
+    : (existing?.last_context_injection_duration_ms ?? null);
+}
+
+export function mergeActivitySuccessExtractionRepository(updates, existing, repo) {
+  return normalizeRepository(updates.lastExtractionRepository)
+    ?? existing?.last_extraction_repository
+    ?? repo;
+}
+
+export function buildActivitySuccessState({ updates, existing, repo }) {
+  return {
+    ...mergeActivitySuccessValues(updates, existing),
+    lastContextInjectionSections: mergeActivitySuccessSections(updates, existing),
+    lastContextInjectionDurationMs: mergeActivitySuccessDuration(updates, existing),
+    lastExtractionRepository: mergeActivitySuccessExtractionRepository(updates, existing, repo),
+  };
+}
+
+export function queryActivityStateRow(db, scopeKey) {
+  return db.prepare(`
+    SELECT
+      scope_key,
+      scope_type,
+      repository,
+      last_context_injection_at,
+      last_context_injection_hook,
+      last_context_injection_sections_json,
+      last_context_injection_trace_id,
+      last_context_injection_duration_ms,
+      last_extraction_completion_at,
+      last_extraction_repository,
+      last_maintenance_completion_at,
+      last_maintenance_status,
+      last_maintenance_run_id,
+      last_trace_recorded_at,
+      last_trace_hook,
+      last_trace_id,
+      updated_at
+    FROM lore_activity_state
+    WHERE scope_key = ?
+  `).get(scopeKey);
+}
+
+export function mapActivityStateRow(row) {
+  return {
+    scopeKey: row.scope_key,
+    scopeType: row.scope_type,
+    repository: row.repository,
+    lastContextInjectionAt: row.last_context_injection_at,
+    lastContextInjectionHook: row.last_context_injection_hook,
+    lastContextInjectionSections: parseJsonArray(row.last_context_injection_sections_json),
+    lastContextInjectionTraceId: row.last_context_injection_trace_id,
+    lastContextInjectionDurationMs: row.last_context_injection_duration_ms,
+    lastExtractionCompletionAt: row.last_extraction_completion_at,
+    lastExtractionRepository: row.last_extraction_repository,
+    lastMaintenanceCompletionAt: row.last_maintenance_completion_at,
+    lastMaintenanceStatus: row.last_maintenance_status,
+    lastMaintenanceRunId: row.last_maintenance_run_id,
+    lastTraceRecordedAt: row.last_trace_recorded_at,
+    lastTraceHook: row.last_trace_hook,
+    lastTraceId: row.last_trace_id,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function upsertActivitySuccess(owner, {
+  repository = null,
+  updates = {},
+} = {}) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const scopeKey = repo ? `repo:${repo}` : "global";
+  const scopeType = repo ? "repo" : "global";
+  const timestamp = nowIso();
+  const normalizedUpdates = updates && typeof updates === "object" ? updates : {};
+
+  const existing = owner.db.prepare(`
+    SELECT *
+    FROM lore_activity_state
+    WHERE scope_key = ?
+    LIMIT 1
+  `).get(scopeKey);
+
+  const next = buildActivitySuccessState({
+    updates: normalizedUpdates,
+    existing,
+    repo,
+  });
+
+  owner.db.prepare(`
+    INSERT INTO lore_activity_state (
+      scope_key,
+      scope_type,
+      repository,
+      last_context_injection_at,
+      last_context_injection_hook,
+      last_context_injection_sections_json,
+      last_context_injection_trace_id,
+      last_context_injection_duration_ms,
+      last_extraction_completion_at,
+      last_extraction_repository,
+      last_maintenance_completion_at,
+      last_maintenance_status,
+      last_maintenance_run_id,
+      last_trace_recorded_at,
+      last_trace_hook,
+      last_trace_id,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(scope_key) DO UPDATE SET
+      scope_type = excluded.scope_type,
+      repository = excluded.repository,
+      last_context_injection_at = excluded.last_context_injection_at,
+      last_context_injection_hook = excluded.last_context_injection_hook,
+      last_context_injection_sections_json = excluded.last_context_injection_sections_json,
+      last_context_injection_trace_id = excluded.last_context_injection_trace_id,
+      last_context_injection_duration_ms = excluded.last_context_injection_duration_ms,
+      last_extraction_completion_at = excluded.last_extraction_completion_at,
+      last_extraction_repository = excluded.last_extraction_repository,
+      last_maintenance_completion_at = excluded.last_maintenance_completion_at,
+      last_maintenance_status = excluded.last_maintenance_status,
+      last_maintenance_run_id = excluded.last_maintenance_run_id,
+      last_trace_recorded_at = excluded.last_trace_recorded_at,
+      last_trace_hook = excluded.last_trace_hook,
+      last_trace_id = excluded.last_trace_id,
+      updated_at = excluded.updated_at
+  `).run(
+    scopeKey,
+    scopeType,
+    repo,
+    next.lastContextInjectionAt,
+    next.lastContextInjectionHook,
+    jsonText(next.lastContextInjectionSections),
+    next.lastContextInjectionTraceId,
+    next.lastContextInjectionDurationMs,
+    next.lastExtractionCompletionAt,
+    next.lastExtractionRepository,
+    next.lastMaintenanceCompletionAt,
+    next.lastMaintenanceStatus,
+    next.lastMaintenanceRunId,
+    next.lastTraceRecordedAt,
+    next.lastTraceHook,
+    next.lastTraceId,
+    timestamp,
+  );
+
+  return owner.getActivityState({ repository: repo, includeGlobal: false });
+}
+
+export function collectDirectActivityRows(owner, repo, includeGlobal) {
+  const rows = [];
+  if (repo) {
+    const row = queryActivityStateRow(owner.db, `repo:${repo}`);
+    if (row) rows.push(row);
+  }
+  if (includeGlobal) {
+    const row = queryActivityStateRow(owner.db, "global");
+    if (row) rows.push(row);
+  }
+  return rows;
+}
+
+export function collectFallbackActivityRows(owner, repo, includeGlobal) {
+  const rows = [];
+  if (repo) {
+    const fallback = owner.deriveActivityStateFallback({ repository: repo, scopeKey: `repo:${repo}`, scopeType: "repo" });
+    if (fallback) rows.push(fallback);
+  }
+  if (includeGlobal) {
+    const fallback = owner.deriveActivityStateFallback({ repository: null, scopeKey: "global", scopeType: "global" });
+    if (fallback) rows.push(fallback);
+  }
+  return rows;
+}
+
+export function getActivityState(owner, { repository = null, includeGlobal = true } = {}) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const direct = owner.collectDirectActivityRows(repo, includeGlobal);
+  const rows = direct.length > 0 ? direct : owner.collectFallbackActivityRows(repo, includeGlobal);
+  return rows.map(mapActivityStateRow);
+}
+
+export function deriveActivityStateFallback(owner, {
+  repository = null,
+  scopeKey,
+  scopeType,
+} = {}) {
+  owner.ensureOpen();
+  const fallbackScope = owner.buildActivityFallbackScope(repository);
+  const fallbackRows = owner.readActivityFallbackRows(fallbackScope);
+  const timestamps = owner.collectActivityFallbackTimestamps(fallbackRows);
+  return timestamps.length > 0
+    ? owner.serializeActivityStateFallback({
+        scopeKey,
+        scopeType,
+        repository: fallbackScope.repo,
+        timestamps,
+        ...fallbackRows,
+      })
+    : null;
+}
+
+export function buildActivityFallbackScope(owner, repository = null) {
+  const repo = normalizeRepository(repository);
+  return {
+    repo,
+    scopedWhere: repo ? "WHERE repository = ?" : "",
+    scopedParams: repo ? [repo] : [],
+  };
+}
+
+export function readActivityFallbackRows(owner, { repo, scopedWhere, scopedParams }) {
+  return {
+    latestContextRow: owner.readLatestContextFallbackRow(repo, scopedParams),
+    latestTraceRow: owner.readLatestTraceFallbackRow(scopedWhere, scopedParams),
+    latestMaintenanceRow: owner.readLatestMaintenanceFallbackRow(repo, scopedParams),
+    latestExtractionRow: owner.readLatestExtractionFallbackRow(scopedWhere, scopedParams),
+  };
+}
+
+export function serializeActivityStateFallback(owner, {
+  scopeKey,
+  scopeType,
+  repository,
+  latestContextRow,
+  latestTraceRow,
+  latestMaintenanceRow,
+  latestExtractionRow,
+  timestamps,
+}) {
+  return owner.buildActivityStateFallbackRow({
+    scope_key: scopeKey,
+    scope_type: scopeType,
+    repository,
+    ...owner.serializeActivityFallbackContext(latestContextRow),
+    ...owner.serializeActivityFallbackExtraction(latestExtractionRow, repository),
+    ...owner.serializeActivityFallbackMaintenance(latestMaintenanceRow),
+    ...owner.serializeActivityFallbackTrace(latestTraceRow),
+    updated_at: owner.resolveActivityFallbackUpdatedAt({
+      latestContextRow,
+      latestTraceRow,
+      latestMaintenanceRow,
+      latestExtractionRow,
+      timestamps,
+    }),
+  });
+}
+
+export function serializeActivityFallbackContext(owner, latestContextRow) {
+  const row = latestContextRow ?? {};
+  return {
+    last_context_injection_at: row.recorded_at ?? null,
+    last_context_injection_hook: row.hook ?? null,
+    last_context_injection_sections_json: JSON.stringify(parseJsonArray(row.section_titles_json)),
+    last_context_injection_trace_id: row.id ?? null,
+    last_context_injection_duration_ms: row.latency_ms ?? null,
+  };
+}
+
+export function serializeActivityFallbackExtraction(owner, latestExtractionRow, repository) {
+  return {
+    last_extraction_completion_at: latestExtractionRow?.updated_at ?? null,
+    last_extraction_repository: normalizeRepository(latestExtractionRow?.repository) ?? repository,
+  };
+}
+
+export function serializeActivityFallbackMaintenance(owner, latestMaintenanceRow) {
+  return {
+    last_maintenance_completion_at: latestMaintenanceRow?.completed_at ?? null,
+    last_maintenance_status: latestMaintenanceRow?.status ?? null,
+    last_maintenance_run_id: latestMaintenanceRow?.id ?? null,
+  };
+}
+
+export function serializeActivityFallbackTrace(owner, latestTraceRow) {
+  return {
+    last_trace_recorded_at: latestTraceRow?.recorded_at ?? null,
+    last_trace_hook: latestTraceRow?.hook ?? null,
+    last_trace_id: latestTraceRow?.id ?? null,
+  };
+}
+
+export function resolveActivityFallbackUpdatedAt(owner, {
+  latestContextRow,
+  latestTraceRow,
+  latestMaintenanceRow,
+  latestExtractionRow,
+  timestamps,
+}) {
+  const effectiveTimestamps = Array.isArray(timestamps)
+    ? timestamps
+    : owner.collectActivityFallbackTimestamps({
+        latestContextRow,
+        latestTraceRow,
+        latestMaintenanceRow,
+        latestExtractionRow,
+      });
+  return [...effectiveTimestamps].sort().at(-1) ?? nowIso();
+}
+
+export function readLatestContextFallbackRow(owner, repo, scopedParams) {
+  return owner.db.prepare(`
+    SELECT
+      id,
+      repository,
+      hook,
+      latency_ms,
+      section_titles_json,
+      recorded_at
+    FROM retrieval_trace_sample
+    WHERE context_injected = 1
+      ${repo ? "AND repository = ?" : ""}
+    ORDER BY recorded_at DESC
+    LIMIT 1
+  `).get(...scopedParams);
+}
+
+export function readLatestTraceFallbackRow(owner, scopedWhere, scopedParams) {
+  return owner.db.prepare(`
+    SELECT
+      id,
+      repository,
+      hook,
+      recorded_at
+    FROM retrieval_trace_sample
+    ${scopedWhere}
+    ORDER BY recorded_at DESC
+    LIMIT 1
+  `).get(...scopedParams);
+}
+
+export function readLatestMaintenanceFallbackRow(owner, repo, scopedParams) {
+  return owner.db.prepare(`
+    SELECT
+      id,
+      repository,
+      status,
+      completed_at
+    FROM maintenance_run
+    WHERE completed_at IS NOT NULL
+      ${repo ? "AND repository = ?" : ""}
+    ORDER BY completed_at DESC
+    LIMIT 1
+  `).get(...scopedParams);
+}
+
+export function readLatestExtractionFallbackRow(owner, scopedWhere, scopedParams) {
+  return owner.db.prepare(`
+    SELECT repository, updated_at
+    FROM (
+      SELECT repository, updated_at
+      FROM semantic_memory
+      ${scopedWhere}
+      UNION ALL
+      SELECT repository, updated_at
+      FROM episode_digest
+      ${scopedWhere}
+    )
+    ORDER BY updated_at DESC
+    LIMIT 1
+  `).get(...scopedParams, ...scopedParams);
+}
+
+export function collectActivityFallbackTimestamps(owner, {
+  latestContextRow,
+  latestTraceRow,
+  latestMaintenanceRow,
+  latestExtractionRow,
+}) {
+  return [
+    latestContextRow?.recorded_at,
+    latestTraceRow?.recorded_at,
+    latestMaintenanceRow?.completed_at,
+    latestExtractionRow?.updated_at,
+  ].filter((value) => typeof value === "string" && value.length > 0);
+}
+
+export function buildActivityStateFallbackRow(owner, row) {
+  return row;
+}

--- a/lib/db/db-backfill-runs.mjs
+++ b/lib/db/db-backfill-runs.mjs
@@ -1,0 +1,242 @@
+import crypto from "node:crypto";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { buildBackfillRunSummaryUpdateImpl } from "./db-improvement-artifacts.mjs";
+import { nowIso } from "./db-shared.mjs";
+
+export function countGeneratedSemanticMemoriesBySession(owner, sessionId) {
+  owner.ensureOpen();
+  return owner.db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM semantic_memory
+    WHERE source_session_id = ?
+      AND superseded_by IS NULL
+      AND COALESCE(json_extract(metadata_json, '$.source'), '') NOT IN ('memory_save', 'lore_retain', 'onboarding', 'pi', 'pi:command')
+  `).get(sessionId).count;
+}
+
+export function getEpisodeDigestBySession(owner, sessionId) {
+  owner.ensureOpen();
+  return owner.db.prepare(`
+    SELECT id, session_id, scope, scope_source, repository, updated_at
+    FROM episode_digest
+    WHERE session_id = ?
+  `).get(sessionId);
+}
+
+export function createBackfillRun(owner, {
+  strategy = "session_refresh",
+  dryRun = false,
+  repository = null,
+  includeOtherRepositories = false,
+  refreshExisting = true,
+  batchSize = 10,
+  totalCandidates = 0,
+  snapshotPath = null,
+  metadata = {},
+}) {
+  owner.ensureOpen();
+  const id = crypto.randomUUID();
+  const timestamp = nowIso();
+  owner.db.prepare(`
+    INSERT INTO backfill_run (
+      id, strategy, status, dry_run, repository, include_other_repositories, refresh_existing,
+      batch_size, total_candidates, snapshot_path, metadata_json, started_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    strategy,
+    dryRun ? "preview" : "running",
+    dryRun ? 1 : 0,
+    normalizeRepository(repository),
+    includeOtherRepositories ? 1 : 0,
+    refreshExisting ? 1 : 0,
+    batchSize,
+    totalCandidates,
+    snapshotPath,
+    JSON.stringify(metadata),
+    timestamp,
+    timestamp,
+  );
+  return id;
+}
+
+export function insertBackfillRunItems(owner, runId, items) {
+  owner.ensureOpen();
+  const insert = owner.db.prepare(`
+    INSERT INTO backfill_run_item (
+      run_id, session_id, repository, ordinal, planned_action, status
+    ) VALUES (?, ?, ?, ?, ?, 'pending')
+  `);
+  for (const item of items) {
+    insert.run(
+      runId,
+      item.sessionId,
+      normalizeRepository(item.repository),
+      item.ordinal,
+      item.plannedAction,
+    );
+  }
+}
+
+export function getBackfillRun(owner, runId) {
+  owner.ensureOpen();
+  return owner.db.prepare(`
+    SELECT
+      id, strategy, status, dry_run, repository, include_other_repositories,
+      refresh_existing, batch_size, total_candidates, processed_count,
+      created_episode_count, refreshed_episode_count, skipped_count,
+      failed_count, snapshot_path, metadata_json, started_at, updated_at,
+      completed_at, last_error
+    FROM backfill_run
+    WHERE id = ?
+  `).get(runId);
+}
+
+export function listBackfillRunItems(owner, { runId, statuses = [], limit = 10 }) {
+  owner.ensureOpen();
+  const params = [runId];
+  let sql = `
+    SELECT
+      run_id, session_id, repository, ordinal, planned_action, status,
+      semantic_before_count, semantic_after_count, semantic_delta,
+      episode_before_scope, episode_after_scope, processed_at, error
+    FROM backfill_run_item
+    WHERE run_id = ?
+  `;
+  if (Array.isArray(statuses) && statuses.length > 0) {
+    sql += ` AND status IN (${statuses.map(() => "?").join(", ")}) `;
+    params.push(...statuses);
+  }
+  sql += ` ORDER BY ordinal ASC LIMIT ? `;
+  params.push(limit);
+  return owner.db.prepare(sql).all(...params);
+}
+
+export function updateBackfillRunItem(owner, {
+  runId,
+  sessionId,
+  status,
+  semanticBeforeCount = null,
+  semanticAfterCount = null,
+  semanticDelta = null,
+  episodeBeforeScope = null,
+  episodeAfterScope = null,
+  error = null,
+}) {
+  owner.ensureOpen();
+  owner.db.prepare(`
+    UPDATE backfill_run_item
+    SET status = ?,
+        semantic_before_count = ?,
+        semantic_after_count = ?,
+        semantic_delta = ?,
+        episode_before_scope = ?,
+        episode_after_scope = ?,
+        processed_at = ?,
+        error = ?
+    WHERE run_id = ? AND session_id = ?
+  `).run(
+    status,
+    semanticBeforeCount,
+    semanticAfterCount,
+    semanticDelta,
+    episodeBeforeScope,
+    episodeAfterScope,
+    nowIso(),
+    error,
+    runId,
+    sessionId,
+  );
+}
+
+export function getBackfillRunCounts(owner, runId) {
+  return owner.db.prepare(`
+    SELECT
+      SUM(CASE WHEN status IN ('completed', 'skipped', 'failed') THEN 1 ELSE 0 END) AS processed_count,
+      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
+      SUM(CASE WHEN planned_action = 'create' AND status = 'completed' THEN 1 ELSE 0 END) AS created_episode_count,
+      SUM(CASE WHEN planned_action = 'refresh' AND status = 'completed' THEN 1 ELSE 0 END) AS refreshed_episode_count,
+      SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END) AS skipped_count,
+      SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pending_count
+    FROM backfill_run_item
+    WHERE run_id = ?
+  `).get(runId);
+}
+
+export function deriveBackfillRunStatus(owner, counts) {
+  if ((counts?.pending_count ?? 0) > 0) {
+    return "running";
+  }
+  if ((counts?.failed_count ?? 0) > 0) {
+    return "failed";
+  }
+  return "completed";
+}
+
+export function deriveBackfillRunLastError(owner, runId, lastError) {
+  if (typeof lastError === "string" && lastError.length > 0) {
+    return lastError;
+  }
+  return owner.db.prepare(`
+    SELECT error
+    FROM backfill_run_item
+    WHERE run_id = ?
+      AND status = 'failed'
+      AND error IS NOT NULL
+      AND error != ''
+    ORDER BY COALESCE(processed_at, '') DESC, ordinal DESC
+    LIMIT 1
+  `).get(runId)?.error ?? null;
+}
+
+export function buildBackfillRunSummaryUpdate(owner, runId, { lastError = null } = {}) {
+  return buildBackfillRunSummaryUpdateImpl(owner.db, runId, { lastError });
+}
+
+export function writeBackfillRunSummary(owner, runId, summaryUpdate) {
+  owner.db.prepare(`
+    UPDATE backfill_run
+    SET status = ?,
+        processed_count = ?,
+        created_episode_count = ?,
+        refreshed_episode_count = ?,
+        skipped_count = ?,
+        failed_count = ?,
+        completed_at = COALESCE(?, completed_at),
+        updated_at = ?,
+        last_error = COALESCE(?, last_error)
+    WHERE id = ?
+  `).run(
+    summaryUpdate.status,
+    summaryUpdate.processedCount,
+    summaryUpdate.createdEpisodeCount,
+    summaryUpdate.refreshedEpisodeCount,
+    summaryUpdate.skippedCount,
+    summaryUpdate.failedCount,
+    summaryUpdate.completedAt,
+    summaryUpdate.updatedAt,
+    summaryUpdate.lastError,
+    runId,
+  );
+}
+
+export function refreshBackfillRunSummary(owner, runId, options = {}) {
+  owner.ensureOpen();
+  const summaryUpdate = owner.buildBackfillRunSummaryUpdate(runId, options);
+  owner.writeBackfillRunSummary(runId, summaryUpdate);
+  return owner.getBackfillRun(runId);
+}
+
+export function listBackfillRuns(owner, { limit = 10 }) {
+  owner.ensureOpen();
+  return owner.db.prepare(`
+    SELECT
+      id, strategy, status, dry_run, repository, include_other_repositories,
+      refresh_existing, batch_size, total_candidates, processed_count,
+      created_episode_count, refreshed_episode_count, skipped_count,
+      failed_count, snapshot_path, started_at, updated_at, completed_at, last_error
+    FROM backfill_run
+    ORDER BY updated_at DESC
+    LIMIT ?
+  `).all(limit);
+}

--- a/lib/db/db-deferred-extraction.mjs
+++ b/lib/db/db-deferred-extraction.mjs
@@ -1,0 +1,266 @@
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { nowIso } from "./db-shared.mjs";
+
+export function enqueueDeferredExtraction(owner, {
+  sessionId,
+  repository,
+  reason = "manual",
+  priority = 0,
+  delayMinutes = 0,
+  metadata = {},
+}) {
+  owner.ensureOpen();
+  const queuedAt = nowIso();
+  const availableAt = new Date(Date.now() + (delayMinutes * 60 * 1000)).toISOString();
+  owner.db.prepare(`
+    INSERT INTO deferred_extraction (
+      session_id, repository, status, priority, reason, queued_at, available_at, metadata_json
+    ) VALUES (?, ?, 'pending', ?, ?, ?, ?, ?)
+    ON CONFLICT(session_id) DO UPDATE SET
+      repository = excluded.repository,
+      status = CASE
+        WHEN deferred_extraction.status = 'running' THEN deferred_extraction.status
+        ELSE 'pending'
+      END,
+      priority = CASE
+        WHEN excluded.priority > deferred_extraction.priority THEN excluded.priority
+        ELSE deferred_extraction.priority
+      END,
+      reason = excluded.reason,
+      queued_at = excluded.queued_at,
+      available_at = CASE
+        WHEN deferred_extraction.status = 'running' THEN deferred_extraction.available_at
+        ELSE excluded.available_at
+      END,
+      last_error = NULL,
+      metadata_json = excluded.metadata_json
+  `).run(
+    sessionId,
+    normalizeRepository(repository),
+    priority,
+    reason,
+    queuedAt,
+    availableAt,
+    JSON.stringify(metadata),
+  );
+}
+
+export function listDeferredExtractions(owner, { repository, limit = 2 }) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const now = nowIso();
+  if (repo) {
+    return owner.db.prepare(`
+      SELECT session_id, repository, status, priority, reason, queued_at, available_at, attempts, last_error, metadata_json
+      FROM deferred_extraction
+      WHERE repository = ?
+        AND status IN ('pending', 'failed')
+        AND available_at <= ?
+      ORDER BY priority DESC, available_at ASC, queued_at ASC
+      LIMIT ?
+    `).all(repo, now, limit);
+  }
+  return owner.db.prepare(`
+    SELECT session_id, repository, status, priority, reason, queued_at, available_at, attempts, last_error, metadata_json
+    FROM deferred_extraction
+    WHERE status IN ('pending', 'failed')
+      AND available_at <= ?
+    ORDER BY priority DESC, available_at ASC, queued_at ASC
+    LIMIT ?
+  `).all(now, limit);
+}
+
+export function markDeferredExtractionRunning(owner, sessionId) {
+  owner.ensureOpen();
+  owner.db.prepare(`
+    UPDATE deferred_extraction
+    SET status = 'running',
+        attempts = attempts + 1,
+        started_at = ?,
+        last_error = NULL
+    WHERE session_id = ?
+  `).run(nowIso(), sessionId);
+}
+
+/**
+ * Atomically claim a pending/failed deferred extraction job for exclusive
+ * processing.  Returns true when the job was successfully claimed by this
+ * caller, false when another worker already holds it or the job is not
+ * available (e.g. not yet due).
+ *
+ * The claim sets a 10-minute lease (configurable via leaseDurationMs) that
+ * must be renewed every ≤2 minutes via heartbeatDeferredExtraction.  If the
+ * lease expires, reclaimStaleDeferredExtractions will reset the job to
+ * "failed" so another worker can pick it up.
+ *
+ * @param {string} sessionId
+ * @param {string} ownerToken - Opaque token identifying the claiming worker
+ * @param {number} [leaseDurationMs=600000] - Lease TTL in milliseconds (default 10 min)
+ * @returns {boolean} true when claimed, false when already held or unavailable
+ */
+export function claimDeferredExtraction(owner, sessionId, ownerToken, leaseDurationMs = 10 * 60 * 1000) {
+  owner.ensureOpen();
+  const now = nowIso();
+  const leaseExpiresAt = new Date(Date.now() + leaseDurationMs).toISOString();
+  const result = owner.db.prepare(`
+    UPDATE deferred_extraction
+    SET status = 'running',
+        attempts = attempts + 1,
+        started_at = ?,
+        owner_token = ?,
+        lease_expires_at = ?,
+        heartbeat_at = ?,
+        last_error = NULL
+    WHERE session_id = ?
+      AND status IN ('pending', 'failed')
+      AND available_at <= ?
+  `).run(now, ownerToken, leaseExpiresAt, now, sessionId, now);
+  return result.changes > 0;
+}
+
+/**
+ * Renew the lease for an active deferred extraction job.  Only succeeds when
+ * the caller still owns the job (owner_token matches) and the job is still
+ * in "running" state.
+ *
+ * Must be called at least once per 10-minute lease window; a 2-minute
+ * heartbeat interval keeps the lease well within its expiry.
+ *
+ * @param {string} sessionId
+ * @param {string} ownerToken
+ * @param {number} [leaseDurationMs=600000] - Renewed lease TTL (default 10 min)
+ * @returns {boolean} true when renewed, false when the lease is already lost
+ */
+export function heartbeatDeferredExtraction(owner, sessionId, ownerToken, leaseDurationMs = 10 * 60 * 1000) {
+  owner.ensureOpen();
+  const now = nowIso();
+  const leaseExpiresAt = new Date(Date.now() + leaseDurationMs).toISOString();
+  const result = owner.db.prepare(`
+    UPDATE deferred_extraction
+    SET heartbeat_at = ?,
+        lease_expires_at = ?
+    WHERE session_id = ?
+      AND owner_token = ?
+      AND status = 'running'
+  `).run(now, leaseExpiresAt, sessionId, ownerToken);
+  return result.changes > 0;
+}
+
+/**
+ * Reclaim running deferred extraction jobs that are no longer making
+ * progress. Lease-aware jobs are reclaimed when their lease expires; legacy
+ * rows without lease metadata are reclaimed after the bounded stale window.
+ * Resets each to "failed" so the next processing cycle can retry it.
+ *
+ * @param {{ staleAfterMs?: number }} [options]
+ * @returns {number} Number of jobs reclaimed
+ */
+export function reclaimStaleDeferredExtractions(owner, { staleAfterMs = 30 * 60 * 1000 } = {}) {
+  owner.ensureOpen();
+  const now = nowIso();
+  const numericStaleAfterMs = Number(staleAfterMs);
+  const boundedStaleAfterMs = Number.isFinite(numericStaleAfterMs)
+    ? Math.max(1, numericStaleAfterMs)
+    : 30 * 60 * 1000;
+  const staleCutoff = new Date(Date.now() - boundedStaleAfterMs).toISOString();
+  const result = owner.db.prepare(`
+    UPDATE deferred_extraction
+    SET status = 'failed',
+        last_error = CASE
+          WHEN lease_expires_at IS NOT NULL AND lease_expires_at < ?
+            THEN 'lease expired'
+          ELSE 'stale running job reclaimed'
+        END,
+        available_at = ?,
+        completed_at = NULL,
+        owner_token = NULL,
+        lease_expires_at = NULL,
+        heartbeat_at = NULL
+    WHERE status = 'running'
+      AND (
+        (lease_expires_at IS NOT NULL AND lease_expires_at < ?)
+        OR (
+          lease_expires_at IS NULL
+          AND COALESCE(started_at, queued_at) IS NOT NULL
+          AND COALESCE(started_at, queued_at) < ?
+        )
+      )
+  `).run(now, now, now, staleCutoff);
+  return result.changes;
+}
+
+export function completeDeferredExtraction(owner, sessionId, ownerToken = null) {
+  owner.ensureOpen();
+  const completedAt = nowIso();
+  const row = owner.db.prepare(`
+    SELECT repository
+    FROM deferred_extraction
+    WHERE session_id = ?
+    LIMIT 1
+  `).get(sessionId);
+  // When an ownerToken is provided, guard against stale workers completing
+  // a job that has already been reclaimed by another caller.  Without a
+  // token (legacy callers), behave as before.
+  const result = ownerToken
+    ? owner.db.prepare(`
+        UPDATE deferred_extraction
+        SET status = 'completed',
+            completed_at = ?,
+            last_error = NULL
+        WHERE session_id = ?
+          AND owner_token = ?
+          AND status = 'running'
+      `).run(completedAt, sessionId, ownerToken)
+    : owner.db.prepare(`
+        UPDATE deferred_extraction
+        SET status = 'completed',
+            completed_at = ?,
+            last_error = NULL
+        WHERE session_id = ?
+      `).run(completedAt, sessionId);
+  // Only update activity state when the completion actually landed.
+  if (!ownerToken || result.changes > 0) {
+    owner.upsertActivitySuccess({
+      repository: row?.repository ?? null,
+      updates: {
+        lastExtractionCompletionAt: completedAt,
+        lastExtractionRepository: row?.repository ?? null,
+      },
+    });
+    owner.upsertActivitySuccess({
+      repository: null,
+      updates: {
+        lastExtractionCompletionAt: completedAt,
+        lastExtractionRepository: row?.repository ?? null,
+      },
+    });
+  }
+}
+
+export function failDeferredExtraction(owner, sessionId, { errorMessage, retryDelayMinutes = 15, ownerToken = null }) {
+  owner.ensureOpen();
+  const availableAt = new Date(Date.now() + (retryDelayMinutes * 60 * 1000)).toISOString();
+  // Guard by ownerToken when provided so a stale worker cannot clobber the
+  // state of a job that has already been reclaimed by a new worker.
+  if (ownerToken) {
+    owner.db.prepare(`
+      UPDATE deferred_extraction
+      SET status = 'failed',
+          available_at = ?,
+          last_error = ?,
+          owner_token = NULL,
+          lease_expires_at = NULL
+      WHERE session_id = ?
+        AND owner_token = ?
+        AND status = 'running'
+    `).run(availableAt, errorMessage, sessionId, ownerToken);
+  } else {
+    owner.db.prepare(`
+      UPDATE deferred_extraction
+      SET status = 'failed',
+          available_at = ?,
+          last_error = ?
+      WHERE session_id = ?
+    `).run(availableAt, errorMessage, sessionId);
+  }
+}

--- a/lib/db/db-embedding.mjs
+++ b/lib/db/db-embedding.mjs
@@ -1,0 +1,170 @@
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { buildSemanticEligibilitySql } from "./db-retrieval-policy.mjs";
+import { nowIso } from "./db-shared.mjs";
+
+/**
+ * Ensure the memory_embedding table exists (semantic search cache).
+ * Additive side table owned by the semantic-search feature; created
+ * idempotently so existing databases adopt it without a full migration.
+ */
+export function ensureMemoryEmbeddingTable(owner) {
+  owner.ensureOpen();
+  owner.db.exec(`
+    CREATE TABLE IF NOT EXISTS memory_embedding (
+      memory_id TEXT PRIMARY KEY,
+      content_hash TEXT,
+      provider TEXT,
+      model TEXT,
+      dimensions INTEGER,
+      vector TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `);
+  // Existing databases may have the original memory_id/vector-only table.
+  // Add metadata columns in place so old rows remain readable but cannot be
+  // mistaken for a validated cache entry until they are refreshed.
+  for (const [column, definition] of [
+    ["content_hash", "TEXT"],
+    ["provider", "TEXT"],
+    ["model", "TEXT"],
+    ["dimensions", "INTEGER"],
+  ]) {
+    try {
+      owner.ensureColumn("memory_embedding", column, definition);
+    } catch (error) {
+      // Another Lore process may have added the column between PRAGMA and
+      // ALTER TABLE. Re-check before surfacing a genuine schema failure.
+      if (!owner.tableHasColumn("memory_embedding", column)) {
+        throw error;
+      }
+    }
+  }
+}
+
+/**
+ * List non-superseded semantic memories eligible for embedding-based search.
+ *
+ * @param {{ types?: string[], repository?: string | null }} [opts]
+ * @returns {Array<{ id: string, type: string, content: string, repository: string | null, updated_at: string }>}
+ */
+export function listSemanticMemoriesForEmbedding(owner, { types = [], scopes = [], repository = null, includeOtherRepositories = false, transferableFallback = false, embeddingState = "all", limit = 256, offset = null, after = null, stableOrder = false, now = new Date() } = {}) {
+  owner.ensureOpen();
+  const params = [];
+  const hasEmbeddingTable = owner.tableExists("memory_embedding");
+  const columns = `sm.rowid AS memory_rowid, sm.id, sm.type, sm.content, sm.repository, sm.scope, sm.scope_source, sm.updated_at,
+    sm.expires_at, sm.canonical_key, sm.metadata_json, sm.source_session_id${hasEmbeddingTable ? ", me.updated_at AS embedding_updated_at, me.vector, me.content_hash, me.provider, me.model, me.dimensions" : ""}`;
+  let sql = `SELECT ${columns} FROM semantic_memory sm ${hasEmbeddingTable ? "LEFT JOIN memory_embedding me ON me.memory_id = sm.id" : ""}`;
+  const eligibility = buildSemanticEligibilitySql({ alias: "sm", repository: normalizeRepository(repository), includeOtherRepositories, transferableFallback, now });
+  sql += ` WHERE ${eligibility.sql}`;
+  params.push(...eligibility.params);
+  if (types.length > 0) {
+    sql += ` AND sm.type IN (${types.map(() => "?").join(", ")})`;
+    params.push(...types);
+  }
+  if (scopes.length > 0) {
+    sql += ` AND sm.scope IN (${scopes.map(() => "?").join(", ")})`;
+    params.push(...scopes);
+  }
+  if (embeddingState === "missing" && hasEmbeddingTable) {
+    sql += " AND me.memory_id IS NULL";
+  } else if (embeddingState === "cached" && hasEmbeddingTable) {
+    sql += " AND me.memory_id IS NOT NULL";
+  }
+  if (after && typeof after === "object") {
+    if (stableOrder) {
+      sql += " AND (sm.updated_at > ? OR (sm.updated_at = ? AND sm.id > ?))";
+      params.push(after.updatedAt ?? "", after.updatedAt ?? "", after.id ?? "");
+    } else if (after.memoryRowid !== undefined && after.memoryRowid !== null) {
+      sql += " AND sm.rowid > ?";
+      params.push(Math.max(0, Math.trunc(Number(after.memoryRowid) || 0)));
+    } else {
+      sql += " AND (sm.updated_at > ? OR (sm.updated_at = ? AND sm.id > ?))";
+      params.push(after.updatedAt ?? "", after.updatedAt ?? "", after.id ?? "");
+    }
+  }
+  sql += stableOrder
+    ? " ORDER BY sm.updated_at ASC, sm.id ASC"
+    : hasEmbeddingTable
+    ? " ORDER BY sm.rowid ASC"
+    : " ORDER BY sm.updated_at ASC, sm.id ASC";
+  sql += " LIMIT ?";
+  params.push(Math.max(1, Math.min(256, Math.trunc(Number(limit) || 256))));
+  if ((!after || typeof after !== "object") && offset !== null) {
+    sql += " OFFSET ?";
+    params.push(Math.max(0, Math.trunc(Number(offset) || 0)));
+  }
+  return owner.mapRetrievalRepositories(owner.db.prepare(sql).all(...params), normalizeRepository(repository));
+}
+
+export function countSemanticMemoriesForEmbedding(owner, { types = [], scopes = [], repository = null, includeOtherRepositories = false, now = new Date() } = {}) {
+  owner.ensureOpen();
+  const eligibility = buildSemanticEligibilitySql({
+    alias: "sm",
+    repository: normalizeRepository(repository),
+    includeOtherRepositories,
+    now,
+  });
+  const params = [...eligibility.params];
+  let sql = `SELECT COUNT(*) AS count FROM semantic_memory sm WHERE ${eligibility.sql}`;
+  if (types.length > 0) {
+    sql += ` AND sm.type IN (${types.map(() => "?").join(", ")})`;
+    params.push(...types);
+  }
+  if (scopes.length > 0) {
+    sql += ` AND sm.scope IN (${scopes.map(() => "?").join(", ")})`;
+    params.push(...scopes);
+  }
+  return Number(owner.db.prepare(sql).get(...params)?.count ?? 0);
+}
+
+/**
+ * Read the cached embedding vector for a memory, or null when absent.
+ *
+ * @param {string} memoryId
+ * @param {{ contentHash?: string, provider?: string, model?: string, dimensions?: number }} [key]
+ * @returns {string | null} JSON-encoded vector
+ */
+export function getMemoryEmbedding(owner, memoryId, key = null) {
+  owner.ensureOpen();
+  const row = owner.db.prepare(`
+    SELECT vector, content_hash, provider, model, dimensions
+    FROM memory_embedding
+    WHERE memory_id = ?
+  `).get(memoryId);
+  if (!row) {
+    return null;
+  }
+  if (key && (
+    row.content_hash !== key.contentHash
+    || row.provider !== key.provider
+    || row.model !== key.model
+    || Number(row.dimensions) !== Number(key.dimensions)
+  )) {
+    return null;
+  }
+  return row.vector ?? null;
+}
+
+/**
+ * Cache an embedding vector for a memory (insert or replace).
+ *
+ * @param {string} memoryId
+ * @param {number[]} vector
+ * @param {{ contentHash?: string, provider?: string, model?: string, dimensions?: number }} [key]
+ */
+export function setMemoryEmbedding(owner, memoryId, vector, key = {}) {
+  owner.ensureOpen();
+  owner.db.prepare(`
+    INSERT OR REPLACE INTO memory_embedding
+      (memory_id, content_hash, provider, model, dimensions, vector, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    memoryId,
+    key.contentHash ?? null,
+    key.provider ?? null,
+    key.model ?? null,
+    Number.isInteger(Number(key.dimensions)) ? Number(key.dimensions) : null,
+    JSON.stringify(vector),
+    nowIso(),
+  );
+}

--- a/lib/db/db-episode-search.mjs
+++ b/lib/db/db-episode-search.mjs
@@ -10,7 +10,7 @@ import { buildSemanticEligibilitySql, isSemanticMemoryRowEligible } from "./db-r
 import { nowIso, SCOPE_SOURCE, applyScopeFilter } from "./db-shared.mjs";
 import { serializeEpisodeTraceRow, buildLocalEligibility } from "./db-trace-serializers.mjs";
 
-export function dedupeSemanticRows(rows) {
+function dedupeSemanticRows(rows) {
   const seen = new Set();
   const deduped = [];
   for (const row of rows) {
@@ -24,11 +24,11 @@ export function dedupeSemanticRows(rows) {
   return deduped;
 }
 
-export function normalizeDaySummaryRepository(repository) {
+function normalizeDaySummaryRepository(repository) {
   return normalizeRepository(repository) ?? "";
 }
 
-export function dedupeEpisodesWithTrace(episodes, currentRepository = null) {
+function dedupeEpisodesWithTrace(episodes, currentRepository = null) {
   const seenSummaries = new Set();
   const seenSessions = new Set();
   const deduped = [];
@@ -65,7 +65,7 @@ export function dedupeEpisodesWithTrace(episodes, currentRepository = null) {
   };
 }
 
-export function filterEpisodePoolWithTrace(pool, stageName, repository) {
+function filterEpisodePoolWithTrace(pool, stageName, repository) {
   const included = [];
   const filtered = [];
   for (const episode of pool) {
@@ -79,7 +79,7 @@ export function filterEpisodePoolWithTrace(pool, stageName, repository) {
   return { included, filtered };
 }
 
-export function separateGenericEpisodes(ordered, repository) {
+function separateGenericEpisodes(ordered, repository) {
   const hasNonGeneric = ordered.some((episode) => !isGenericWorkSummary(episode.summary));
   const genericFiltered = hasNonGeneric
     ? ordered

--- a/lib/db/db-episode-search.mjs
+++ b/lib/db/db-episode-search.mjs
@@ -1,0 +1,618 @@
+import { classifyEpisodeDigest, MEMORY_SCOPE } from "../memory/memory-scope.mjs";
+import { parseJsonObject } from "../utils/json-object-utils.mjs";
+import { jsonText } from "../utils/json-text-utils.mjs";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { buildFtsOrRetryQuery, normalizeFtsToken, QUERY_ALIASES, sanitizeFtsQuery as sanitizeNormalizedFtsQuery } from "../utils/query-normalizer.mjs";
+import { normalizeText } from "../utils/text-normalizer.mjs";
+import { buildEpisodeQueryTermsets, buildTermWeights, explainEpisodeExclusionReason, isGenericWorkSummary, isPlaceholderSummary, isToolInvocationSummary, scoreAndRankEpisodeCandidates } from "./db-episode-scoring.mjs";
+import { buildImprovementArtifactEpisode, IMPROVEMENT_SOURCE_KIND, IMPROVEMENT_STATUS } from "./db-improvement-artifacts.mjs";
+import { buildSemanticEligibilitySql, isSemanticMemoryRowEligible } from "./db-retrieval-policy.mjs";
+import { nowIso, SCOPE_SOURCE, applyScopeFilter } from "./db-shared.mjs";
+import { serializeEpisodeTraceRow, buildLocalEligibility } from "./db-trace-serializers.mjs";
+
+export function dedupeSemanticRows(rows) {
+  const seen = new Set();
+  const deduped = [];
+  for (const row of rows) {
+    const key = `${row.type}::${normalizeText(row.content).toLowerCase()}::${row.scope ?? MEMORY_SCOPE.REPO}::${row.repository ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(row);
+  }
+  return deduped;
+}
+
+export function normalizeDaySummaryRepository(repository) {
+  return normalizeRepository(repository) ?? "";
+}
+
+export function dedupeEpisodesWithTrace(episodes, currentRepository = null) {
+  const seenSummaries = new Set();
+  const seenSessions = new Set();
+  const deduped = [];
+  const filtered = [];
+
+  for (const episode of episodes) {
+    if (seenSessions.has(episode.session_id)) {
+      filtered.push({
+        stage: "dedupe",
+        reason: "duplicate_session",
+        row: serializeEpisodeTraceRow(episode, currentRepository),
+      });
+      continue;
+    }
+    const summaryKey = normalizeText(episode.summary).toLowerCase();
+    if (summaryKey && seenSummaries.has(summaryKey)) {
+      filtered.push({
+        stage: "dedupe",
+        reason: "duplicate_summary",
+        row: serializeEpisodeTraceRow(episode, currentRepository),
+      });
+      continue;
+    }
+    seenSessions.add(episode.session_id);
+    if (summaryKey) {
+      seenSummaries.add(summaryKey);
+    }
+    deduped.push(episode);
+  }
+
+  return {
+    rows: deduped,
+    filtered,
+  };
+}
+
+export function filterEpisodePoolWithTrace(pool, stageName, repository) {
+  const included = [];
+  const filtered = [];
+  for (const episode of pool) {
+    const reason = explainEpisodeExclusionReason(episode);
+    if (!reason) {
+      included.push(episode);
+    } else {
+      filtered.push({ stage: stageName, reason, row: serializeEpisodeTraceRow(episode, repository) });
+    }
+  }
+  return { included, filtered };
+}
+
+export function separateGenericEpisodes(ordered, repository) {
+  const hasNonGeneric = ordered.some((episode) => !isGenericWorkSummary(episode.summary));
+  const genericFiltered = hasNonGeneric
+    ? ordered
+      .filter((episode) => isGenericWorkSummary(episode.summary))
+      .map((episode) => ({
+        stage: "preference",
+        reason: "generic_work_summary",
+        row: serializeEpisodeTraceRow(episode, repository),
+      }))
+    : [];
+  const preferred = hasNonGeneric
+    ? ordered.filter((episode) => !isGenericWorkSummary(episode.summary))
+    : ordered;
+  return { preferred, genericFiltered };
+}
+
+export function hasEpisodeDigest(owner, sessionId) {
+  owner.ensureOpen();
+  const row = owner.db.prepare(`
+    SELECT id FROM episode_digest WHERE session_id = ?
+  `).get(sessionId);
+  return !!row;
+}
+
+export function upsertEpisodeDigest(owner, digest) {
+  owner.ensureOpen();
+  const timestamp = nowIso();
+  const classification = classifyEpisodeDigest(digest);
+  owner.db.prepare(`
+    INSERT INTO episode_digest (
+      id, session_id, scope, scope_source, repository, branch, summary, actions_json, decisions_json,
+      learnings_json, files_changed_json, refs_json, significance, themes_json,
+      open_items_json, source, date_key, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(session_id) DO UPDATE SET
+      scope = CASE
+        WHEN episode_digest.scope_source = 'manual' THEN episode_digest.scope
+        ELSE excluded.scope
+      END,
+      repository = CASE
+        WHEN episode_digest.scope_source = 'manual' THEN episode_digest.repository
+        ELSE excluded.repository
+      END,
+      branch = excluded.branch,
+      summary = excluded.summary,
+      actions_json = excluded.actions_json,
+      decisions_json = excluded.decisions_json,
+      learnings_json = excluded.learnings_json,
+      files_changed_json = excluded.files_changed_json,
+      refs_json = excluded.refs_json,
+      significance = excluded.significance,
+      themes_json = excluded.themes_json,
+      open_items_json = excluded.open_items_json,
+      source = excluded.source,
+      date_key = excluded.date_key,
+      updated_at = excluded.updated_at
+  `).run(
+    digest.id ?? digest.sessionId,
+    digest.sessionId,
+    classification.scope,
+    SCOPE_SOURCE.AUTO,
+    classification.repository,
+    digest.branch ?? null,
+    digest.summary,
+    jsonText(digest.actions),
+    jsonText(digest.decisions),
+    jsonText(digest.learnings),
+    jsonText(digest.filesChanged),
+    jsonText(digest.refs),
+    digest.significance ?? 5,
+    jsonText(digest.themes),
+    jsonText(digest.openItems),
+    digest.source ?? "rule",
+    digest.dateKey,
+    digest.createdAt ?? timestamp,
+    timestamp,
+  );
+}
+
+export function refreshDaySummary(owner, { date, repository }) {
+  owner.ensureOpen();
+  const repo = normalizeDaySummaryRepository(repository);
+  const rows = owner.db.prepare(`
+    SELECT session_id, summary
+    FROM episode_digest
+    WHERE date_key = ? AND (
+      (? = '' AND (repository IS NULL OR repository = '')) OR repository = ?
+    )
+    ORDER BY updated_at DESC
+    LIMIT 8
+  `).all(date, repo, repo);
+
+  const summaries = rows
+    .map((row) => ({
+      session_id: row.session_id,
+      summary: normalizeText(row.summary),
+    }))
+    .filter((row) => row.summary.length > 0);
+
+  const preferred = summaries.some((row) => !isGenericWorkSummary(row.summary) && !isPlaceholderSummary(row.summary) && !isToolInvocationSummary(row.summary))
+    ? summaries.filter((row) => !isGenericWorkSummary(row.summary) && !isPlaceholderSummary(row.summary) && !isToolInvocationSummary(row.summary))
+    : summaries;
+
+  const summary = preferred.length === 0
+    ? "No remembered activity."
+    : preferred.map((row) => `- ${row.summary}`).join("\n");
+
+  owner.db.prepare(`
+    INSERT INTO day_summary (date_key, repository, summary, episode_ids_json, computed_at)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT(date_key, repository) DO UPDATE SET
+      summary = excluded.summary,
+      episode_ids_json = excluded.episode_ids_json,
+      computed_at = excluded.computed_at
+  `).run(
+    date,
+    repo,
+    summary,
+    JSON.stringify(preferred.map((row) => row.session_id)),
+    nowIso(),
+  );
+}
+
+export function mapRetrievalRepositories(owner, rows, repository) {
+  if (!repository || rows.length === 0) return rows;
+  const aliases = new Set(owner.db.prepare("SELECT legacy FROM repository_identity_mapping WHERE canonical = ?")
+    .all(repository).map((row) => row.legacy));
+  return rows.map((row) => aliases.has(row.repository)
+    ? { ...row, sourceRepository: row.repository, repository }
+    : row);
+}
+
+export function searchSemantic(owner, {
+  query,
+  repository,
+  includeOtherRepositories = false,
+  types = [],
+  scopes = [],
+  limit = 8,
+  includeTypedFallback = false,
+  expandAliases = true,
+  standingExtractorPolicy = false,
+  now = new Date(),
+}) {
+  owner.ensureOpen();
+  const sanitized = sanitizeNormalizedFtsQuery(query, {
+    aliases: expandAliases ? QUERY_ALIASES : {},
+    normalize: normalizeFtsToken,
+  });
+  const repo = normalizeRepository(repository);
+  const runSearch = (ftsQuery, effectiveLimit = limit, excludedIds = []) => {
+    const pageSize = Math.max(64, Math.min(256, Math.max(effectiveLimit, 8) * 8));
+    const collected = [];
+    for (let offset = 0; ; offset += pageSize) {
+      const params = [];
+      let sql = `
+      SELECT
+        sm.id,
+        sm.type,
+        sm.content,
+        sm.scope,
+        sm.scope_source,
+        sm.confidence,
+        sm.repository,
+        sm.domain_key,
+        sm.updated_at,
+        sm.source_session_id,
+        sm.canonical_key,
+        sm.superseded_by,
+        sm.reinforcement_count,
+        sm.last_seen_at,
+        sm.expires_at,
+        sm.tags,
+        sm.metadata_json
+      FROM semantic_memory sm
+      `;
+
+      if (ftsQuery) {
+        sql += ` JOIN semantic_fts ON semantic_fts.rowid = sm.rowid `;
+      }
+
+      const eligibility = buildSemanticEligibilitySql({
+      alias: "sm",
+      repository: repo,
+      includeOtherRepositories,
+      now,
+      });
+      sql += ` WHERE ${eligibility.sql} `;
+      params.push(...eligibility.params);
+
+      if (types.length > 0) {
+      sql += ` AND sm.type IN (${types.map(() => "?").join(", ")}) `;
+      params.push(...types);
+      }
+
+      if (scopes.length > 0) {
+      sql += ` AND sm.scope IN (${scopes.map(() => "?").join(", ")}) `;
+      params.push(...scopes);
+      }
+
+      if (standingExtractorPolicy) {
+      sql += ` AND COALESCE(json_extract(sm.metadata_json, '$.source'), '') = 'rule_extractor'
+        AND (
+          COALESCE(json_extract(sm.metadata_json, '$.confidenceBasis'), '') IN ('explicit_preference_sentence', 'standing_policy_sentence')
+          OR instr(' ' || lower(COALESCE(sm.tags, '')) || ' ', ' preference ') > 0
+          OR instr(' ' || lower(COALESCE(sm.tags, '')) || ' ', ' policy ') > 0
+        ) `;
+      }
+
+      if (excludedIds.length > 0) {
+      sql += ` AND sm.id NOT IN (${excludedIds.map(() => "?").join(", ")}) `;
+      params.push(...excludedIds);
+      }
+
+      if (ftsQuery) {
+      sql += ` AND semantic_fts MATCH ? `;
+      params.push(ftsQuery);
+      sql += ` ORDER BY bm25(semantic_fts), sm.updated_at DESC, sm.reinforcement_count DESC `;
+      } else {
+      sql += ` ORDER BY sm.updated_at DESC, sm.reinforcement_count DESC `;
+      }
+
+      params.push(pageSize, offset);
+      const page = owner.mapRetrievalRepositories(owner.db.prepare(`${sql} LIMIT ? OFFSET ?`).all(...params), repo);
+      collected.push(...page.filter((row) => isSemanticMemoryRowEligible(row, {
+        repository: repo,
+        includeOtherRepositories,
+        now,
+      }).eligible));
+      if (collected.length >= effectiveLimit || page.length < pageSize) break;
+    }
+    return collected.slice(0, effectiveLimit);
+  };
+
+  let lexicalRows = runSearch(sanitized);
+  if (sanitized && lexicalRows.length === 0) {
+    const orQuery = buildFtsOrRetryQuery(query);
+    if (orQuery && orQuery !== sanitized) {
+      lexicalRows = runSearch(orQuery);
+    }
+  }
+  const shouldRunTypedFallback = includeTypedFallback
+    && types.length > 0
+    && sanitized
+    && lexicalRows.length < limit;
+  const lexicalIds = lexicalRows.map((row) => row.id).filter(Boolean);
+  const fallbackRows = shouldRunTypedFallback
+    ? runSearch("", Math.max(1, limit - lexicalRows.length), lexicalIds)
+    : [];
+  const rows = fallbackRows.length > 0
+    ? dedupeSemanticRows([...lexicalRows, ...fallbackRows])
+    : lexicalRows;
+
+  const eligibleRows = rows.filter((row) => isSemanticMemoryRowEligible(row, {
+    repository: repo,
+    includeOtherRepositories,
+    now,
+  }).eligible);
+  return dedupeSemanticRows(eligibleRows).slice(0, limit)
+    .map((row) => ({
+      ...row,
+      domainKey: row.domain_key ?? null,
+      metadata: parseJsonObject(row.metadata_json),
+    }));
+}
+
+export function searchEpisodes(owner, { query, repository, includeOtherRepositories = false, scopes = [], limit = 5 }) {
+  owner.ensureOpen();
+  const sanitized = sanitizeNormalizedFtsQuery(query, {
+    aliases: QUERY_ALIASES,
+    normalize: normalizeFtsToken,
+  });
+  const repo = normalizeRepository(repository);
+  const params = [];
+  let sql = `
+    SELECT
+      ed.id,
+      ed.session_id,
+      ed.scope,
+      ed.scope_source,
+      ed.repository,
+      ed.summary,
+      ed.actions_json,
+      ed.decisions_json,
+      ed.files_changed_json,
+      ed.themes_json,
+      ed.open_items_json,
+      ed.significance,
+      ed.date_key,
+      ed.updated_at
+    FROM episode_digest ed
+  `;
+
+  if (sanitized) {
+    sql += ` JOIN episode_fts ON episode_fts.rowid = ed.rowid `;
+  }
+
+  sql += ` WHERE 1 = 1 `;
+
+  sql = applyScopeFilter(sql, params, repo, includeOtherRepositories, "ed");
+
+  if (scopes.length > 0) {
+    sql += ` AND ed.scope IN (${scopes.map(() => "?").join(", ")}) `;
+    params.push(...scopes);
+  }
+
+  if (sanitized) {
+    sql += ` AND episode_fts MATCH ? `;
+    params.push(sanitized);
+    sql += ` ORDER BY bm25(episode_fts), ed.significance DESC, ed.updated_at DESC `;
+  } else {
+    sql += ` ORDER BY ed.updated_at DESC, ed.significance DESC `;
+  }
+
+  sql += ` LIMIT ? `;
+  params.push(limit);
+  return owner.mapRetrievalRepositories(owner.db.prepare(sql).all(...params), repo);
+}
+
+export function findRelevantEpisodesDetailed(owner, { prompt, repository, includeOtherRepositories = false, scopes = [], limit = 5 }) {
+  const { entityTerms, hybridEnabled, effectivePrimaryTerms, effectiveTerms, lexicalQuery } =
+    buildEpisodeQueryTermsets(prompt, owner.config);
+  const improvementRows = owner.listImprovementArtifacts({
+    sourceKind: IMPROVEMENT_SOURCE_KIND.REPLAY,
+    status: IMPROVEMENT_STATUS.ACTIVE,
+    limit: Math.max(limit * 3, 12),
+  });
+  const improvementEpisodes = improvementRows
+    .filter((artifact) => {
+      const evidence = parseJsonObject(artifact.evidence_json);
+      return evidence.caseType === "ranking_target";
+    })
+    .map((artifact) => buildImprovementArtifactEpisode(artifact, repository))
+    .filter(Boolean);
+  const rawExactMatches = owner.searchEpisodes({
+    query: lexicalQuery, repository, includeOtherRepositories, scopes, limit: Math.max(limit * 2, 8),
+  });
+  const { included: exactMatches, filtered: exactFiltered } =
+    filterEpisodePoolWithTrace([...rawExactMatches, ...improvementEpisodes], "exact_matches", repository);
+
+  const seen = new Set(exactMatches.map((episode) => episode.session_id));
+  const rawFallbackPool = owner.searchEpisodes({
+    query: "", repository, includeOtherRepositories, scopes, limit: Math.max(limit * 8, 24),
+  });
+  const { included: fallbackPool, filtered: fallbackFiltered } =
+    filterEpisodePoolWithTrace([...rawFallbackPool, ...improvementEpisodes], "fallback_pool", repository);
+
+  const deduped = dedupeEpisodesWithTrace([...exactMatches, ...fallbackPool], repository);
+  const candidatePool = deduped.rows;
+  const exactMatchIds = new Set(exactMatches.map((episode) => episode.session_id));
+  const termWeights = buildTermWeights(candidatePool, effectiveTerms);
+
+  // Build rank maps for RRF fusion: preserve the FTS (BM25) order and the recency order
+  // so the final scoring blends both signals rather than discarding FTS rank.
+  const ftsRankMap = hybridEnabled
+    ? new Map(rawExactMatches.map((ep, i) => [ep.session_id, i]))
+    : new Map();
+  const recencyRankMap = hybridEnabled
+    ? new Map(rawFallbackPool.map((ep, i) => [ep.session_id, i]))
+    : new Map();
+  const ranked = scoreAndRankEpisodeCandidates({
+    candidatePool, seen, exactMatchIds, effectiveTerms, effectivePrimaryTerms, termWeights,
+    hybridEnabled, ftsRankMap, recencyRankMap,
+    ftsMissRank: rawExactMatches.length, recencyMissRank: rawFallbackPool.length,
+  });
+
+  const ordered = ranked.map((entry) => entry.episode);
+  const { preferred, genericFiltered } = separateGenericEpisodes(ordered, repository);
+  const includedRows = preferred.slice(0, limit);
+  return {
+    episodes: includedRows,
+    trace: {
+      prompt,
+      repository,
+      includeOtherRepositories,
+      eligibleScopes: scopes.length > 0 ? [...scopes] : buildLocalEligibility(repository),
+      primaryTerms: effectivePrimaryTerms,
+      entityTerms: hybridEnabled ? entityTerms : [],
+      hybridEnabled,
+      terms: effectiveTerms,
+      lexicalQuery,
+      rankedRows: ranked
+        .slice(0, Math.max(limit * 3, 12))
+        .map((entry) => ({
+          ...serializeEpisodeTraceRow(entry.episode, repository),
+          score: Number(entry.score.toFixed(2)),
+        })),
+      includedRows: includedRows.map((episode) => serializeEpisodeTraceRow(episode, repository)),
+      filtered: [
+        ...exactFiltered,
+        ...fallbackFiltered,
+        ...deduped.filtered,
+        ...genericFiltered,
+      ],
+    },
+  };
+}
+
+export function findRelevantEpisodes(owner, { prompt, repository, includeOtherRepositories = false, scopes = [], limit = 5 }) {
+  return owner.findRelevantEpisodesDetailed({
+    prompt,
+    repository,
+    includeOtherRepositories,
+    scopes,
+    limit,
+  }).episodes;
+}
+
+export function getDaySummary(owner, { date, repository }) {
+  owner.ensureOpen();
+  return owner.getDaySummaries({ date, repository, limit: 1 })[0];
+}
+
+export function getDaySummaries(owner, { date, repository, includeOtherRepositories = false, limit = 4 }) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const params = [date];
+  let sql = `
+    SELECT date_key, repository, summary, episode_ids_json, computed_at
+    FROM day_summary
+    WHERE date_key = ?
+  `;
+
+  if (!includeOtherRepositories) {
+    const scopedRepo = normalizeDaySummaryRepository(repository);
+    sql += ` AND ((? = '' AND repository = '') OR repository = ? OR repository IN (SELECT legacy FROM repository_identity_mapping WHERE canonical = ?)) `;
+    params.push(scopedRepo, scopedRepo, scopedRepo);
+  }
+
+  sql += `
+    ORDER BY
+      CASE
+        WHEN ? IS NOT NULL AND repository = ? THEN 0
+        WHEN repository IS NULL OR repository = '' THEN 1
+        ELSE 2
+      END,
+      computed_at DESC,
+      repository ASC
+    LIMIT ?
+  `;
+  params.push(repo, repo, limit);
+  return owner.mapRetrievalRepositories(owner.db.prepare(sql).all(...params), repo);
+}
+
+export function findRelevantEpisodesByDateDetailed(owner, { date, repository, includeOtherRepositories = false, limit = 5 }) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const params = [date];
+  let sql = `
+    SELECT
+      ed.id,
+      ed.session_id,
+      ed.scope,
+      ed.scope_source,
+      ed.repository,
+      ed.summary,
+      ed.actions_json,
+      ed.decisions_json,
+      ed.files_changed_json,
+      ed.themes_json,
+      ed.open_items_json,
+      ed.significance,
+      ed.date_key,
+      ed.updated_at
+    FROM episode_digest ed
+    WHERE ed.date_key = ?
+  `;
+
+  sql = applyScopeFilter(sql, params, repo, includeOtherRepositories, "ed");
+
+  sql += `
+    ORDER BY
+      CASE
+        WHEN ? IS NOT NULL AND ed.repository = ? THEN 0
+        WHEN ed.scope = ? THEN 1
+        ELSE 2
+      END,
+      ed.significance DESC,
+      ed.updated_at DESC
+    LIMIT ?
+  `;
+  params.push(repo, repo, MEMORY_SCOPE.GLOBAL, Math.max(limit * 3, 12));
+
+  const rawRows = owner.mapRetrievalRepositories(owner.db.prepare(sql).all(...params), repo);
+  const filtered = [];
+  const eligibleRows = rawRows.filter((episode) => {
+    const reason = explainEpisodeExclusionReason(episode);
+    if (!reason) {
+      return true;
+    }
+    filtered.push({
+      stage: "date_matches",
+      reason,
+      row: serializeEpisodeTraceRow(episode, repository),
+    });
+    return false;
+  });
+
+  const deduped = dedupeEpisodesWithTrace(eligibleRows, repository);
+  const ordered = deduped.rows;
+  const genericFiltered = ordered.some((episode) => !isGenericWorkSummary(episode.summary))
+    ? ordered
+        .filter((episode) => isGenericWorkSummary(episode.summary))
+        .map((episode) => ({
+          stage: "preference",
+          reason: "generic_work_summary",
+          row: serializeEpisodeTraceRow(episode, repository),
+        }))
+    : [];
+  const preferred = ordered.some((episode) => !isGenericWorkSummary(episode.summary))
+    ? ordered.filter((episode) => !isGenericWorkSummary(episode.summary))
+    : ordered;
+  const includedRows = preferred.slice(0, limit);
+
+  return {
+    episodes: includedRows,
+    trace: {
+      prompt: `date:${date}`,
+      repository,
+      includeOtherRepositories,
+      eligibleScopes: includeOtherRepositories ? [] : buildLocalEligibility(repository),
+      primaryTerms: [],
+      terms: [],
+      lexicalQuery: "",
+      rankedRows: preferred
+        .slice(0, Math.max(limit * 3, 12))
+        .map((episode) => serializeEpisodeTraceRow(episode, repository)),
+      includedRows: includedRows.map((episode) => serializeEpisodeTraceRow(episode, repository)),
+      filtered: [
+        ...filtered,
+        ...deduped.filtered,
+        ...genericFiltered,
+      ],
+    },
+  };
+}

--- a/lib/db/db-error-telemetry.mjs
+++ b/lib/db/db-error-telemetry.mjs
@@ -1,0 +1,53 @@
+import crypto from "node:crypto";
+import { nowIso } from "./db-shared.mjs";
+
+/**
+ * Persist a privacy-minimised error telemetry record.
+ * Accepts only categorical fields — never raw messages or stacks.
+ *
+ * @param {{ sessionId: string | null, contextCategory: string, recoverability: string, fingerprint: string }} record
+ * @returns {string} Generated record ID.
+ */
+export function insertErrorTelemetry(owner, { sessionId, contextCategory, recoverability, fingerprint }) {
+  owner.ensureOpen();
+  const id = crypto.randomUUID();
+  owner.db.prepare(`
+    INSERT INTO error_telemetry (id, session_id, context_category, recoverability, fingerprint, created_at)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    sessionId ?? null,
+    String(contextCategory || "unknown"),
+    String(recoverability || "unknown"),
+    String(fingerprint || ""),
+    nowIso(),
+  );
+  return id;
+}
+
+/**
+ * Prune old error telemetry rows for retention compliance.
+ * Deletes rows older than maxAgeMs and trims to maxRowsGlobal.
+ *
+ * @param {{ maxRowsGlobal?: number, maxAgeMs?: number }} options
+ * @returns {{ deletedByAge: number, deletedByLimit: number }}
+ */
+export function pruneErrorTelemetry(owner, {
+  maxRowsGlobal = 500,
+  maxAgeMs = 30 * 24 * 60 * 60 * 1000,
+} = {}) {
+  owner.ensureOpen();
+  const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
+  const byAge = owner.db.prepare(
+    `DELETE FROM error_telemetry WHERE created_at < ?`,
+  ).run(cutoff);
+  const byLimit = owner.db.prepare(`
+    DELETE FROM error_telemetry WHERE id NOT IN (
+      SELECT id FROM error_telemetry ORDER BY created_at DESC LIMIT ?
+    )
+  `).run(maxRowsGlobal);
+  return {
+    deletedByAge: byAge.changes ?? 0,
+    deletedByLimit: byLimit.changes ?? 0,
+  };
+}

--- a/lib/db/db-improvement-artifacts.mjs
+++ b/lib/db/db-improvement-artifacts.mjs
@@ -24,7 +24,7 @@ export const IMPROVEMENT_STATUS = Object.freeze({
   SUPERSEDED: "superseded",
 });
 
-export const IMPROVEMENT_REVIEW_STATE = Object.freeze({
+const IMPROVEMENT_REVIEW_STATE = Object.freeze({
   NONE: "none",
   DRAFT: "draft",
   APPROVED: "approved",
@@ -49,7 +49,7 @@ function normalizeImprovementSourceKind(value) {
     : IMPROVEMENT_SOURCE_KIND.VALIDATION;
 }
 
-export function normalizeImprovementStatus(value, fallback = IMPROVEMENT_STATUS.ACTIVE) {
+function normalizeImprovementStatus(value, fallback = IMPROVEMENT_STATUS.ACTIVE) {
   if (value === IMPROVEMENT_STATUS.RESOLVED) {
     return IMPROVEMENT_STATUS.RESOLVED;
   }
@@ -136,7 +136,7 @@ function buildEpisodeActions(prompt, caseId, sourceKind) {
   ].map(normalizeText).filter(Boolean);
 }
 
-export function buildImprovementArtifactFilters({
+function buildImprovementArtifactFilters({
   sourceKind,
   sourceCaseId,
   status,
@@ -217,7 +217,7 @@ export function buildImprovementArtifactEpisode(artifact, repository) {
 
 // --- Improvement artifact operations (called by class methods) ---
 
-export function upsertImprovementArtifactImpl(db, {
+function upsertImprovementArtifactImpl(db, {
   sourceCaseId,
   sourceKind,
   title,
@@ -287,7 +287,7 @@ export function upsertImprovementArtifactImpl(db, {
   return artifactId;
 }
 
-export function setImprovementArtifactProposalImpl(db, {
+function setImprovementArtifactProposalImpl(db, {
   id,
   proposalType,
   proposalPath,

--- a/lib/db/db-improvement-artifacts.mjs
+++ b/lib/db/db-improvement-artifacts.mjs
@@ -379,3 +379,193 @@ export function buildBackfillRunSummaryUpdateImpl(db, runId, { lastError = null 
     lastError: derivedLastError,
   };
 }
+
+export function upsertImprovementArtifact(owner, {
+  sourceCaseId,
+  sourceKind,
+  title,
+  summary,
+  evidence = {},
+  trace = {},
+  linkedMemoryId = null,
+  repository = null,
+}) {
+  owner.ensureOpen();
+  return upsertImprovementArtifactImpl(owner.db, {
+    sourceCaseId,
+    sourceKind,
+    title,
+    summary,
+    evidence,
+    trace,
+    linkedMemoryId,
+    repository,
+  });
+}
+
+export function updateImprovementArtifactStatus(owner, {
+  id,
+  status,
+  supersededBy = null,
+}) {
+  owner.ensureOpen();
+  const normalizedId = String(id || "").trim();
+  if (!normalizedId) {
+    throw new Error("id is required");
+  }
+  const nextStatus = normalizeImprovementStatus(status, IMPROVEMENT_STATUS.ACTIVE);
+  const timestamp = nowIso();
+  const resolvedAt = nextStatus === IMPROVEMENT_STATUS.RESOLVED ? timestamp : null;
+  owner.db.prepare(`
+    UPDATE improvement_backlog
+    SET status = ?,
+        superseded_by = CASE
+          WHEN ? = 'superseded' THEN COALESCE(?, superseded_by)
+          ELSE NULL
+        END,
+        review_state = CASE
+          WHEN ? = 'superseded' AND proposal_path IS NOT NULL THEN 'superseded'
+          ELSE review_state
+        END,
+        resolved_at = ?,
+        updated_at = ?
+    WHERE id = ?
+  `).run(
+    nextStatus,
+    nextStatus,
+    supersededBy ?? null,
+    nextStatus,
+    resolvedAt,
+    timestamp,
+    normalizedId,
+  );
+}
+
+export function getImprovementArtifact(owner, id) {
+  owner.ensureOpen();
+  const normalizedId = String(id || "").trim();
+  if (!normalizedId) {
+    return null;
+  }
+  const row = owner.db.prepare(`
+    SELECT
+      id,
+      source_case_id,
+      source_kind,
+      title,
+      summary,
+      evidence_json,
+      trace_json,
+      status,
+      linked_memory_id,
+      repository,
+      superseded_by,
+      proposal_type,
+      proposal_path,
+      proposal_hash,
+      review_state,
+      review_requested_at,
+      review_requested_by,
+      reviewer_decision,
+      reviewer_notes_json,
+      created_at,
+      updated_at,
+      resolved_at
+    FROM improvement_backlog
+    WHERE id = ?
+    LIMIT 1
+  `).get(normalizedId);
+  if (!row) {
+    return null;
+  }
+  return {
+    ...row,
+    evidence: parseJsonObject(row.evidence_json),
+    trace: parseJsonObject(row.trace_json),
+    reviewer_notes: parseJsonObject(row.reviewer_notes_json),
+  };
+}
+
+export function setImprovementArtifactProposal(owner, {
+  id,
+  proposalType,
+  proposalPath,
+  proposalHash,
+  reviewState = IMPROVEMENT_REVIEW_STATE.DRAFT,
+  reviewRequestedAt = null,
+  reviewRequestedBy = null,
+  reviewerDecision = null,
+  reviewerNotes = {},
+}) {
+  owner.ensureOpen();
+  setImprovementArtifactProposalImpl(owner.db, {
+    id,
+    proposalType,
+    proposalPath,
+    proposalHash,
+    reviewState,
+    reviewRequestedAt,
+    reviewRequestedBy,
+    reviewerDecision,
+    reviewerNotes,
+  });
+}
+
+export function listImprovementArtifacts(owner, {
+  sourceKind,
+  sourceCaseId,
+  status,
+  reviewState,
+  hasProposal,
+  updatedBefore,
+  repository,
+  sort = "updated_desc",
+  limit = 10,
+} = {}) {
+  owner.ensureOpen();
+  const { where, params } = buildImprovementArtifactFilters({
+    sourceKind,
+    sourceCaseId,
+    status,
+    reviewState,
+    hasProposal,
+    updatedBefore,
+    repository,
+  });
+  params.push(limit);
+  const rows = owner.db.prepare(`
+    SELECT
+      id,
+      source_case_id,
+      source_kind,
+      title,
+      summary,
+      evidence_json,
+      trace_json,
+      status,
+      linked_memory_id,
+      repository,
+      superseded_by,
+      proposal_type,
+      proposal_path,
+      proposal_hash,
+      review_state,
+      review_requested_at,
+      review_requested_by,
+      reviewer_decision,
+      reviewer_notes_json,
+      created_at,
+      updated_at,
+      resolved_at
+    FROM improvement_backlog
+    ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+    ORDER BY updated_at ${sort === "updated_asc" ? "ASC" : "DESC"}
+    LIMIT ?
+  `).all(...params);
+  return rows.map((row) => ({
+    ...row,
+    evidence: parseJsonObject(row.evidence_json),
+    trace: parseJsonObject(row.trace_json),
+    reviewer_notes: parseJsonObject(row.reviewer_notes_json),
+  }));
+}

--- a/lib/db/db-intent-trajectory.mjs
+++ b/lib/db/db-intent-trajectory.mjs
@@ -1,0 +1,193 @@
+import crypto from "node:crypto";
+import { parseJsonObject } from "../utils/json-object-utils.mjs";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { addStringFilter } from "../utils/sql-filter-utils.mjs";
+import { validateRequiredStringField } from "../utils/required-field-utils.mjs";
+import { nowIso } from "./db-shared.mjs";
+
+export function insertIntentJournalEntry(owner, {
+  repository = null,
+  sessionId = null,
+  turnHint = null,
+  intentKind = "journal",
+  summary,
+  rationale = null,
+  context = {},
+}) {
+  owner.ensureOpen();
+  const normalizedSummary = String(summary || "").trim();
+  if (!normalizedSummary) {
+    throw new Error("summary is required");
+  }
+  const normalizeIntentKind = (value) => {
+    const normalized = String(value || "").trim().toLowerCase() || "journal";
+    const allowedKinds = new Set(["journal", "routing", "rollout", "reviewer", "fallback", "serendipity"]);
+    return allowedKinds.has(normalized) ? normalized : "journal";
+  };
+  const normalizeOptionalString = (value) => (
+    typeof value === "string" && value.trim().length > 0 ? value.trim() : null
+  );
+  const id = crypto.randomUUID();
+  owner.db.prepare(`
+    INSERT INTO intent_journal (
+      id,
+      repository,
+      session_id,
+      turn_hint,
+      intent_kind,
+      summary,
+      rationale,
+      context_json,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    normalizeRepository(repository),
+    normalizeOptionalString(sessionId),
+    normalizeOptionalString(turnHint),
+    normalizeIntentKind(intentKind),
+    normalizedSummary,
+    normalizeOptionalString(rationale),
+    JSON.stringify(context ?? {}),
+    nowIso(),
+  );
+  return id;
+}
+
+export function listIntentJournalEntries(owner, {
+  repository,
+  sessionId,
+  intentKind,
+  limit = 10,
+} = {}) {
+  owner.ensureOpen();
+  const where = [];
+  const params = [];
+  addStringFilter(where, params, "repository", repository);
+  addStringFilter(where, params, "session_id", sessionId);
+  addStringFilter(where, params, "intent_kind", intentKind, (v) => v.toLowerCase());
+  params.push(limit);
+  const rows = owner.db.prepare(`
+    SELECT
+      id,
+      repository,
+      session_id,
+      turn_hint,
+      intent_kind,
+      summary,
+      rationale,
+      context_json,
+      created_at
+    FROM intent_journal
+    ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+    ORDER BY created_at DESC
+    LIMIT ?
+  `).all(...params);
+  return rows.map((row) => ({
+    ...row,
+    context: parseJsonObject(row.context_json),
+  }));
+}
+
+export function insertTrajectoryArtifact(owner, {
+  kind,
+  repository = null,
+  sourceCaseId = null,
+  sourceKind = null,
+  improvementArtifactId = null,
+  eventKey = null,
+  summary,
+  severity = "info",
+  outcome = "captured",
+  latencyMs = null,
+  targetMs = null,
+  context = {},
+  trace = {},
+}) {
+  owner.ensureOpen();
+  const normalizedKind = validateRequiredStringField(kind, "kind");
+  const normalizedSummary = validateRequiredStringField(summary, "summary");
+  const normalizeOptionalValue = (value) => (value ? String(value) : null);
+  const roundIfFinite = (value) => (Number.isFinite(value) ? Math.round(value) : null);
+  const id = crypto.randomUUID();
+  owner.db.prepare(`
+    INSERT INTO trajectory_artifact (
+      id,
+      kind,
+      repository,
+      source_case_id,
+      source_kind,
+      improvement_artifact_id,
+      event_key,
+      summary,
+      severity,
+      outcome,
+      latency_ms,
+      target_ms,
+      context_json,
+      trace_json,
+      created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    normalizedKind,
+    normalizeRepository(repository),
+    normalizeOptionalValue(sourceCaseId),
+    normalizeOptionalValue(sourceKind),
+    normalizeOptionalValue(improvementArtifactId),
+    normalizeOptionalValue(eventKey),
+    normalizedSummary,
+    String(severity || "info"),
+    String(outcome || "captured"),
+    roundIfFinite(latencyMs),
+    roundIfFinite(targetMs),
+    JSON.stringify(context ?? {}),
+    JSON.stringify(trace ?? {}),
+    nowIso(),
+  );
+  return id;
+}
+
+export function listTrajectoryArtifacts(owner, {
+  kind,
+  sourceKind,
+  sourceCaseId,
+  repository,
+  limit = 10,
+} = {}) {
+  owner.ensureOpen();
+  const where = [];
+  const params = [];
+  addStringFilter(where, params, "kind", kind);
+  addStringFilter(where, params, "source_kind", sourceKind);
+  addStringFilter(where, params, "source_case_id", sourceCaseId);
+  addStringFilter(where, params, "repository", repository);
+  params.push(limit);
+  const rows = owner.db.prepare(`
+    SELECT
+      id,
+      kind,
+      repository,
+      source_case_id,
+      source_kind,
+      improvement_artifact_id,
+      event_key,
+      summary,
+      severity,
+      outcome,
+      latency_ms,
+      target_ms,
+      context_json,
+      trace_json,
+      created_at
+    FROM trajectory_artifact
+    ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+    ORDER BY created_at DESC
+    LIMIT ?
+  `).all(...params);
+  return rows.map((row) => ({
+    ...row,
+    context: parseJsonObject(row.context_json),
+    trace: parseJsonObject(row.trace_json),
+  }));
+}

--- a/lib/db/db-maintenance-runs.mjs
+++ b/lib/db/db-maintenance-runs.mjs
@@ -1,0 +1,303 @@
+import crypto from "node:crypto";
+import { parseJsonArray } from "../utils/json-array-utils.mjs";
+import { parseJsonObject } from "../utils/json-object-utils.mjs";
+import { clampInteger } from "../utils/numeric-utils.mjs";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { nowIso } from "./db-shared.mjs";
+
+export function ensureArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+export function createMaintenanceRun(owner, {
+  trigger,
+  repository = null,
+  dryRun = false,
+  plannedTasks = [],
+}) {
+  owner.ensureOpen();
+  const id = crypto.randomUUID();
+  const timestamp = nowIso();
+  owner.db.prepare(`
+    INSERT INTO maintenance_run (
+      id, trigger, repository, dry_run, status, planned_tasks_json, summary_json,
+      started_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    id,
+    String(trigger || "manual"),
+    normalizeRepository(repository),
+    dryRun ? 1 : 0,
+    dryRun ? "planned" : "running",
+    JSON.stringify(ensureArray(plannedTasks)),
+    JSON.stringify({}),
+    timestamp,
+    timestamp,
+  );
+  return id;
+}
+
+export function reclaimStaleMaintenanceRuns(owner, { staleAfterMs = 30 * 60 * 1000 } = {}) {
+  owner.ensureOpen();
+  const numericStaleAfterMs = Number(staleAfterMs);
+  const boundedStaleAfterMs = Number.isFinite(numericStaleAfterMs)
+    ? Math.max(1, numericStaleAfterMs)
+    : 30 * 60 * 1000;
+  const staleCutoff = new Date(Date.now() - boundedStaleAfterMs).toISOString();
+  const recoveredAt = nowIso();
+  const staleRuns = owner.db.prepare(`
+    SELECT id, repository, planned_tasks_json, started_at, updated_at
+    FROM maintenance_run
+    WHERE status = 'running'
+      AND updated_at < ?
+    ORDER BY updated_at ASC
+  `).all(staleCutoff);
+  if (staleRuns.length === 0) {
+    return 0;
+  }
+
+  const updateRun = owner.db.prepare(`
+    UPDATE maintenance_run
+    SET status = 'failed',
+        summary_json = ?,
+        failed_count = ?,
+        completed_at = ?,
+        updated_at = ?
+    WHERE id = ?
+      AND status = 'running'
+  `);
+  const updateTaskState = owner.db.prepare(`
+    UPDATE maintenance_task_state
+    SET last_status = 'failed',
+        last_trigger = 'recovery',
+        last_repository = ?,
+        last_started_at = ?,
+        last_completed_at = ?,
+        last_duration_ms = 0,
+        total_runs = total_runs + 1,
+        total_failures = total_failures + 1,
+        last_summary_json = ?,
+        updated_at = ?
+    WHERE task_name = ?
+      AND last_status = 'running'
+      AND (last_started_at IS NULL OR last_started_at <= ?)
+  `);
+
+  owner.db.exec("BEGIN IMMEDIATE");
+  try {
+    let recoveredCount = 0;
+    for (const run of staleRuns) {
+      const plannedTasks = parseJsonArray(run.planned_tasks_json)
+        .filter((taskName) => typeof taskName === "string" && taskName.length > 0);
+      const summary = {
+        recovery: "stale maintenance run reclaimed",
+        originalStatus: "running",
+        startedAt: run.started_at ?? null,
+        lastUpdatedAt: run.updated_at ?? null,
+        recoveredAt,
+        plannedTasks,
+      };
+      const failedCount = Math.max(1, plannedTasks.length);
+      const updated = updateRun.run(
+        JSON.stringify(summary),
+        failedCount,
+        recoveredAt,
+        recoveredAt,
+        run.id,
+      );
+      if (updated.changes === 0) {
+        continue;
+      }
+      recoveredCount += 1;
+      for (const taskName of plannedTasks) {
+        updateTaskState.run(
+          normalizeRepository(run.repository),
+          recoveredAt,
+          recoveredAt,
+          JSON.stringify(summary),
+          recoveredAt,
+          taskName,
+          run.updated_at ?? recoveredAt,
+        );
+      }
+    }
+    owner.db.exec("COMMIT");
+    return recoveredCount;
+  } catch (error) {
+    try {
+      owner.db.exec("ROLLBACK");
+    } catch {
+      // best-effort rollback before surfacing the original failure
+    }
+    throw error;
+  }
+}
+
+export function completeMaintenanceRun(owner, {
+  runId,
+  status,
+  repository = null,
+  completedAt = null,
+  completedCount = 0,
+  needsAttentionCount = 0,
+  failedCount = 0,
+  skippedCount = 0,
+  summary = {},
+}) {
+  owner.ensureOpen();
+  const result = owner.db.prepare(`
+    UPDATE maintenance_run
+    SET status = ?,
+        summary_json = ?,
+        completed_count = ?,
+        needs_attention_count = ?,
+        failed_count = ?,
+        skipped_count = ?,
+        completed_at = ?,
+        updated_at = ?
+    WHERE id = ?
+      AND status = 'running'
+  `).run(
+    String(status || "completed"),
+    JSON.stringify(summary ?? {}),
+    completedCount,
+    needsAttentionCount,
+    failedCount,
+    skippedCount,
+    completedAt,
+    nowIso(),
+    runId,
+  );
+  if (completedAt && result.changes > 0) {
+    owner.upsertActivitySuccess({
+      repository,
+      updates: {
+        lastMaintenanceCompletionAt: completedAt,
+        lastMaintenanceStatus: String(status || "completed"),
+        lastMaintenanceRunId: runId,
+      },
+    });
+    owner.upsertActivitySuccess({
+      repository: null,
+      updates: {
+        lastMaintenanceCompletionAt: completedAt,
+        lastMaintenanceStatus: String(status || "completed"),
+        lastMaintenanceRunId: runId,
+      },
+    });
+  }
+}
+
+export function listMaintenanceRuns(owner, { limit = 10 } = {}) {
+  owner.ensureOpen();
+  const rows = owner.db.prepare(`
+    SELECT
+      id, trigger, repository, dry_run, status, planned_tasks_json, summary_json,
+      completed_count, needs_attention_count, failed_count, skipped_count,
+      started_at, updated_at, completed_at
+    FROM maintenance_run
+    ORDER BY updated_at DESC
+    LIMIT ?
+  `).all(limit);
+  return rows.map((row) => ({
+    ...row,
+    plannedTasks: parseJsonArray(row.planned_tasks_json),
+    summary: parseJsonObject(row.summary_json),
+  }));
+}
+
+export function listMaintenanceTaskStates(owner) {
+  owner.ensureOpen();
+  const rows = owner.db.prepare(`
+    SELECT
+      task_name, last_status, last_trigger, last_repository, last_started_at,
+      last_completed_at, last_duration_ms, cursor, total_runs, total_failures,
+      total_needs_attention, last_summary_json, updated_at
+    FROM maintenance_task_state
+    ORDER BY task_name ASC
+  `).all();
+  return rows.map((row) => ({
+    ...row,
+    lastSummary: parseJsonObject(row.last_summary_json),
+  }));
+}
+
+export function recordMaintenanceTaskStart(owner, {
+  taskName,
+  trigger,
+  repository = null,
+  startedAt = nowIso(),
+}) {
+  owner.ensureOpen();
+  owner.db.prepare(`
+    INSERT INTO maintenance_task_state (
+      task_name, last_status, last_trigger, last_repository, last_started_at,
+      last_completed_at, last_duration_ms, cursor, total_runs, total_failures,
+      total_needs_attention, last_summary_json, updated_at
+    ) VALUES (?, 'running', ?, ?, ?, NULL, 0, 0, 0, 0, 0, '{}', ?)
+    ON CONFLICT(task_name) DO UPDATE SET
+      last_status = 'running',
+      last_trigger = excluded.last_trigger,
+      last_repository = excluded.last_repository,
+      last_started_at = excluded.last_started_at,
+      updated_at = excluded.updated_at
+  `).run(
+    taskName,
+    String(trigger || "manual"),
+    normalizeRepository(repository),
+    startedAt,
+    startedAt,
+  );
+}
+
+export function recordMaintenanceTaskResult(owner, {
+  taskName,
+  status,
+  trigger,
+  repository = null,
+  startedAt = null,
+  completedAt = nowIso(),
+  durationMs = 0,
+  cursor = 0,
+  summary = {},
+}) {
+  owner.ensureOpen();
+  const normalizedStatus = String(status || "completed");
+  owner.db.prepare(`
+    INSERT INTO maintenance_task_state (
+      task_name, last_status, last_trigger, last_repository, last_started_at,
+      last_completed_at, last_duration_ms, cursor, total_runs, total_failures,
+      total_needs_attention, last_summary_json, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
+    ON CONFLICT(task_name) DO UPDATE SET
+      last_status = excluded.last_status,
+      last_trigger = excluded.last_trigger,
+      last_repository = excluded.last_repository,
+      last_started_at = COALESCE(excluded.last_started_at, maintenance_task_state.last_started_at),
+      last_completed_at = excluded.last_completed_at,
+      last_duration_ms = excluded.last_duration_ms,
+      cursor = excluded.cursor,
+      total_runs = maintenance_task_state.total_runs + 1,
+      total_failures = maintenance_task_state.total_failures
+        + CASE WHEN excluded.last_status = 'failed' THEN 1 ELSE 0 END,
+      total_needs_attention = maintenance_task_state.total_needs_attention
+        + CASE WHEN excluded.last_status = 'needs_attention' THEN 1 ELSE 0 END,
+      last_summary_json = excluded.last_summary_json,
+      updated_at = excluded.updated_at
+    WHERE maintenance_task_state.last_started_at IS NULL
+      OR maintenance_task_state.last_started_at = excluded.last_started_at
+  `).run(
+    taskName,
+    normalizedStatus,
+    String(trigger || "manual"),
+    normalizeRepository(repository),
+    startedAt,
+    completedAt,
+    clampInteger(durationMs, 0, { min: 0, max: 24 * 60 * 60 * 1000 }),
+    clampInteger(cursor, 0, { min: 0, max: Number.MAX_SAFE_INTEGER }),
+    normalizedStatus === "failed" ? 1 : 0,
+    normalizedStatus === "needs_attention" ? 1 : 0,
+    JSON.stringify(summary ?? {}),
+    completedAt,
+  );
+}

--- a/lib/db/db-maintenance-runs.mjs
+++ b/lib/db/db-maintenance-runs.mjs
@@ -5,7 +5,7 @@ import { clampInteger } from "../utils/numeric-utils.mjs";
 import { normalizeRepository } from "../utils/repository-utils.mjs";
 import { nowIso } from "./db-shared.mjs";
 
-export function ensureArray(value) {
+function ensureArray(value) {
   return Array.isArray(value) ? value : [];
 }
 

--- a/lib/db/db-memory-domain-observation.mjs
+++ b/lib/db/db-memory-domain-observation.mjs
@@ -6,7 +6,7 @@ import { normalizeRepository } from "../utils/repository-utils.mjs";
 import { normalizeText } from "../utils/text-normalizer.mjs";
 import { nowIso, applyScopeFilter } from "./db-shared.mjs";
 
-export function mapMemoryDomainRow(row) {
+function mapMemoryDomainRow(row) {
   return {
     domainKey: row.domain_key,
     kind: row.kind,
@@ -24,7 +24,7 @@ export function mapMemoryDomainRow(row) {
   };
 }
 
-export function mapObservationRow(row) {
+function mapObservationRow(row) {
   return {
     observationKey: row.observation_key,
     domainKey: row.domain_key,

--- a/lib/db/db-memory-domain-observation.mjs
+++ b/lib/db/db-memory-domain-observation.mjs
@@ -1,0 +1,246 @@
+import { buildMemoryDomain } from "../memory/memory-domains.mjs";
+import { buildRefreshableObservation } from "../sessions/observations.mjs";
+import { parseJsonArray } from "../utils/json-array-utils.mjs";
+import { parseJsonObject } from "../utils/json-object-utils.mjs";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { normalizeText } from "../utils/text-normalizer.mjs";
+import { nowIso, applyScopeFilter } from "./db-shared.mjs";
+
+export function mapMemoryDomainRow(row) {
+  return {
+    domainKey: row.domain_key,
+    kind: row.kind,
+    title: row.title,
+    mission: row.mission,
+    scope: row.scope,
+    repository: row.repository,
+    directives: parseJsonArray(row.directives_json),
+    disposition: parseJsonObject(row.disposition_json),
+    metadata: parseJsonObject(row.metadata_json),
+    status: row.status,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastUsedAt: row.last_used_at,
+  };
+}
+
+export function mapObservationRow(row) {
+  return {
+    observationKey: row.observation_key,
+    domainKey: row.domain_key,
+    title: row.title,
+    prompt: row.prompt,
+    focus: row.focus,
+    summary: row.summary,
+    confidence: row.confidence,
+    scope: row.scope,
+    repository: row.repository,
+    freshnessHours: row.freshness_hours,
+    status: row.status,
+    source: row.source,
+    trace: parseJsonObject(row.trace_json),
+    metadata: parseJsonObject(row.metadata_json),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    lastRefreshedAt: row.last_refreshed_at,
+  };
+}
+
+export function upsertMemoryDomain(owner, domain) {
+  owner.ensureOpen();
+  const normalized = buildMemoryDomain(domain);
+  if (!normalized) {
+    throw new Error("invalid memory domain");
+  }
+  const timestamp = nowIso();
+  owner.db.prepare(`
+    INSERT INTO memory_domain (
+      domain_key, kind, title, mission, scope, repository, directives_json,
+      disposition_json, metadata_json, status, created_at, updated_at, last_used_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(domain_key) DO UPDATE SET
+      kind = excluded.kind,
+      title = excluded.title,
+      mission = excluded.mission,
+      scope = excluded.scope,
+      repository = excluded.repository,
+      directives_json = excluded.directives_json,
+      disposition_json = excluded.disposition_json,
+      metadata_json = excluded.metadata_json,
+      status = excluded.status,
+      updated_at = excluded.updated_at,
+      last_used_at = COALESCE(excluded.last_used_at, memory_domain.last_used_at)
+  `).run(
+    normalized.domainKey,
+    normalized.kind,
+    normalized.title,
+    normalized.mission,
+    normalized.scope,
+    normalized.repository,
+    JSON.stringify(normalized.directives),
+    JSON.stringify(normalized.disposition),
+    JSON.stringify(normalized.metadata),
+    normalized.status,
+    timestamp,
+    timestamp,
+    domain.lastUsedAt ?? null,
+  );
+  return normalized.domainKey;
+}
+
+export function getMemoryDomain(owner, domainKey) {
+  owner.ensureOpen();
+  const normalizedDomainKey = normalizeText(domainKey).toLowerCase();
+  if (!normalizedDomainKey) {
+    return null;
+  }
+  const row = owner.db.prepare(`
+    SELECT
+      domain_key, kind, title, mission, scope, repository, directives_json,
+      disposition_json, metadata_json, status, created_at, updated_at, last_used_at
+    FROM memory_domain
+    WHERE domain_key = ?
+    LIMIT 1
+  `).get(normalizedDomainKey);
+  if (!row) {
+    return null;
+  }
+  return mapMemoryDomainRow(row);
+}
+
+export function listMemoryDomains(owner, { repository, includeOtherRepositories = false, scopes = [], status } = {}) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const params = [];
+  let sql = `
+    SELECT
+      domain_key, kind, title, mission, scope, repository, directives_json,
+      disposition_json, metadata_json, status, created_at, updated_at, last_used_at
+    FROM memory_domain
+    WHERE 1 = 1
+  `;
+  sql = applyScopeFilter(sql, params, repo, includeOtherRepositories);
+  if (scopes.length > 0) {
+    sql += ` AND scope IN (${scopes.map(() => "?").join(", ")}) `;
+    params.push(...scopes);
+  }
+  if (status) {
+    sql += ` AND status = ? `;
+    params.push(normalizeText(status).toLowerCase());
+  }
+  sql += ` ORDER BY updated_at DESC, domain_key ASC `;
+  return owner.db.prepare(sql).all(...params).map(mapMemoryDomainRow);
+}
+
+export function upsertObservation(owner, observation) {
+  owner.ensureOpen();
+  const normalized = buildRefreshableObservation(observation);
+  if (!normalized) {
+    throw new Error("invalid refreshable observation");
+  }
+  const timestamp = nowIso();
+  const lastRefreshedAt = observation.lastRefreshedAt ?? timestamp;
+  owner.db.prepare(`
+    INSERT INTO refreshable_observation (
+      observation_key, domain_key, title, prompt, focus, summary, confidence, scope,
+      repository, freshness_hours, status, source, trace_json, metadata_json,
+      created_at, updated_at, last_refreshed_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ON CONFLICT(observation_key) DO UPDATE SET
+      domain_key = excluded.domain_key,
+      title = excluded.title,
+      prompt = excluded.prompt,
+      focus = excluded.focus,
+      summary = excluded.summary,
+      confidence = excluded.confidence,
+      scope = excluded.scope,
+      repository = excluded.repository,
+      freshness_hours = excluded.freshness_hours,
+      status = excluded.status,
+      source = excluded.source,
+      trace_json = excluded.trace_json,
+      metadata_json = excluded.metadata_json,
+      updated_at = excluded.updated_at,
+      last_refreshed_at = excluded.last_refreshed_at
+  `).run(
+    normalized.observationKey,
+    normalized.domainKey,
+    normalized.title,
+    normalized.prompt,
+    normalized.focus,
+    normalized.summary,
+    normalized.confidence,
+    normalized.scope,
+    normalized.repository,
+    normalized.freshnessHours,
+    normalized.status,
+    normalized.source,
+    JSON.stringify(normalized.trace),
+    JSON.stringify(normalized.metadata),
+    timestamp,
+    timestamp,
+    lastRefreshedAt,
+  );
+  return normalized.observationKey;
+}
+
+export function getObservation(owner, observationKey) {
+  owner.ensureOpen();
+  const normalizedObservationKey = normalizeText(observationKey).toLowerCase();
+  if (!normalizedObservationKey) {
+    return null;
+  }
+  const row = owner.db.prepare(`
+    SELECT
+      observation_key, domain_key, title, prompt, focus, summary, confidence, scope,
+      repository, freshness_hours, status, source, trace_json, metadata_json,
+      created_at, updated_at, last_refreshed_at
+    FROM refreshable_observation
+    WHERE observation_key = ?
+    LIMIT 1
+  `).get(normalizedObservationKey);
+  if (!row) {
+    return null;
+  }
+  return mapObservationRow(row);
+}
+
+export function listObservations(owner, { repository, includeOtherRepositories = false, domainKey, scopes = [], status } = {}) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const normalizedDomainKey = normalizeText(domainKey).toLowerCase() || null;
+  const params = [];
+  let sql = `
+    SELECT
+      observation_key, domain_key, title, prompt, focus, summary, confidence, scope,
+      repository, freshness_hours, status, source, trace_json, metadata_json,
+      created_at, updated_at, last_refreshed_at
+    FROM refreshable_observation
+    WHERE 1 = 1
+  `;
+  sql = applyScopeFilter(sql, params, repo, includeOtherRepositories);
+  if (normalizedDomainKey) {
+    sql += ` AND domain_key = ? `;
+    params.push(normalizedDomainKey);
+  }
+  if (scopes.length > 0) {
+    sql += ` AND scope IN (${scopes.map(() => "?").join(", ")}) `;
+    params.push(...scopes);
+  }
+  if (status) {
+    sql += ` AND status = ? `;
+    params.push(normalizeText(status).toLowerCase());
+  }
+  sql += ` ORDER BY updated_at DESC, observation_key ASC `;
+  return owner.db.prepare(sql).all(...params).map(mapObservationRow);
+}
+
+export function deleteGeneratedSemanticMemories(owner, sessionId) {
+  owner.ensureOpen();
+  owner.db.prepare(`
+    DELETE FROM semantic_memory
+    WHERE source_session_id = ?
+      AND COALESCE(json_extract(metadata_json, '$.source'), '') NOT IN ('memory_save', 'lore_retain', 'onboarding', 'pi', 'pi:command')
+      AND COALESCE(scope_source, 'auto') != 'manual'
+  `).run(sessionId);
+}

--- a/lib/db/db-memory-hygiene.mjs
+++ b/lib/db/db-memory-hygiene.mjs
@@ -1,0 +1,126 @@
+import { parseJsonArray } from "../utils/json-array-utils.mjs";
+import { parseJsonObject } from "../utils/json-object-utils.mjs";
+import { clampInteger } from "../utils/numeric-utils.mjs";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { buildSemanticEligibilitySql } from "./db-retrieval-policy.mjs";
+import { nowIso } from "./db-shared.mjs";
+
+export function listActiveStabilisationMemories(owner, {
+  repository,
+  includeGlobal = true,
+  limit = 50,
+} = {}) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const eligibility = buildSemanticEligibilitySql({
+    alias: "",
+    repository: repo,
+    includeOtherRepositories: false,
+  });
+  return owner.db.prepare(`
+    SELECT
+      id,
+      type,
+      content,
+      scope,
+      repository,
+    confidence,
+    updated_at,
+      expires_at,
+    source_session_id,
+    metadata_json
+    FROM semantic_memory
+    WHERE ${eligibility.sql}
+      AND type IN ('open_loop', 'assistant_goal')
+      ${includeGlobal ? "" : "AND scope = 'repo'"}
+    ORDER BY updated_at DESC
+    LIMIT ?
+  `).all(
+    ...eligibility.params,
+    clampInteger(limit, 50, { min: 1, max: 200 }),
+  ).map((row) => ({
+    ...row,
+    metadata: parseJsonObject(row.metadata_json),
+  }));
+}
+
+export function listMemoryHygieneEpisodes(owner, {
+  repository,
+  includeOtherRepositories = true,
+  limit = 100,
+} = {}) {
+  owner.ensureOpen();
+  const repo = normalizeRepository(repository);
+  const boundedLimit = clampInteger(limit, 100, { min: 1, max: 500 });
+  const mapRows = (rows) => rows.map((row) => ({
+    sessionId: row.session_id,
+    scope: row.scope,
+    repository: row.repository,
+    summary: row.summary,
+    actions: parseJsonArray(row.actions_json),
+    decisions: parseJsonArray(row.decisions_json),
+    openItems: parseJsonArray(row.open_items_json),
+    updatedAt: row.updated_at,
+  }));
+  const selectSql = `
+    SELECT
+      session_id,
+      scope,
+      repository,
+      summary,
+      actions_json,
+      decisions_json,
+      open_items_json,
+      updated_at
+    FROM episode_digest
+  `;
+  if (!includeOtherRepositories) {
+    return mapRows(owner.db.prepare(`
+      ${selectSql}
+      WHERE IFNULL(repository, '') = IFNULL(?, '')
+      ORDER BY updated_at DESC
+      LIMIT ?
+    `).all(repo, boundedLimit));
+  }
+
+  const primaryLimit = Math.max(1, Math.ceil(boundedLimit / 2));
+  const otherLimit = Math.max(0, boundedLimit - primaryLimit);
+  const primaryRows = owner.db.prepare(`
+    ${selectSql}
+    WHERE IFNULL(repository, '') = IFNULL(?, '')
+    ORDER BY updated_at DESC
+    LIMIT ?
+  `).all(repo, primaryLimit);
+  const otherRows = otherLimit > 0
+    ? owner.db.prepare(`
+        ${selectSql}
+        WHERE IFNULL(repository, '') != IFNULL(?, '')
+        ORDER BY updated_at DESC
+        LIMIT ?
+      `).all(repo, otherLimit)
+    : [];
+  return mapRows([...primaryRows, ...otherRows]);
+}
+
+export function restoreMemoriesBySupersessionMarker(owner, marker) {
+  owner.ensureOpen();
+  const normalizedMarker = String(marker ?? "").trim();
+  if (!normalizedMarker.startsWith("auto-hygiene:")) {
+    throw new Error("marker must start with auto-hygiene:");
+  }
+  const rows = owner.db.prepare(`
+    SELECT id
+    FROM semantic_memory
+    WHERE superseded_by = ?
+    ORDER BY id
+  `).all(normalizedMarker);
+  if (rows.length === 0) {
+    return [];
+  }
+  owner.db.prepare(`
+    UPDATE semantic_memory
+    SET superseded_by = NULL, updated_at = ?
+    WHERE superseded_by = ?
+  `).run(nowIso(), normalizedMarker);
+  return rows.map((row) => row.id);
+}

--- a/lib/db/db-prompt-context.mjs
+++ b/lib/db/db-prompt-context.mjs
@@ -1,0 +1,852 @@
+import { promptSearchQuery, extractMeaningfulPromptTerms, expandPromptSearchTerms, scorePromptFallbackRows } from "../context/prompt-search-query.mjs";
+import { detectPromptContextNeed } from "../context/prompt-need.mjs";
+import { formatSemanticContextLine, renderPromptContext } from "../context/prompt-context-render.mjs";
+import { detectAssistantIdentityName, MEMORY_SCOPE } from "../memory/memory-scope.mjs";
+import { buildStyleAddressingSection, isStyleAddressingMemory } from "../context/style-addressing.mjs";
+import { readTemporalQueryNormalizationEnabled } from "../rollout/rollout-flags.mjs";
+import { extractFtsTerms as extractNormalizedFtsTerms, extractDirectTerms as extractNormalizedDirectTerms, extractTemporalContentTerms as extractNormalizedTemporalContentTerms, inferDateFromPrompt as inferNormalizedDateFromPrompt, normalizeFtsToken, QUERY_ALIASES, tokenizeText } from "../utils/query-normalizer.mjs";
+import { normalizeText } from "../utils/text-normalizer.mjs";
+import { isCrossRepoRow, serializeSessionTraceRow, setPromptTemporalVerifierTraceState } from "./db-temporal.mjs";
+import { serializeEpisodeTraceRow, buildLocalEligibility } from "./db-trace-serializers.mjs";
+
+export function normalizeTraceMemoryRow(memory) {
+  return memory && typeof memory === "object" ? memory : {};
+}
+
+export function buildSemanticTraceIdentity(memory) {
+  return {
+    id: memory.id ?? null,
+    type: memory.type ?? null,
+    scope: memory.scope ?? null,
+    scopeSource: memory.scope_source ?? null,
+    repository: memory.repository ?? null,
+  };
+}
+
+export function buildSemanticTraceMetadata(memory) {
+  return {
+    updatedAt: memory.updated_at ?? null,
+    canonicalKey: memory.canonical_key ?? null,
+    reinforcementCount: memory.reinforcement_count ?? 1,
+    lastSeenAt: memory.last_seen_at ?? null,
+  };
+}
+
+export function serializeSemanticRows(rows, repository) {
+  return rows.map((memory) => serializeSemanticTraceRow(memory, repository));
+}
+
+export function serializeEpisodeRows(rows, repository) {
+  return rows.map((episode) => serializeEpisodeTraceRow(episode, repository));
+}
+
+export function serializeSessionRows(rows, repository) {
+  return rows.map((session) => serializeSessionTraceRow(session, repository));
+}
+
+export function serializeSemanticTraceRow(memory, currentRepository = null) {
+  const normalizedMemory = normalizeTraceMemoryRow(memory);
+  return {
+    ...buildSemanticTraceIdentity(normalizedMemory),
+    ...buildSemanticTraceMetadata(normalizedMemory),
+    crossRepo: isCrossRepoRow(normalizedMemory, currentRepository),
+    content: normalizeText(normalizedMemory.content),
+  };
+}
+
+export function buildStyleAddressingTraceLookup({
+  effectiveStyleSection,
+  assistantPersonaRows,
+  relationshipPreferenceRows,
+  repository,
+}) {
+  const styleRows = [
+    ...serializeSemanticRows(assistantPersonaRows, repository),
+    ...serializeSemanticRows(relationshipPreferenceRows, repository),
+  ];
+  return {
+    enabled: effectiveStyleSection.trace.enabled,
+    ambientEnabled: effectiveStyleSection.trace.ambientEnabled,
+    includeAmbient: effectiveStyleSection.trace.includeAmbient,
+    promptLocal: effectiveStyleSection.trace.promptLocal,
+    rows: styleRows,
+    includedRows: effectiveStyleSection.trace.includeAmbient ? styleRows : [],
+    reason: effectiveStyleSection.trace.reason,
+  };
+}
+
+export function buildCrossRepoPreferencesTraceLookup({
+  allowGenericCrossRepoFallback,
+  crossRepoPreferenceRows,
+  crossRepoPreferences,
+  repository,
+}) {
+  return {
+    enabled: allowGenericCrossRepoFallback,
+    scopes: [MEMORY_SCOPE.TRANSFERABLE],
+    rows: serializeSemanticRows(crossRepoPreferenceRows, repository),
+    includedRows: serializeSemanticRows(crossRepoPreferences, repository),
+    filtered: crossRepoPreferenceRows
+      .filter((memory) => !isCrossRepoRow(memory, repository))
+      .map((memory) => ({
+        stage: "cross_repo_filter",
+        reason: "same_repository",
+        row: serializeSemanticTraceRow(memory, repository),
+      })),
+    reason: null,
+  };
+}
+
+export function buildCrossRepoEpisodesTraceLookup({
+  allowGenericCrossRepoFallback,
+  crossRepoEpisodeDetails,
+  crossRepoEpisodes,
+  repository,
+}) {
+  return {
+    enabled: allowGenericCrossRepoFallback,
+    scopes: [MEMORY_SCOPE.TRANSFERABLE],
+    rankedRows: crossRepoEpisodeDetails?.trace?.rankedRows ?? [],
+    includedRows: serializeEpisodeRows(crossRepoEpisodes, repository),
+    filtered: [
+      ...(crossRepoEpisodeDetails?.trace?.filtered ?? []),
+      ...((crossRepoEpisodeDetails?.episodes ?? [])
+        .filter((episode) => !isCrossRepoRow(episode, repository))
+        .map((episode) => ({
+          stage: "cross_repo_filter",
+          reason: "same_repository",
+          row: serializeEpisodeTraceRow(episode, repository),
+        }))),
+    ],
+    reason: null,
+  };
+}
+
+export function serializeDaySummaryTraceRow(summary, currentRepository = null) {
+  return {
+    repository: summary.repository ?? null,
+    dateKey: summary.date_key ?? null,
+    computedAt: summary.computed_at ?? null,
+    crossRepo: isCrossRepoRow(summary, currentRepository),
+    summary: normalizeText(summary.summary),
+  };
+}
+
+export function createPromptContextTrace({
+  prompt,
+  repository,
+  allowCrossRepoFallback,
+  allowGenericCrossRepoFallback,
+  promptTerms,
+  identityName,
+  temporalDate,
+  memories,
+  localMemories,
+  identityMemories,
+  effectiveStyleSection,
+  assistantPersonaRows,
+  relationshipPreferenceRows,
+  daySummaryRows,
+  includedDaySummaryRows,
+  episodeDetails,
+  crossRepoPreferenceRows,
+  crossRepoPreferences,
+  crossRepoEpisodeDetails,
+  crossRepoEpisodes,
+  crossRepoHints,
+  sessionStore,
+}) {
+  return {
+    mode: "prompt_context",
+    repository,
+    includeOtherRepositories: allowCrossRepoFallback,
+    promptTerms,
+    identityName: identityName ?? null,
+    temporalDate,
+    temporal: null,
+    eligibility: {
+      localSemantic: buildLocalEligibility(repository),
+      localEpisodes: buildLocalEligibility(repository),
+      crossRepoFallback: allowCrossRepoFallback ? [MEMORY_SCOPE.TRANSFERABLE] : [],
+    },
+    lookups: {
+      localMemories: {
+        query: prompt,
+        types: ["commitment", "open_loop", "rejected_approach", "blocker", "user_preference", "assistant_identity", "user_identity", "assistant_goal", "recurring_mistake", "decision", "learned_rule"],
+        rows: serializeSemanticRows(memories, repository),
+        includedRows: serializeSemanticRows(localMemories, repository),
+      },
+      identityMemories: {
+        query: identityName ?? "",
+        scopes: [MEMORY_SCOPE.GLOBAL],
+        rows: serializeSemanticRows(identityMemories, repository),
+        includedRows: serializeSemanticRows(identityMemories, repository),
+      },
+      styleAddressing: buildStyleAddressingTraceLookup({
+        effectiveStyleSection,
+        assistantPersonaRows,
+        relationshipPreferenceRows,
+        repository,
+      }),
+      daySummary: {
+        date: temporalDate,
+        rows: daySummaryRows.map((summary) => serializeDaySummaryTraceRow(summary, repository)),
+        includedRows: includedDaySummaryRows.map((summary) => serializeDaySummaryTraceRow(summary, repository)),
+        included: false,
+        reason: null,
+      },
+      localEpisodes: episodeDetails.trace,
+      crossRepoPreferences: buildCrossRepoPreferencesTraceLookup({
+        allowGenericCrossRepoFallback,
+        crossRepoPreferenceRows,
+        crossRepoPreferences,
+        repository,
+      }),
+      crossRepoEpisodes: buildCrossRepoEpisodesTraceLookup({
+        allowGenericCrossRepoFallback,
+        crossRepoEpisodeDetails,
+        crossRepoEpisodes,
+        repository,
+      }),
+      crossRepoHints: {
+        enabled: allowGenericCrossRepoFallback && !!sessionStore,
+        rows: serializeSessionRows(crossRepoHints, repository),
+        includedRows: [],
+        reason: null,
+      },
+      temporalVerifier: {
+        enabled: !!sessionStore && temporalDate !== null,
+        date: temporalDate,
+        rows: [],
+        includedRows: [],
+        reason: null,
+      },
+    },
+    omissions: [],
+    output: {
+      sectionTitles: [],
+      sectionDetails: [],
+      estimatedTokens: 0,
+    },
+  };
+}
+
+export function dedupeSemanticContextRows(rows) {
+  const seen = new Set();
+  const deduped = [];
+  for (const row of rows) {
+    const key = `${row.type}::${normalizeText(row.content).toLowerCase()}::${row.scope ?? ""}::${row.repository ?? ""}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    deduped.push(row);
+  }
+  return deduped;
+}
+
+export function buildDefaultPromptNeed(prompt, includeOtherRepositories = false) {
+  const detected = detectPromptContextNeed(prompt);
+  return {
+    ...detected,
+    allowCrossRepoFallback: detected.allowCrossRepoFallback || includeOtherRepositories,
+  };
+}
+
+export function extractTemporalContentTerms(query, config = null) {
+  if (!readTemporalQueryNormalizationEnabled(config)) {
+    return extractNormalizedDirectTerms(query);
+  }
+  return extractNormalizedTemporalContentTerms(query);
+}
+
+export function withCurrentRepository(rows, repository) {
+  return rows.map((row) => ({
+    ...row,
+    currentRepository: repository,
+  }));
+}
+
+export function inferDateFromPrompt(prompt, config = null) {
+  if (!readTemporalQueryNormalizationEnabled(config)) {
+    const text = String(prompt || "").toLowerCase();
+    const now = new Date();
+    const startOfUtcDay = new Date(now);
+    startOfUtcDay.setUTCHours(0, 0, 0, 0);
+
+    if (text.includes("today")) {
+      return startOfUtcDay.toISOString().slice(0, 10);
+    }
+    if (text.includes("yesterday")) {
+      const value = new Date(startOfUtcDay);
+      value.setUTCDate(value.getUTCDate() - 1);
+      return value.toISOString().slice(0, 10);
+    }
+
+    const weekdays = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
+    const namedDay = weekdays.find((weekday) => text.includes(weekday));
+    if (!namedDay) {
+      return null;
+    }
+
+    const targetIndex = weekdays.indexOf(namedDay);
+    const currentIndex = now.getUTCDay();
+    const diff = (currentIndex - targetIndex + 7) % 7 || 7;
+    const value = new Date(startOfUtcDay);
+    value.setUTCDate(value.getUTCDate() - diff);
+    return value.toISOString().slice(0, 10);
+  }
+  return inferNormalizedDateFromPrompt(prompt, { now: config?.now });
+}
+
+export function buildExplainPromptTrace({ prompt, repository, allowCrossRepoFallback, promptTerms, identityName, semanticCtx, temporalCtx, crossRepoCtx, sessionStore }) {
+  return createPromptContextTrace({
+    prompt,
+    repository,
+    allowCrossRepoFallback,
+    allowGenericCrossRepoFallback: crossRepoCtx.allowGenericCrossRepoFallback,
+    promptTerms,
+    identityName,
+    temporalDate: temporalCtx.temporalDate,
+    memories: semanticCtx.memories,
+    localMemories: semanticCtx.localMemories,
+    identityMemories: semanticCtx.identityMemories,
+    effectiveStyleSection: temporalCtx.effectiveStyleSection,
+    assistantPersonaRows: semanticCtx.assistantPersonaRows,
+    relationshipPreferenceRows: semanticCtx.relationshipPreferenceRows,
+    daySummaryRows: temporalCtx.daySummaryRows,
+    includedDaySummaryRows: temporalCtx.includedDaySummaryRows,
+    episodeDetails: temporalCtx.episodeDetails,
+    crossRepoPreferenceRows: crossRepoCtx.crossRepoPreferenceRows,
+    crossRepoPreferences: crossRepoCtx.crossRepoPreferences,
+    crossRepoEpisodeDetails: crossRepoCtx.crossRepoEpisodeDetails,
+    crossRepoEpisodes: crossRepoCtx.crossRepoEpisodes,
+    crossRepoHints: crossRepoCtx.crossRepoHints,
+    sessionStore,
+  });
+}
+
+export function searchPromptSemanticRows(owner, {
+  query,
+  repository,
+  types,
+  scopes,
+  limit,
+  includeOtherRepositories = false,
+  expandAliases = true,
+}) {
+  return withCurrentRepository(owner.searchSemantic({
+    query,
+    repository,
+    includeOtherRepositories,
+    types,
+    scopes,
+    limit,
+    expandAliases,
+  }), repository);
+}
+
+export function searchPromptSemanticFallback(owner, {
+  prompt,
+  repository,
+  types = [],
+  scopes = [],
+  limit = 8,
+  includeOtherRepositories = false,
+  now = new Date(),
+}) {
+  const terms = extractMeaningfulPromptTerms(prompt, { maxTerms: 8 });
+  if (terms.length === 0) return [];
+  const queryTerms = expandPromptSearchTerms(terms, { maxTerms: 8, maxVariants: 16 });
+  const maxCandidates = Math.max(64, Math.min(256, Math.max(limit, 1) * 32));
+  const rowsById = new Map();
+  for (let index = 0; index < queryTerms.length; index += 1) {
+    const remainingTerms = queryTerms.length - index;
+    const remainingRows = maxCandidates - rowsById.size;
+    if (remainingRows <= 0) break;
+    const termLimit = Math.max(8, Math.ceil(remainingRows / remainingTerms));
+    const rows = owner.searchSemantic({
+      query: queryTerms[index],
+      repository,
+      includeOtherRepositories,
+      types,
+      scopes,
+      limit: Math.min(64, termLimit),
+      expandAliases: false,
+      now,
+    });
+    for (const row of rows) {
+      if (!rowsById.has(row.id)) rowsById.set(row.id, row);
+      if (rowsById.size >= maxCandidates) break;
+    }
+  }
+  return scorePromptFallbackRows([...rowsById.values()], terms, { limit });
+}
+
+export function buildPromptSemanticContext(owner, { prompt, repository, limit, identityName, identityOnly }) {
+  let memories = !identityOnly
+    ? owner.searchPromptSemanticRows({
+        query: prompt,
+        repository,
+        includeOtherRepositories: false,
+        types: ["commitment", "open_loop", "rejected_approach", "blocker", "user_preference", "assistant_identity", "user_identity", "assistant_goal", "recurring_mistake", "decision", "learned_rule"],
+        limit,
+      })
+    : [];
+  const contentQuery = promptSearchQuery(prompt);
+  if (!identityOnly && memories.length < limit && contentQuery) {
+    const fallbackRows = owner.searchPromptSemanticFallback({
+      prompt,
+      repository,
+      includeOtherRepositories: false,
+      types: ["commitment", "open_loop", "rejected_approach", "blocker", "user_preference", "assistant_identity", "user_identity", "assistant_goal", "recurring_mistake", "decision", "learned_rule"],
+      limit,
+    });
+    const byId = new Map(memories.map((row) => [row.id, row]));
+    for (const row of fallbackRows) {
+      if (!byId.has(row.id)) byId.set(row.id, row);
+      if (byId.size >= limit) break;
+    }
+    memories = [...byId.values()].slice(0, limit);
+  }
+  const identityMemories = identityName
+    ? owner.searchPromptSemanticRows({
+        query: "",
+        repository,
+        includeOtherRepositories: false,
+        types: ["assistant_identity"],
+        scopes: [MEMORY_SCOPE.GLOBAL],
+        limit: 4,
+      })
+    : [];
+  const assistantPersonaRows = owner.searchPromptSemanticRows({
+    query: identityName || "assistant preferred human name",
+    repository,
+    includeOtherRepositories: false,
+    types: ["assistant_identity"],
+    scopes: [MEMORY_SCOPE.GLOBAL],
+    limit: 2,
+  });
+  const relationshipPreferenceRows = !identityOnly
+    ? owner.searchPromptSemanticRows({
+        query: "",
+        repository,
+        includeOtherRepositories: false,
+        types: ["interaction_style", "user_identity", "user_preference", "recurring_mistake"],
+        scopes: [MEMORY_SCOPE.GLOBAL],
+        limit: 6,
+      }).filter((memory) => isStyleAddressingMemory(memory)).slice(0, 4)
+    : [];
+
+  return {
+    memories,
+    identityMemories,
+    localMemories: dedupeSemanticContextRows([
+      ...identityMemories,
+      ...memories,
+    ]),
+    assistantPersonaRows,
+    relationshipPreferenceRows,
+  };
+}
+
+export function buildEffectivePromptStyleSection(owner, {
+  prompt,
+  need,
+  assistantPersonaRows,
+  relationshipPreferenceRows,
+  pureTemporalRecall,
+}) {
+  const styleSection = buildStyleAddressingSection({
+    prompt,
+    promptNeed: need,
+    config: owner.config,
+    assistantPersonaRows,
+    relationshipPreferenceRows,
+    renderSemantic: formatSemanticContextLine,
+  });
+  return pureTemporalRecall && need.wantsStyleContext !== true
+    ? {
+        ...styleSection,
+        text: "",
+        trace: {
+          ...styleSection.trace,
+          enabled: false,
+          includeAmbient: false,
+          reason: "suppressed_for_pure_temporal_recall",
+        },
+      }
+    : styleSection;
+}
+
+export function filterPromptDaySummaries(owner, daySummaryRows, pureTemporalRecall, temporalContentTerms) {
+  return daySummaryRows.filter((summary) => {
+    if (pureTemporalRecall || temporalContentTerms.length === 0) {
+      return true;
+    }
+    const summaryTokens = tokenizeText(summary.summary);
+    return temporalContentTerms.some((term) => summaryTokens.has(term));
+  });
+}
+
+export function buildIdentityOnlyEpisodeDetails(owner, prompt, repository) {
+  return {
+    episodes: [],
+    trace: {
+      prompt,
+      repository,
+      includeOtherRepositories: false,
+      eligibleScopes: buildLocalEligibility(repository),
+      primaryTerms: [],
+      terms: [],
+      lexicalQuery: "",
+      rankedRows: [],
+      includedRows: [],
+      filtered: [],
+      reason: "identity_only_prompt",
+    },
+  };
+}
+
+export function buildPromptEpisodeContext(owner, {
+  prompt,
+  repository,
+  limit,
+  allowRepoLocalTaskContext,
+  allowCrossRepoFallback,
+  pureTemporalRecall,
+  temporalDate,
+  includedDaySummaryRows,
+}) {
+  if (!allowRepoLocalTaskContext) {
+    return owner.buildIdentityOnlyEpisodeDetails(prompt, repository);
+  }
+  if (pureTemporalRecall && includedDaySummaryRows.length > 0) {
+    return {
+      episodes: [],
+      trace: {
+        prompt,
+        repository,
+        includeOtherRepositories: allowCrossRepoFallback,
+        eligibleScopes: allowCrossRepoFallback ? [] : buildLocalEligibility(repository),
+        primaryTerms: [],
+        terms: [],
+        lexicalQuery: "",
+        rankedRows: [],
+        includedRows: [],
+        filtered: [],
+        reason: "suppressed_by_day_summaries",
+      },
+    };
+  }
+  return pureTemporalRecall
+    ? owner.findRelevantEpisodesByDateDetailed({
+        date: temporalDate,
+        repository,
+        includeOtherRepositories: allowCrossRepoFallback,
+        limit: Math.max(2, Math.floor(limit / 2)),
+      })
+    : owner.findRelevantEpisodesDetailed({
+        prompt,
+        repository,
+        includeOtherRepositories: false,
+        limit: Math.max(2, Math.floor(limit / 2)),
+      });
+}
+
+export function buildPromptTemporalContext(owner, {
+  prompt,
+  repository,
+  need,
+  limit,
+  allowRepoLocalTaskContext,
+  allowCrossRepoFallback,
+  assistantPersonaRows,
+  relationshipPreferenceRows,
+}) {
+  const temporalDate = need.hasTemporalSignal ? inferDateFromPrompt(prompt, owner.config) : null;
+  const temporalContentTerms = temporalDate ? extractTemporalContentTerms(prompt, owner.config) : [];
+  const pureTemporalRecall = temporalDate !== null && temporalContentTerms.length === 0;
+  const daySummaryRows = temporalDate
+    ? owner.getDaySummaries({
+        date: temporalDate,
+        repository,
+        includeOtherRepositories: allowCrossRepoFallback && pureTemporalRecall,
+        limit: pureTemporalRecall && allowCrossRepoFallback
+          ? Math.max(2, Math.min(limit, 4))
+          : 1,
+      })
+    : [];
+  const includedDaySummaryRows = owner.filterPromptDaySummaries(
+    daySummaryRows,
+    pureTemporalRecall,
+    temporalContentTerms,
+  );
+  const episodeDetails = owner.buildPromptEpisodeContext({
+    prompt,
+    repository,
+    limit,
+    allowRepoLocalTaskContext,
+    allowCrossRepoFallback,
+    pureTemporalRecall,
+    temporalDate,
+    includedDaySummaryRows,
+  });
+  return {
+    temporalDate,
+    temporalContentTerms,
+    pureTemporalRecall,
+    daySummaryRows,
+    includedDaySummaryRows,
+    episodeDetails,
+    episodes: withCurrentRepository(episodeDetails.episodes, repository),
+    effectiveStyleSection: owner.buildEffectivePromptStyleSection({
+      prompt,
+      need,
+      assistantPersonaRows,
+      relationshipPreferenceRows,
+      pureTemporalRecall,
+    }),
+  };
+}
+
+export function buildPromptCrossRepoContext(owner, {
+  lexicalPrompt,
+  repository,
+  allowCrossRepoFallback,
+  pureTemporalRecall,
+  sessionStore,
+  limit,
+}) {
+  const allowGenericCrossRepoFallback = allowCrossRepoFallback && !pureTemporalRecall;
+  const crossRepoPreferenceLimit = Math.max(1, Math.min(2, Math.floor(limit / 2) || 1));
+  const selectCrossRepoRows = (rows) => withCurrentRepository(
+    rows
+      .filter((row) => isCrossRepoRow(row, repository))
+      .slice(0, crossRepoPreferenceLimit),
+    repository,
+  );
+  const crossRepoPreferenceRows = allowGenericCrossRepoFallback
+    ? owner.searchSemantic({
+        query: lexicalPrompt,
+        repository,
+        includeOtherRepositories: true,
+        types: ["user_preference", "rejected_approach", "recurring_mistake"],
+        scopes: [MEMORY_SCOPE.TRANSFERABLE],
+        limit: Math.max(limit * 4, 8),
+      })
+    : [];
+  const crossRepoPreferences = allowGenericCrossRepoFallback
+    ? selectCrossRepoRows(crossRepoPreferenceRows)
+    : [];
+  const crossRepoEpisodeDetails = allowGenericCrossRepoFallback
+    ? owner.findRelevantEpisodesDetailed({
+        prompt: lexicalPrompt,
+        repository,
+        includeOtherRepositories: true,
+        scopes: [MEMORY_SCOPE.TRANSFERABLE],
+        limit: Math.max(limit * 4, 8),
+      })
+    : null;
+  const crossRepoEpisodes = allowGenericCrossRepoFallback
+    ? selectCrossRepoRows(crossRepoEpisodeDetails.episodes)
+    : [];
+  const crossRepoHints = allowGenericCrossRepoFallback && sessionStore
+    ? withCurrentRepository(
+        sessionStore.findRelevantSessions({
+          prompt: lexicalPrompt,
+          repository: null,
+          limit: Math.max(limit * 4, 8),
+        }).filter((session) => isCrossRepoRow(session, repository))
+          .slice(0, crossRepoPreferenceLimit),
+        repository,
+      )
+    : [];
+  return {
+    allowGenericCrossRepoFallback,
+    crossRepoPreferenceRows,
+    crossRepoPreferences,
+    crossRepoEpisodeDetails,
+    crossRepoEpisodes,
+    crossRepoHints,
+  };
+}
+
+export function determinePromptDaySummaryReason(owner, {
+  need,
+  temporalDate,
+  includedDaySummaryRows,
+  daySummaryRows,
+}) {
+  if (!need.hasTemporalSignal) {
+    return "no_temporal_signal";
+  }
+  if (temporalDate === null) {
+    return "unresolved_temporal_date";
+  }
+  if (includedDaySummaryRows.length === 0 && daySummaryRows.length === 0) {
+    return "missing_day_summary";
+  }
+  return includedDaySummaryRows.length === 0
+    ? "summary_did_not_match_prompt_terms"
+    : null;
+}
+
+export function buildPromptTemporalVerifier(owner, {
+  repository,
+  sessionStore,
+  temporalDate,
+  pureTemporalRecall,
+  allowCrossRepoFallback,
+  limit,
+  daySummaryReason,
+  includedDaySummaryRows,
+  episodes,
+}) {
+  const temporalVerifierEnabled = !!sessionStore && temporalDate !== null && pureTemporalRecall;
+  const shouldRunTemporalVerifier = temporalVerifierEnabled
+    && includedDaySummaryRows.length === 0
+    && episodes.length === 0
+    && (daySummaryReason === "missing_day_summary" || daySummaryReason === "summary_did_not_match_prompt_terms");
+  const temporalVerifierRows = shouldRunTemporalVerifier
+    ? withCurrentRepository(
+        sessionStore.findSessionsByDate({
+          dateKey: temporalDate,
+          repository,
+          includeOtherRepositories: allowCrossRepoFallback,
+          limit: Math.max(2, Math.min(limit, 3)),
+        }).map((session) => ({
+          ...session,
+          source_type: "session_store_verifier",
+          excerpt: session.workspaceSummary || session.summary,
+        })),
+        repository,
+      )
+    : [];
+  return {
+    temporalVerifierEnabled,
+    shouldRunTemporalVerifier,
+    temporalVerifierRows,
+  };
+}
+
+export function buildPromptContextFlags(owner, need) {
+  return {
+    allowRepoLocalTaskContext: need.wantsRepoLocalTaskContext === true
+      && need.wantsCrossRepoExamples !== true,
+    allowCrossRepoFallback: need.allowCrossRepoFallback === true,
+    identityOnly: need.identityOnly === true,
+  };
+}
+
+export function buildLexicalPrompt(owner, prompt, promptTerms) {
+  return promptTerms.length > 0 ? promptTerms.join(" ") : prompt;
+}
+
+export function resolvePromptRenderTerms(owner, promptTerms, temporalContentTerms) {
+  return temporalContentTerms.length > 0 ? temporalContentTerms : promptTerms;
+}
+
+export function buildExplainComputedState(owner, trace, {
+  need, temporalCtx, allowCrossRepoFallback, limit, repository, sessionStore, promptTerms,
+}) {
+  const { temporalDate, temporalContentTerms, pureTemporalRecall, includedDaySummaryRows, daySummaryRows, episodes } = temporalCtx;
+  const renderTerms = owner.resolvePromptRenderTerms(promptTerms, temporalContentTerms);
+  const hasIncludedDaySummary = includedDaySummaryRows.length > 0;
+  const hasIncludedEpisodes = episodes.length > 0;
+  const daySummaryReason = owner.determinePromptDaySummaryReason({
+    need, temporalDate, includedDaySummaryRows, daySummaryRows,
+  });
+  const {
+    temporalVerifierEnabled,
+    shouldRunTemporalVerifier,
+    temporalVerifierRows,
+  } = owner.buildPromptTemporalVerifier({
+    repository, sessionStore, temporalDate, pureTemporalRecall,
+    allowCrossRepoFallback, limit, daySummaryReason, includedDaySummaryRows, episodes,
+  });
+  setPromptTemporalVerifierTraceState({
+    trace, repository, sessionStore, temporalDate, pureTemporalRecall,
+    temporalVerifierEnabled, shouldRunTemporalVerifier, temporalVerifierRows,
+  });
+  return { renderTerms, hasIncludedDaySummary, hasIncludedEpisodes, daySummaryReason, shouldRunTemporalVerifier, temporalVerifierRows };
+}
+
+export function collectPromptContext(owner, {
+  prompt,
+  repository,
+  includeOtherRepositories = false,
+  limit = 6,
+  sessionStore = null,
+  promptNeed = null,
+}) {
+  owner.ensureOpen();
+  const promptTerms = extractNormalizedFtsTerms(prompt, {
+    aliases: QUERY_ALIASES,
+    normalize: normalizeFtsToken,
+  });
+  const lexicalPrompt = owner.buildLexicalPrompt(prompt, promptTerms);
+  const identityName = detectAssistantIdentityName(prompt);
+  const need = promptNeed ?? buildDefaultPromptNeed(prompt, includeOtherRepositories);
+  const flags = owner.buildPromptContextFlags(need);
+  const { allowRepoLocalTaskContext, allowCrossRepoFallback, identityOnly } = flags;
+  const semanticCtx = owner.buildPromptSemanticContext({ prompt, repository, limit, identityName, identityOnly });
+  const temporalCtx = owner.buildPromptTemporalContext({
+    prompt, repository, need, limit, allowRepoLocalTaskContext, allowCrossRepoFallback,
+    assistantPersonaRows: semanticCtx.assistantPersonaRows,
+    relationshipPreferenceRows: semanticCtx.relationshipPreferenceRows,
+  });
+  // Query-matched style evidence remains useful even when ambient persona
+  // injection is disabled. Only suppress duplicate style entries that the
+  // dedicated section actually renders, or preserve temporal suppression.
+  semanticCtx.localMemories = semanticCtx.localMemories.filter((memory) => !isStyleAddressingMemory(memory)
+    || (!need.hasTemporalSignal && !temporalCtx.effectiveStyleSection.text.includes(memory.content)));
+  const crossRepoCtx = owner.buildPromptCrossRepoContext({
+    lexicalPrompt, repository, allowCrossRepoFallback,
+    pureTemporalRecall: temporalCtx.pureTemporalRecall, sessionStore, limit,
+  });
+  const trace = buildExplainPromptTrace({
+    prompt, repository, allowCrossRepoFallback, promptTerms, identityName,
+    semanticCtx, temporalCtx, crossRepoCtx, sessionStore,
+  });
+  const state = owner.buildExplainComputedState(trace, {
+    need, temporalCtx, allowCrossRepoFallback, limit, repository, sessionStore, promptTerms,
+  });
+  return {
+    prompt,
+    repository,
+    sessionStore,
+    need,
+    flags,
+    promptTerms,
+    semanticCtx,
+    temporalCtx,
+    crossRepoCtx,
+    state,
+    trace,
+  };
+}
+
+// Deprecated wrapper: prefer assembleRecall. Kept for one PR so existing
+// row/trace callers can keep a { text, trace } shape.
+export function explainPromptContext(owner, args) {
+  return renderPromptContext(owner.collectPromptContext(args));
+}
+
+export function buildPromptContext(owner, {
+  prompt,
+  repository,
+  includeOtherRepositories = false,
+  limit = 6,
+  sessionStore = null,
+  promptNeed = null,
+}) {
+  return owner.explainPromptContext({
+    prompt,
+    repository,
+    includeOtherRepositories,
+    limit,
+    sessionStore,
+    promptNeed,
+  }).text;
+}

--- a/lib/db/db-prompt-context.mjs
+++ b/lib/db/db-prompt-context.mjs
@@ -9,11 +9,11 @@ import { normalizeText } from "../utils/text-normalizer.mjs";
 import { isCrossRepoRow, serializeSessionTraceRow, setPromptTemporalVerifierTraceState } from "./db-temporal.mjs";
 import { serializeEpisodeTraceRow, buildLocalEligibility } from "./db-trace-serializers.mjs";
 
-export function normalizeTraceMemoryRow(memory) {
+function normalizeTraceMemoryRow(memory) {
   return memory && typeof memory === "object" ? memory : {};
 }
 
-export function buildSemanticTraceIdentity(memory) {
+function buildSemanticTraceIdentity(memory) {
   return {
     id: memory.id ?? null,
     type: memory.type ?? null,
@@ -23,7 +23,7 @@ export function buildSemanticTraceIdentity(memory) {
   };
 }
 
-export function buildSemanticTraceMetadata(memory) {
+function buildSemanticTraceMetadata(memory) {
   return {
     updatedAt: memory.updated_at ?? null,
     canonicalKey: memory.canonical_key ?? null,
@@ -32,19 +32,19 @@ export function buildSemanticTraceMetadata(memory) {
   };
 }
 
-export function serializeSemanticRows(rows, repository) {
+function serializeSemanticRows(rows, repository) {
   return rows.map((memory) => serializeSemanticTraceRow(memory, repository));
 }
 
-export function serializeEpisodeRows(rows, repository) {
+function serializeEpisodeRows(rows, repository) {
   return rows.map((episode) => serializeEpisodeTraceRow(episode, repository));
 }
 
-export function serializeSessionRows(rows, repository) {
+function serializeSessionRows(rows, repository) {
   return rows.map((session) => serializeSessionTraceRow(session, repository));
 }
 
-export function serializeSemanticTraceRow(memory, currentRepository = null) {
+function serializeSemanticTraceRow(memory, currentRepository = null) {
   const normalizedMemory = normalizeTraceMemoryRow(memory);
   return {
     ...buildSemanticTraceIdentity(normalizedMemory),
@@ -54,7 +54,7 @@ export function serializeSemanticTraceRow(memory, currentRepository = null) {
   };
 }
 
-export function buildStyleAddressingTraceLookup({
+function buildStyleAddressingTraceLookup({
   effectiveStyleSection,
   assistantPersonaRows,
   relationshipPreferenceRows,
@@ -75,7 +75,7 @@ export function buildStyleAddressingTraceLookup({
   };
 }
 
-export function buildCrossRepoPreferencesTraceLookup({
+function buildCrossRepoPreferencesTraceLookup({
   allowGenericCrossRepoFallback,
   crossRepoPreferenceRows,
   crossRepoPreferences,
@@ -97,7 +97,7 @@ export function buildCrossRepoPreferencesTraceLookup({
   };
 }
 
-export function buildCrossRepoEpisodesTraceLookup({
+function buildCrossRepoEpisodesTraceLookup({
   allowGenericCrossRepoFallback,
   crossRepoEpisodeDetails,
   crossRepoEpisodes,
@@ -122,7 +122,7 @@ export function buildCrossRepoEpisodesTraceLookup({
   };
 }
 
-export function serializeDaySummaryTraceRow(summary, currentRepository = null) {
+function serializeDaySummaryTraceRow(summary, currentRepository = null) {
   return {
     repository: summary.repository ?? null,
     dateKey: summary.date_key ?? null,
@@ -132,7 +132,7 @@ export function serializeDaySummaryTraceRow(summary, currentRepository = null) {
   };
 }
 
-export function createPromptContextTrace({
+function createPromptContextTrace({
   prompt,
   repository,
   allowCrossRepoFallback,
@@ -231,7 +231,7 @@ export function createPromptContextTrace({
   };
 }
 
-export function dedupeSemanticContextRows(rows) {
+function dedupeSemanticContextRows(rows) {
   const seen = new Set();
   const deduped = [];
   for (const row of rows) {
@@ -245,7 +245,7 @@ export function dedupeSemanticContextRows(rows) {
   return deduped;
 }
 
-export function buildDefaultPromptNeed(prompt, includeOtherRepositories = false) {
+function buildDefaultPromptNeed(prompt, includeOtherRepositories = false) {
   const detected = detectPromptContextNeed(prompt);
   return {
     ...detected,
@@ -253,21 +253,21 @@ export function buildDefaultPromptNeed(prompt, includeOtherRepositories = false)
   };
 }
 
-export function extractTemporalContentTerms(query, config = null) {
+function extractTemporalContentTerms(query, config = null) {
   if (!readTemporalQueryNormalizationEnabled(config)) {
     return extractNormalizedDirectTerms(query);
   }
   return extractNormalizedTemporalContentTerms(query);
 }
 
-export function withCurrentRepository(rows, repository) {
+function withCurrentRepository(rows, repository) {
   return rows.map((row) => ({
     ...row,
     currentRepository: repository,
   }));
 }
 
-export function inferDateFromPrompt(prompt, config = null) {
+function inferDateFromPrompt(prompt, config = null) {
   if (!readTemporalQueryNormalizationEnabled(config)) {
     const text = String(prompt || "").toLowerCase();
     const now = new Date();
@@ -299,7 +299,7 @@ export function inferDateFromPrompt(prompt, config = null) {
   return inferNormalizedDateFromPrompt(prompt, { now: config?.now });
 }
 
-export function buildExplainPromptTrace({ prompt, repository, allowCrossRepoFallback, promptTerms, identityName, semanticCtx, temporalCtx, crossRepoCtx, sessionStore }) {
+function buildExplainPromptTrace({ prompt, repository, allowCrossRepoFallback, promptTerms, identityName, semanticCtx, temporalCtx, crossRepoCtx, sessionStore }) {
   return createPromptContextTrace({
     prompt,
     repository,

--- a/lib/db/db-scope-management.mjs
+++ b/lib/db/db-scope-management.mjs
@@ -6,7 +6,7 @@ import { normalizeRepository } from "../utils/repository-utils.mjs";
 import { addStringFilter } from "../utils/sql-filter-utils.mjs";
 import { nowIso, SCOPE_SOURCE, normalizeScopeSource } from "./db-shared.mjs";
 
-export function effectiveRepositoryForScope(scope, rowRepository, metadata = {}, fallbackRepository = null) {
+function effectiveRepositoryForScope(scope, rowRepository, metadata = {}, fallbackRepository = null) {
   if (scope === MEMORY_SCOPE.GLOBAL) {
     return null;
   }
@@ -15,7 +15,7 @@ export function effectiveRepositoryForScope(scope, rowRepository, metadata = {},
     ?? normalizeRepository(fallbackRepository);
 }
 
-export function classifySemanticRow(row, { fallbackRepository = null, ignoreManualOverride = false } = {}) {
+function classifySemanticRow(row, { fallbackRepository = null, ignoreManualOverride = false } = {}) {
   const metadata = parseJsonObject(row.metadata_json);
   const scopeSource = normalizeScopeSource(row.scope_source);
   if (!ignoreManualOverride && scopeSource === SCOPE_SOURCE.MANUAL) {
@@ -41,7 +41,7 @@ export function classifySemanticRow(row, { fallbackRepository = null, ignoreManu
   };
 }
 
-export function classifyEpisodeRow(row, { fallbackRepository = null, ignoreManualOverride = false } = {}) {
+function classifyEpisodeRow(row, { fallbackRepository = null, ignoreManualOverride = false } = {}) {
   const scopeSource = normalizeScopeSource(row.scope_source);
   if (!ignoreManualOverride && scopeSource === SCOPE_SOURCE.MANUAL) {
     const scope = normalizeScope(row.scope, MEMORY_SCOPE.REPO);

--- a/lib/db/db-scope-management.mjs
+++ b/lib/db/db-scope-management.mjs
@@ -1,0 +1,309 @@
+import crypto from "node:crypto";
+import { classifyEpisodeDigest, classifySemanticMemory, MEMORY_SCOPE, normalizeScope } from "../memory/memory-scope.mjs";
+import { parseJsonArray } from "../utils/json-array-utils.mjs";
+import { parseJsonObject } from "../utils/json-object-utils.mjs";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { addStringFilter } from "../utils/sql-filter-utils.mjs";
+import { nowIso, SCOPE_SOURCE, normalizeScopeSource } from "./db-shared.mjs";
+
+export function effectiveRepositoryForScope(scope, rowRepository, metadata = {}, fallbackRepository = null) {
+  if (scope === MEMORY_SCOPE.GLOBAL) {
+    return null;
+  }
+  return normalizeRepository(rowRepository)
+    ?? normalizeRepository(metadata?.originRepository)
+    ?? normalizeRepository(fallbackRepository);
+}
+
+export function classifySemanticRow(row, { fallbackRepository = null, ignoreManualOverride = false } = {}) {
+  const metadata = parseJsonObject(row.metadata_json);
+  const scopeSource = normalizeScopeSource(row.scope_source);
+  if (!ignoreManualOverride && scopeSource === SCOPE_SOURCE.MANUAL) {
+    const scope = normalizeScope(row.scope, MEMORY_SCOPE.REPO);
+    return {
+      scope,
+      repository: effectiveRepositoryForScope(scope, row.repository, metadata, fallbackRepository),
+      metadata,
+      scopeSource,
+    };
+  }
+  const classification = classifySemanticMemory({
+    type: row.type,
+    content: row.content,
+    scope: null,
+    repository: row.repository ?? fallbackRepository ?? metadata.originRepository ?? null,
+    tags: row.tags ? row.tags.split(/\s+/).filter(Boolean) : [],
+    metadata,
+  });
+  return {
+    ...classification,
+    scopeSource: SCOPE_SOURCE.AUTO,
+  };
+}
+
+export function classifyEpisodeRow(row, { fallbackRepository = null, ignoreManualOverride = false } = {}) {
+  const scopeSource = normalizeScopeSource(row.scope_source);
+  if (!ignoreManualOverride && scopeSource === SCOPE_SOURCE.MANUAL) {
+    const scope = normalizeScope(row.scope, MEMORY_SCOPE.REPO);
+    return {
+      scope,
+      repository: effectiveRepositoryForScope(scope, row.repository, {}, fallbackRepository),
+      scopeSource,
+    };
+  }
+  const classification = classifyEpisodeDigest({
+    scope: null,
+    repository: row.repository ?? fallbackRepository ?? null,
+    summary: row.summary,
+    actions: parseJsonArray(row.actions_json),
+    decisions: parseJsonArray(row.decisions_json),
+    learnings: parseJsonArray(row.learnings_json),
+    refs: parseJsonArray(row.refs_json),
+    themes: parseJsonArray(row.themes_json),
+    openItems: parseJsonArray(row.open_items_json),
+  });
+  return {
+    ...classification,
+    scopeSource: SCOPE_SOURCE.AUTO,
+  };
+}
+
+export function getSemanticMemoryByIds(owner, ids) {
+  owner.ensureOpen();
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return [];
+  }
+  const placeholders = ids.map(() => "?").join(", ");
+  return owner.db.prepare(`
+    SELECT
+      id, type, content, confidence, source_session_id, source_turn_index,
+      scope, scope_source, scope_override_actor, scope_override_reason, scope_override_source, scope_override_at,
+      repository, tags, created_at, updated_at, superseded_by, canonical_key, reinforcement_count,
+      last_seen_at, expires_at, metadata_json
+    FROM semantic_memory
+    WHERE id IN (${placeholders})
+    ORDER BY updated_at DESC
+  `).all(...ids);
+}
+
+export function getEpisodeDigestsByIds(owner, ids) {
+  owner.ensureOpen();
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return [];
+  }
+  const placeholders = ids.map(() => "?").join(", ");
+  return owner.db.prepare(`
+    SELECT
+      id, session_id, scope, scope_source, scope_override_actor, scope_override_reason, scope_override_source, scope_override_at,
+      repository, branch, summary, actions_json, decisions_json, learnings_json, files_changed_json,
+      refs_json, significance, themes_json, open_items_json, source, date_key, created_at, updated_at
+    FROM episode_digest
+    WHERE id IN (${placeholders})
+    ORDER BY updated_at DESC
+  `).all(...ids);
+}
+
+export function previewScopeChanges(owner, {
+  targetType,
+  ids,
+  action = "set",
+  scope,
+  repository,
+}) {
+  owner.ensureOpen();
+  const targetIds = Array.isArray(ids) ? [...new Set(ids.filter((value) => typeof value === "string" && value.trim().length > 0))] : [];
+  if (targetIds.length === 0) {
+    throw new Error("ids must include at least one target id");
+  }
+  const normalizedAction = action === "clear" ? "clear" : "set";
+  const nextScope = normalizedAction === "set" ? normalizeScope(scope, null) : null;
+  if (normalizedAction === "set" && !nextScope) {
+    throw new Error("scope must be one of: global, transferable, repo");
+  }
+  const fallbackRepository = normalizeRepository(repository);
+  const rows = targetType === "episode"
+    ? owner.getEpisodeDigestsByIds(targetIds)
+    : owner.getSemanticMemoryByIds(targetIds);
+
+  const foundIds = new Set(rows.map((row) => row.id));
+  const missingIds = targetIds.filter((id) => !foundIds.has(id));
+  const previews = rows.map((row) => {
+    const currentMetadata = targetType === "semantic" ? parseJsonObject(row.metadata_json) : {};
+    const current = {
+      scope: row.scope,
+      repository: row.repository,
+      scopeSource: normalizeScopeSource(row.scope_source),
+    };
+    const next = normalizedAction === "clear"
+      ? (targetType === "episode"
+          ? classifyEpisodeRow(row, { fallbackRepository, ignoreManualOverride: true })
+          : classifySemanticRow(row, { fallbackRepository, ignoreManualOverride: true }))
+      : {
+          scope: nextScope,
+          repository: effectiveRepositoryForScope(nextScope, row.repository, currentMetadata, fallbackRepository),
+          scopeSource: SCOPE_SOURCE.MANUAL,
+        };
+    return {
+      id: row.id,
+      targetType,
+      current,
+      next,
+      changed: current.scope !== next.scope
+        || (current.repository ?? null) !== (next.repository ?? null)
+        || current.scopeSource !== next.scopeSource,
+    };
+  });
+
+  return {
+    action: normalizedAction,
+    targetType,
+    requestedCount: targetIds.length,
+    matchedCount: previews.length,
+    missingIds,
+    rows: previews,
+  };
+}
+
+export function insertScopeOverrideAudit(owner, {
+  targetType,
+  targetId,
+  action,
+  previousScope,
+  nextScope,
+  previousRepository,
+  nextRepository,
+  actor,
+  reason,
+  source,
+}) {
+  owner.db.prepare(`
+    INSERT INTO scope_override_audit (
+      id, target_type, target_id, action, previous_scope, next_scope,
+      previous_repository, next_repository, actor, reason, source, created_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    crypto.randomUUID(),
+    targetType,
+    targetId,
+    action,
+    previousScope ?? null,
+    nextScope ?? null,
+    normalizeRepository(previousRepository),
+    normalizeRepository(nextRepository),
+    actor,
+    reason,
+    source,
+    nowIso(),
+  );
+}
+
+export function applyScopeChanges(owner, {
+  targetType,
+  ids,
+  action = "set",
+  scope,
+  repository,
+  actor,
+  reason,
+  source,
+}) {
+  owner.ensureOpen();
+  const preview = owner.previewScopeChanges({
+    targetType,
+    ids,
+    action,
+    scope,
+    repository,
+  });
+  const timestamp = nowIso();
+  const normalizedAction = preview.action;
+  const updateSemantic = owner.db.prepare(`
+    UPDATE semantic_memory
+    SET scope = ?,
+        repository = ?,
+        scope_source = ?,
+        scope_override_actor = ?,
+        scope_override_reason = ?,
+        scope_override_source = ?,
+        scope_override_at = ?,
+        updated_at = ?
+    WHERE id = ?
+  `);
+  const updateEpisode = owner.db.prepare(`
+    UPDATE episode_digest
+    SET scope = ?,
+        repository = ?,
+        scope_source = ?,
+        scope_override_actor = ?,
+        scope_override_reason = ?,
+        scope_override_source = ?,
+        scope_override_at = ?,
+        updated_at = ?
+    WHERE id = ?
+  `);
+
+  for (const row of preview.rows) {
+    const nextScopeSource = normalizedAction === "clear" ? SCOPE_SOURCE.AUTO : SCOPE_SOURCE.MANUAL;
+    const overrideActor = normalizedAction === "clear" ? null : actor;
+    const overrideReason = normalizedAction === "clear" ? null : reason;
+    const overrideSource = normalizedAction === "clear" ? null : source;
+    const overrideAt = normalizedAction === "clear" ? null : timestamp;
+    if (targetType === "episode") {
+      updateEpisode.run(
+        row.next.scope,
+        row.next.repository,
+        nextScopeSource,
+        overrideActor,
+        overrideReason,
+        overrideSource,
+        overrideAt,
+        timestamp,
+        row.id,
+      );
+    } else {
+      updateSemantic.run(
+        row.next.scope,
+        row.next.repository,
+        nextScopeSource,
+        overrideActor,
+        overrideReason,
+        overrideSource,
+        overrideAt,
+        timestamp,
+        row.id,
+      );
+    }
+    owner.insertScopeOverrideAudit({
+      targetType,
+      targetId: row.id,
+      action: normalizedAction,
+      previousScope: row.current.scope,
+      nextScope: row.next.scope,
+      previousRepository: row.current.repository,
+      nextRepository: row.next.repository,
+      actor,
+      reason,
+      source,
+    });
+  }
+
+  return preview;
+}
+
+export function listScopeOverrideAudit(owner, { targetType, targetId, limit = 10 }) {
+  owner.ensureOpen();
+  const params = [];
+  const where = [];
+  addStringFilter(where, params, "target_type", targetType);
+  addStringFilter(where, params, "target_id", targetId);
+  params.push(limit);
+  return owner.db.prepare(`
+    SELECT
+      id, target_type, target_id, action, previous_scope, next_scope,
+      previous_repository, next_repository, actor, reason, source, created_at
+    FROM scope_override_audit
+    ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
+    ORDER BY created_at DESC
+    LIMIT ?
+  `).all(...params);
+}

--- a/lib/db/db-semantic-memory-write.mjs
+++ b/lib/db/db-semantic-memory-write.mjs
@@ -7,13 +7,13 @@ import { normalizeRepository } from "../utils/repository-utils.mjs";
 import { normalizeText } from "../utils/text-normalizer.mjs";
 import { nowIso, SCOPE_SOURCE, normalizeScopeSource } from "./db-shared.mjs";
 
-export const LAST_SEEN_AT_CASE_SQL = "last_seen_at = CASE WHEN ? IS NULL THEN COALESCE(last_seen_at, ?) WHEN last_seen_at IS NULL OR ? > last_seen_at THEN ? ELSE last_seen_at END";
+const LAST_SEEN_AT_CASE_SQL = "last_seen_at = CASE WHEN ? IS NULL THEN COALESCE(last_seen_at, ?) WHEN last_seen_at IS NULL OR ? > last_seen_at THEN ? ELSE last_seen_at END";
 
-export function lastSeenAtParams(value) {
+function lastSeenAtParams(value) {
   return [value, value, value, value];
 }
 
-export function mergeTagText(existingTags, incomingTags) {
+function mergeTagText(existingTags, incomingTags) {
   const tags = new Set(
     `${existingTags || ""} ${incomingTags || ""}`
       .trim()
@@ -23,19 +23,19 @@ export function mergeTagText(existingTags, incomingTags) {
   return [...tags].join(" ");
 }
 
-export function resolveTimestamp(value, fallback) {
+function resolveTimestamp(value, fallback) {
   return typeof value === "string" && value.length > 0 ? value : fallback;
 }
 
-export const MS_PER_HOUR = 60 * 60 * 1000;
+const MS_PER_HOUR = 60 * 60 * 1000;
 
-export const VOLATILE_TTL_MS = Object.freeze({
+const VOLATILE_TTL_MS = Object.freeze({
   assistant_goal: 24 * MS_PER_HOUR,
   open_loop: 7 * 24 * MS_PER_HOUR,
   blocker: 7 * 24 * MS_PER_HOUR,
 });
 
-export function defaultVolatileExpiry(type, timestamp) {
+function defaultVolatileExpiry(type, timestamp) {
   const ttlMs = VOLATILE_TTL_MS[type];
   if (!ttlMs) {
     return null;

--- a/lib/db/db-semantic-memory-write.mjs
+++ b/lib/db/db-semantic-memory-write.mjs
@@ -1,0 +1,401 @@
+import crypto from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import { buildSemanticCanonicalKey, classifySemanticMemory } from "../memory/memory-scope.mjs";
+import { findActiveSuppression as findLifecycleSuppression, isExplicitLifecycleWrite, normalizeEvidence } from "./db-memory-lifecycle.mjs";
+import { parseJsonObject } from "../utils/json-object-utils.mjs";
+import { normalizeRepository } from "../utils/repository-utils.mjs";
+import { normalizeText } from "../utils/text-normalizer.mjs";
+import { nowIso, SCOPE_SOURCE, normalizeScopeSource } from "./db-shared.mjs";
+
+export const LAST_SEEN_AT_CASE_SQL = "last_seen_at = CASE WHEN ? IS NULL THEN COALESCE(last_seen_at, ?) WHEN last_seen_at IS NULL OR ? > last_seen_at THEN ? ELSE last_seen_at END";
+
+export function lastSeenAtParams(value) {
+  return [value, value, value, value];
+}
+
+export function mergeTagText(existingTags, incomingTags) {
+  const tags = new Set(
+    `${existingTags || ""} ${incomingTags || ""}`
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean),
+  );
+  return [...tags].join(" ");
+}
+
+export function resolveTimestamp(value, fallback) {
+  return typeof value === "string" && value.length > 0 ? value : fallback;
+}
+
+export const MS_PER_HOUR = 60 * 60 * 1000;
+
+export const VOLATILE_TTL_MS = Object.freeze({
+  assistant_goal: 24 * MS_PER_HOUR,
+  open_loop: 7 * 24 * MS_PER_HOUR,
+  blocker: 7 * 24 * MS_PER_HOUR,
+});
+
+export function defaultVolatileExpiry(type, timestamp) {
+  const ttlMs = VOLATILE_TTL_MS[type];
+  if (!ttlMs) {
+    return null;
+  }
+  const start = Date.parse(timestamp);
+  if (!Number.isFinite(start)) {
+    return null;
+  }
+  return new Date(start + ttlMs).toISOString();
+}
+
+export function buildSemanticMemoryWriteContext(owner, memory, timestamp) {
+  const classification = classifySemanticMemory(memory);
+  const evidence = normalizeEvidence({
+    sessionId: memory.sourceSessionId,
+    memory,
+    repository: classification.repository,
+  });
+  return {
+    id: memory.id ?? crypto.randomUUID(),
+    type: memory.type,
+    content: memory.content,
+    classification,
+    repository: normalizeRepository(classification.repository),
+    scope: classification.scope,
+    domainKey: normalizeText(memory.domainKey).toLowerCase() || null,
+    tagsText: Array.isArray(memory.tags) ? memory.tags.join(" ") : "",
+    sourceText: typeof classification.metadata?.source === "string" ? classification.metadata.source : "",
+    canonicalKey: buildSemanticCanonicalKey({
+      ...memory,
+      metadata: classification.metadata,
+      content: memory.content,
+      type: memory.type,
+    }),
+    incomingReinforcement: Number.isInteger(memory.reinforcementCount)
+      ? Math.max(1, memory.reinforcementCount)
+      : 1,
+    incomingLastSeenAt: memory.lastSeenAt ?? timestamp,
+    incomingConfidence: typeof memory.confidence === "number" ? memory.confidence : 1.0,
+    insertedUpdatedAt: resolveTimestamp(memory.updatedAt, timestamp),
+    evidence,
+    explicitWrite: isExplicitLifecycleWrite(memory, classification.metadata),
+    hasExpiresAt: Object.hasOwn(memory ?? {}, "expiresAt") || Object.hasOwn(memory ?? {}, "expires_at"),
+    expiresAt: Object.hasOwn(memory ?? {}, "expiresAt") ? memory.expiresAt : memory.expires_at,
+  };
+}
+
+export function findActiveSuppression(owner, write) {
+  return findLifecycleSuppression(owner, write);
+}
+
+export function isMemorySuppressed(owner, id) {
+  return !!owner.db.prepare(`
+    SELECT 1 FROM memory_suppression
+    WHERE memory_id = ? AND superseded_at IS NULL AND COALESCE(repair_candidate, 0) = 0
+    LIMIT 1
+  `).get(id);
+}
+
+export function listActiveMemorySuppressions(owner) {
+  owner.ensureOpen();
+  return owner.db.prepare(`
+    SELECT memory_id, canonical_fingerprint, evidence_fingerprint, scope, repository
+    FROM memory_suppression
+    WHERE superseded_at IS NULL AND COALESCE(repair_candidate, 0) = 0
+  `).all();
+}
+
+export function findManualSemanticMemoryMatch(owner, memory, canonicalKey, scope, repository) {
+  return owner.db.prepare(`
+    SELECT
+      id, tags, metadata_json, scope, repository, scope_source, confidence,
+      reinforcement_count, last_seen_at, expires_at
+    FROM semantic_memory
+    WHERE superseded_by IS NULL
+      AND type = ?
+      AND (
+        (? IS NOT NULL AND canonical_key = ?)
+        OR (canonical_key IS NULL AND content = ?)
+      )
+      AND scope_source = 'manual'
+      AND scope = ?
+      AND IFNULL(repository, '') = IFNULL(?, '')
+    ORDER BY CASE WHEN canonical_key IS NOT NULL THEN 0 ELSE 1 END, updated_at DESC
+    LIMIT 1
+  `).get(
+    memory.type,
+    canonicalKey,
+    canonicalKey,
+    memory.content,
+    scope,
+    repository,
+  );
+}
+
+export function findScopedSemanticMemoryMatch(owner, memory, canonicalKey, scope, repository) {
+  return owner.db.prepare(`
+    SELECT id, content, tags, metadata_json, scope_source, reinforcement_count, last_seen_at, expires_at
+    FROM semantic_memory
+    WHERE superseded_by IS NULL
+      AND type = ?
+      AND (
+        (? IS NOT NULL AND canonical_key = ?)
+        OR (canonical_key IS NULL AND content = ?)
+      )
+      AND scope = ?
+      AND IFNULL(repository, '') = IFNULL(?, '')
+    ORDER BY CASE WHEN canonical_key IS NOT NULL THEN 0 ELSE 1 END, updated_at DESC
+    LIMIT 1
+  `).get(
+    memory.type,
+    canonicalKey,
+    canonicalKey,
+    memory.content,
+    scope,
+    repository,
+  );
+}
+
+export function buildSemanticMemoryMetadata(owner, existingMetadata, domainKey, classificationMetadata, evidence = null) {
+  return {
+    ...existingMetadata,
+    ...(domainKey ? { domainKey } : {}),
+    ...classificationMetadata,
+    ...(evidence ? {
+      evidence: {
+        key: evidence.key,
+        sourceRecordId: evidence.sourceRecordId,
+        sourceKind: evidence.sourceKind,
+        revision: evidence.revision,
+        contentHash: evidence.contentHash,
+      },
+    } : {}),
+  };
+}
+
+export function updateManualSemanticMemoryMatch(owner, memory, write, timestamp, match) {
+  const mergedMetadata = owner.buildSemanticMemoryMetadata(
+    parseJsonObject(match.metadata_json),
+    write.domainKey,
+    write.classification.metadata,
+    write.explicitWrite ? null : write.evidence,
+  );
+  owner.db.prepare(`
+    UPDATE semantic_memory
+    SET confidence = MAX(confidence, ?),
+        updated_at = ?,
+        source_session_id = COALESCE(?, source_session_id),
+        source_turn_index = COALESCE(?, source_turn_index),
+        domain_key = COALESCE(?, domain_key),
+        tags = ?,
+        metadata_json = ?,
+        canonical_key = COALESCE(canonical_key, ?),
+        reinforcement_count = MAX(1, COALESCE(reinforcement_count, 1) + ?),
+        expires_at = CASE WHEN ? = 1 THEN ? ELSE expires_at END,
+        ${LAST_SEEN_AT_CASE_SQL}
+    WHERE id = ?
+  `).run(
+    write.incomingConfidence,
+    timestamp,
+    memory.sourceSessionId ?? null,
+    Number.isInteger(memory.sourceTurnIndex) ? memory.sourceTurnIndex : null,
+    write.domainKey,
+    mergeTagText(match.tags, write.tagsText),
+    JSON.stringify(mergedMetadata),
+    write.canonicalKey,
+    write.incomingReinforcement,
+    write.hasExpiresAt ? 1 : 0,
+    write.hasExpiresAt ? write.expiresAt ?? null : null,
+    ...lastSeenAtParams(write.incomingLastSeenAt),
+    match.id,
+  );
+  return match.id;
+}
+
+export function updateProtectedSemanticMemoryMatch(owner, existing) {
+  // Inferred evidence can share an explicit proposition, but it must not
+  // rewrite the explicit row's provenance, confidence, or reinforcement.
+  return existing.id;
+}
+
+export function updateScopedSemanticMemoryMatch(owner, memory, existing, write, timestamp) {
+  const mergedMetadata = owner.buildSemanticMemoryMetadata(
+    parseJsonObject(existing.metadata_json),
+    write.domainKey,
+    write.classification.metadata,
+    write.explicitWrite ? null : write.evidence,
+  );
+  owner.db.prepare(`
+    UPDATE semantic_memory
+    SET confidence = ?,
+        updated_at = ?,
+        source_session_id = COALESCE(?, source_session_id),
+        source_turn_index = COALESCE(?, source_turn_index),
+        domain_key = COALESCE(?, domain_key),
+        tags = ?,
+        metadata_json = ?,
+        canonical_key = COALESCE(canonical_key, ?),
+        reinforcement_count = MAX(1, COALESCE(reinforcement_count, 1) + ?),
+        expires_at = CASE WHEN ? = 1 THEN ? ELSE expires_at END,
+        ${LAST_SEEN_AT_CASE_SQL}
+    WHERE id = ?
+  `).run(
+    write.incomingConfidence,
+    timestamp,
+    memory.sourceSessionId ?? null,
+    Number.isInteger(memory.sourceTurnIndex) ? memory.sourceTurnIndex : null,
+    write.domainKey,
+    mergeTagText(existing.tags, write.tagsText),
+    JSON.stringify(mergedMetadata),
+    write.canonicalKey,
+    write.incomingReinforcement,
+    write.hasExpiresAt ? 1 : 0,
+    write.hasExpiresAt ? write.expiresAt ?? null : null,
+    ...lastSeenAtParams(write.incomingLastSeenAt),
+    existing.id,
+  );
+  return existing.id;
+}
+
+export function insertNewSemanticMemory(owner, memory, write, timestamp) {
+  const expiresAt = write.hasExpiresAt
+    ? write.expiresAt ?? null
+    : defaultVolatileExpiry(memory.type, timestamp);
+  owner.db.prepare(`
+    INSERT INTO semantic_memory (
+      id, type, content, confidence, source_session_id, source_turn_index,
+      scope, repository, domain_key, tags, created_at, updated_at, superseded_by, canonical_key,
+      reinforcement_count, last_seen_at, expires_at, metadata_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    write.id,
+    memory.type,
+    memory.content,
+    write.incomingConfidence,
+    memory.sourceSessionId ?? null,
+    Number.isInteger(memory.sourceTurnIndex) ? memory.sourceTurnIndex : null,
+    write.scope,
+    write.repository,
+    write.domainKey,
+    write.tagsText,
+    memory.createdAt ?? timestamp,
+    write.insertedUpdatedAt,
+    memory.supersededBy ?? null,
+    write.canonicalKey,
+    write.incomingReinforcement,
+    write.incomingLastSeenAt,
+    expiresAt,
+    JSON.stringify(owner.buildSemanticMemoryMetadata({}, write.domainKey, write.classification.metadata,
+      write.explicitWrite ? null : write.evidence)),
+  );
+  return write.id;
+}
+
+export function upsertManualSemanticMemory(owner, memory, write, timestamp) {
+  const manualScopeMatch = owner.findManualSemanticMemoryMatch(memory, write.canonicalKey, write.scope, write.repository);
+  if (!manualScopeMatch?.id) return null;
+  return write.explicitWrite
+    ? owner.updateManualSemanticMemoryMatch(memory, write, timestamp, manualScopeMatch)
+    : owner.updateProtectedSemanticMemoryMatch(manualScopeMatch, write, timestamp);
+}
+
+export function upsertScopedSemanticMemory(owner, memory, write, timestamp) {
+  const existing = owner.findScopedSemanticMemoryMatch(
+    memory,
+    write.canonicalKey,
+    write.scope,
+    write.repository,
+  );
+  if (!existing?.id) {
+    return null;
+  }
+  // An explicit save is an intentional restore. Keep the suppressed
+  // generated row immutable and create a fresh manual row so retrieval can
+  // distinguish the restoration from the forgotten proposition.
+  if (write.explicitWrite && (owner.isMemorySuppressed(existing.id) || owner.findActiveSuppression(write))) {
+    return null;
+  }
+  const existingMetadata = parseJsonObject(existing.metadata_json);
+  const manualExisting = ["memory_save", "lore_retain", "onboarding", "pi", "pi:command"].includes(existingMetadata.source);
+  const manualIncoming = write.explicitWrite;
+  const lockedScope = normalizeScopeSource(existing.scope_source) === SCOPE_SOURCE.MANUAL;
+  if ((manualExisting || lockedScope) && !manualIncoming) return owner.updateProtectedSemanticMemoryMatch(existing, write, timestamp);
+  if (write.preserveProposition && existing.content !== memory.content) return null;
+  return owner.updateScopedSemanticMemoryMatch(memory, existing, write, timestamp);
+}
+
+export function insertSemanticMemory(owner, memory, { preserveProposition = false } = {}) {
+  owner.ensureOpen();
+  const timestamp = nowIso();
+  const write = owner.buildSemanticMemoryWriteContext(memory, timestamp);
+  if (write.hasExpiresAt && write.expiresAt !== null && write.expiresAt !== undefined
+    && (typeof write.expiresAt !== "string" || !Number.isFinite(Date.parse(write.expiresAt)))) {
+    throw new Error("expiresAt must be a valid timestamp or null");
+  }
+  if (typeof write.expiresAt === "string") write.expiresAt = new Date(write.expiresAt).toISOString();
+  write.preserveProposition = preserveProposition;
+  if (!write.explicitWrite && owner.findActiveSuppression(write)) {
+    return null;
+  }
+  const id = owner.upsertManualSemanticMemory(memory, write, timestamp)
+    ?? owner.upsertScopedSemanticMemory(memory, write, timestamp)
+    ?? owner.insertNewSemanticMemory(memory, write, timestamp);
+  if (owner.pendingSemanticDurability) owner.pendingSemanticDurability.add(id);
+  else owner.verifySemanticMemoryDurability(id);
+  return id;
+}
+
+// Capture hooks can race at turn/session end. Commit the complete refresh
+// atomically, then perform the usual independent-connection durability check.
+export function withSemanticMemoryTransaction(owner, callback) {
+  owner.ensureOpen();
+  if (owner.pendingSemanticDurability) throw new Error("Nested semantic transactions are not supported");
+  owner.db.exec("BEGIN IMMEDIATE");
+  const pending = new Set();
+  owner.pendingSemanticDurability = pending;
+  let committed = false;
+  try {
+    const result = callback();
+    if (result?.then) throw new Error("Semantic transaction callbacks must be synchronous");
+    owner.db.exec("COMMIT");
+    committed = true;
+    for (const id of pending) owner.verifySemanticMemoryDurability(id);
+    return result;
+  } catch (error) {
+    if (!committed) owner.db.exec("ROLLBACK");
+    throw error;
+  } finally {
+    owner.pendingSemanticDurability = null;
+  }
+}
+
+// Re-reads the row via an independent connection right after writing it.
+// A same-connection read can't catch a cross-process WAL checkpoint race
+// (multiple Copilot CLI processes can hold lore.db open concurrently);
+// this call, from a fresh connection, mirrors what an external reader
+// would actually see and turns a silent data-loss into a real failure
+// instead of a false "Retained semantic memory <id>" success message.
+export function verifySemanticMemoryDurability(owner, id) {
+  const dbPath = owner.config.paths.derivedStorePath;
+  let verifyDb;
+  try {
+    verifyDb = new DatabaseSync(dbPath, { readOnly: true });
+    verifyDb.exec("PRAGMA busy_timeout = 2000;");
+    const row = verifyDb.prepare(`
+      SELECT id FROM semantic_memory WHERE id = ? LIMIT 1
+    `).get(id);
+    if (!row) {
+      throw new Error(
+        `semantic memory ${id} did not durably persist: not visible via an ` +
+        "independent connection immediately after insert. This can happen when " +
+        "multiple concurrent Copilot CLI processes hold lore.db open and a WAL " +
+        "checkpoint races an in-flight write. The memory was NOT saved - retry.",
+      );
+    }
+  } finally {
+    try {
+      verifyDb?.close();
+    } catch {
+      // best-effort close of the verification connection
+    }
+  }
+}

--- a/lib/db/db-shared.mjs
+++ b/lib/db/db-shared.mjs
@@ -1,0 +1,24 @@
+import { buildScopeEligibilitySql } from "./db-retrieval-policy.mjs";
+
+export function nowIso() {
+  return new Date().toISOString();
+}
+
+export const SCOPE_SOURCE = Object.freeze({
+  AUTO: "auto",
+  MANUAL: "manual",
+});
+
+export function normalizeScopeSource(value, fallback = SCOPE_SOURCE.AUTO) {
+  return value === SCOPE_SOURCE.MANUAL ? SCOPE_SOURCE.MANUAL : fallback;
+}
+
+export function applyScopeFilter(sql, params, repo, includeOtherRepositories, alias = "") {
+  const policy = buildScopeEligibilitySql({
+    alias: alias || "",
+    repository: repo,
+    includeOtherRepositories,
+  });
+  params.push(...policy.params);
+  return `${sql} AND (${policy.sql}) `;
+}

--- a/lib/db/db-stats.mjs
+++ b/lib/db/db-stats.mjs
@@ -1,20 +1,20 @@
 import { queryActivityStateRow, mapActivityStateRow } from "./db-activity-state.mjs";
 
-export const SEMANTIC_SCOPE_STAT_FIELDS = Object.freeze([
+const SEMANTIC_SCOPE_STAT_FIELDS = Object.freeze([
   ["semanticGlobalCount", "global_count"],
   ["semanticTransferableCount", "transferable_count"],
   ["semanticRepoCount", "repo_count"],
   ["semanticManualCount", "manual_count"],
 ]);
 
-export const EPISODE_SCOPE_STAT_FIELDS = Object.freeze([
+const EPISODE_SCOPE_STAT_FIELDS = Object.freeze([
   ["episodeGlobalCount", "global_count"],
   ["episodeTransferableCount", "transferable_count"],
   ["episodeRepoCount", "repo_count"],
   ["episodeManualCount", "manual_count"],
 ]);
 
-export const SEMANTIC_GROWTH_STAT_FIELDS = Object.freeze([
+const SEMANTIC_GROWTH_STAT_FIELDS = Object.freeze([
   ["semanticCanonicalCount", "canonical_count"],
   ["semanticReinforcedCount", "reinforced_count"],
   ["assistantGoalCount", "assistant_goal_count"],
@@ -24,7 +24,7 @@ export const SEMANTIC_GROWTH_STAT_FIELDS = Object.freeze([
   ["directiveCount", "directive_count"],
 ]);
 
-export const IMPROVEMENT_STAT_FIELDS = Object.freeze([
+const IMPROVEMENT_STAT_FIELDS = Object.freeze([
   ["improvementCount", "total_count"],
   ["improvementActiveCount", "active_count"],
   ["improvementResolvedCount", "resolved_count"],
@@ -36,28 +36,28 @@ export const IMPROVEMENT_STAT_FIELDS = Object.freeze([
   ["supersededProposalCount", "superseded_proposal_count"],
 ]);
 
-export const BACKFILL_STAT_FIELDS = Object.freeze([
+const BACKFILL_STAT_FIELDS = Object.freeze([
   ["backfillRunningCount", "running_count"],
   ["backfillCompletedCount", "completed_count"],
   ["backfillFailedCount", "failed_count"],
   ["backfillDryRunCount", "dry_run_count"],
 ]);
 
-export const DEFERRED_STAT_FIELDS = Object.freeze([
+const DEFERRED_STAT_FIELDS = Object.freeze([
   ["deferredPendingCount", "pending_count"],
   ["deferredRunningCount", "running_count"],
   ["deferredFailedCount", "failed_count"],
   ["deferredCompletedCount", "completed_count"],
 ]);
 
-export const MAINTENANCE_STAT_FIELDS = Object.freeze([
+const MAINTENANCE_STAT_FIELDS = Object.freeze([
   ["maintenanceCompletedCount", "completed_count"],
   ["maintenanceNeedsAttentionCount", "needs_attention_count"],
   ["maintenanceFailedCount", "failed_count"],
   ["maintenanceSkippedCount", "skipped_count"],
 ]);
 
-export const TRAJECTORY_STAT_FIELDS = Object.freeze([
+const TRAJECTORY_STAT_FIELDS = Object.freeze([
   ["trajectoryArtifactCount", "total_count"],
   ["trajectoryReplayFailureCount", "replay_failure_count"],
   ["trajectoryValidationMissCount", "validation_miss_count"],
@@ -65,7 +65,7 @@ export const TRAJECTORY_STAT_FIELDS = Object.freeze([
   ["trajectoryLatencyOutlierCount", "latency_outlier_count"],
 ]);
 
-export const INTENT_JOURNAL_STAT_FIELDS = Object.freeze([
+const INTENT_JOURNAL_STAT_FIELDS = Object.freeze([
   ["intentJournalCount", "total_count"],
   ["intentRoutingCount", "routing_count"],
   ["intentRolloutCount", "rollout_count"],
@@ -74,30 +74,30 @@ export const INTENT_JOURNAL_STAT_FIELDS = Object.freeze([
   ["intentSerendipityCount", "serendipity_count"],
 ]);
 
-export const RETRIEVAL_TRACE_SAMPLE_STAT_FIELDS = Object.freeze([
+const RETRIEVAL_TRACE_SAMPLE_STAT_FIELDS = Object.freeze([
   ["retrievalTraceSampleCount", "total_count"],
   ["retrievalTraceSampleGlobalCount", "global_count"],
   ["retrievalTraceSampleRepositoryCount", "repository_count"],
 ]);
 
-export function readTableCount(db, tableName) {
+function readTableCount(db, tableName) {
   return db.prepare(`SELECT COUNT(*) AS count FROM ${tableName}`).get().count;
 }
 
-export function mapStatFields(row, mappings) {
+function mapStatFields(row, mappings) {
   return Object.fromEntries(
     mappings.map(([outputKey, rowKey]) => [outputKey, row?.[rowKey] ?? 0]),
   );
 }
 
-export function serializeLastSuccessActivity(row) {
+function serializeLastSuccessActivity(row) {
   if (!row) {
     return null;
   }
   return mapActivityStateRow(row);
 }
 
-export function buildLoreStatsPayload({
+function buildLoreStatsPayload({
   config,
   lastBackupPath,
   semanticCount,
@@ -150,7 +150,7 @@ export function buildLoreStatsPayload({
   };
 }
 
-export function querySemanticMemoryStats(db) {
+function querySemanticMemoryStats(db) {
   const semanticCount = readTableCount(db, "semantic_memory");
   const semanticGrowth = db.prepare(`
     SELECT
@@ -175,7 +175,7 @@ export function querySemanticMemoryStats(db) {
   return { semanticCount, semanticGrowth, semanticScopes };
 }
 
-export function queryEpisodeDigestStats(db) {
+function queryEpisodeDigestStats(db) {
   const episodeCount = readTableCount(db, "episode_digest");
   const episodeScopes = db.prepare(`
     SELECT
@@ -189,7 +189,7 @@ export function queryEpisodeDigestStats(db) {
   return { episodeCount, episodeScopes, daySummaryCount };
 }
 
-export function queryExtractionJobStats(db) {
+function queryExtractionJobStats(db) {
   const deferredCounts = db.prepare(`
     SELECT
       SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pending_count,
@@ -209,7 +209,7 @@ export function queryExtractionJobStats(db) {
   return { deferredCounts, backfillCounts };
 }
 
-export function queryMaintenanceRunStats(db) {
+function queryMaintenanceRunStats(db) {
   const maintenanceCounts = db.prepare(`
     SELECT
       SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count,
@@ -233,7 +233,7 @@ export function queryMaintenanceRunStats(db) {
   return { maintenanceCounts, maintenanceLatest, maintenanceTaskCount };
 }
 
-export function queryImprovementBacklogStats(db) {
+function queryImprovementBacklogStats(db) {
   return db.prepare(`
     SELECT
       COUNT(*) AS total_count,
@@ -249,7 +249,7 @@ export function queryImprovementBacklogStats(db) {
   `).get();
 }
 
-export function querySignalStats(db) {
+function querySignalStats(db) {
   const trajectoryCounts = db.prepare(`
     SELECT
       COUNT(*) AS total_count,

--- a/lib/db/db-stats.mjs
+++ b/lib/db/db-stats.mjs
@@ -1,0 +1,320 @@
+import { queryActivityStateRow, mapActivityStateRow } from "./db-activity-state.mjs";
+
+export const SEMANTIC_SCOPE_STAT_FIELDS = Object.freeze([
+  ["semanticGlobalCount", "global_count"],
+  ["semanticTransferableCount", "transferable_count"],
+  ["semanticRepoCount", "repo_count"],
+  ["semanticManualCount", "manual_count"],
+]);
+
+export const EPISODE_SCOPE_STAT_FIELDS = Object.freeze([
+  ["episodeGlobalCount", "global_count"],
+  ["episodeTransferableCount", "transferable_count"],
+  ["episodeRepoCount", "repo_count"],
+  ["episodeManualCount", "manual_count"],
+]);
+
+export const SEMANTIC_GROWTH_STAT_FIELDS = Object.freeze([
+  ["semanticCanonicalCount", "canonical_count"],
+  ["semanticReinforcedCount", "reinforced_count"],
+  ["assistantGoalCount", "assistant_goal_count"],
+  ["recurringMistakeCount", "recurring_mistake_count"],
+  ["userIdentityCount", "user_identity_count"],
+  ["workstreamOverlayCount", "workstream_overlay_count"],
+  ["directiveCount", "directive_count"],
+]);
+
+export const IMPROVEMENT_STAT_FIELDS = Object.freeze([
+  ["improvementCount", "total_count"],
+  ["improvementActiveCount", "active_count"],
+  ["improvementResolvedCount", "resolved_count"],
+  ["improvementSupersededCount", "superseded_count"],
+  ["improvementProposalCount", "proposal_count"],
+  ["draftProposalCount", "draft_proposal_count"],
+  ["approvedProposalCount", "approved_proposal_count"],
+  ["rejectedProposalCount", "rejected_proposal_count"],
+  ["supersededProposalCount", "superseded_proposal_count"],
+]);
+
+export const BACKFILL_STAT_FIELDS = Object.freeze([
+  ["backfillRunningCount", "running_count"],
+  ["backfillCompletedCount", "completed_count"],
+  ["backfillFailedCount", "failed_count"],
+  ["backfillDryRunCount", "dry_run_count"],
+]);
+
+export const DEFERRED_STAT_FIELDS = Object.freeze([
+  ["deferredPendingCount", "pending_count"],
+  ["deferredRunningCount", "running_count"],
+  ["deferredFailedCount", "failed_count"],
+  ["deferredCompletedCount", "completed_count"],
+]);
+
+export const MAINTENANCE_STAT_FIELDS = Object.freeze([
+  ["maintenanceCompletedCount", "completed_count"],
+  ["maintenanceNeedsAttentionCount", "needs_attention_count"],
+  ["maintenanceFailedCount", "failed_count"],
+  ["maintenanceSkippedCount", "skipped_count"],
+]);
+
+export const TRAJECTORY_STAT_FIELDS = Object.freeze([
+  ["trajectoryArtifactCount", "total_count"],
+  ["trajectoryReplayFailureCount", "replay_failure_count"],
+  ["trajectoryValidationMissCount", "validation_miss_count"],
+  ["trajectoryProposalFailureCount", "proposal_failure_count"],
+  ["trajectoryLatencyOutlierCount", "latency_outlier_count"],
+]);
+
+export const INTENT_JOURNAL_STAT_FIELDS = Object.freeze([
+  ["intentJournalCount", "total_count"],
+  ["intentRoutingCount", "routing_count"],
+  ["intentRolloutCount", "rollout_count"],
+  ["intentReviewerCount", "reviewer_count"],
+  ["intentFallbackCount", "fallback_count"],
+  ["intentSerendipityCount", "serendipity_count"],
+]);
+
+export const RETRIEVAL_TRACE_SAMPLE_STAT_FIELDS = Object.freeze([
+  ["retrievalTraceSampleCount", "total_count"],
+  ["retrievalTraceSampleGlobalCount", "global_count"],
+  ["retrievalTraceSampleRepositoryCount", "repository_count"],
+]);
+
+export function readTableCount(db, tableName) {
+  return db.prepare(`SELECT COUNT(*) AS count FROM ${tableName}`).get().count;
+}
+
+export function mapStatFields(row, mappings) {
+  return Object.fromEntries(
+    mappings.map(([outputKey, rowKey]) => [outputKey, row?.[rowKey] ?? 0]),
+  );
+}
+
+export function serializeLastSuccessActivity(row) {
+  if (!row) {
+    return null;
+  }
+  return mapActivityStateRow(row);
+}
+
+export function buildLoreStatsPayload({
+  config,
+  lastBackupPath,
+  semanticCount,
+  episodeCount,
+  domainCount,
+  observationCount,
+  semanticScopes,
+  episodeScopes,
+  daySummaryCount,
+  schemaVersion,
+  overrideAuditCount,
+  semanticGrowth,
+  improvementCounts,
+  backfillCounts,
+  deferredCounts,
+  maintenanceCounts,
+  maintenanceLatest,
+  maintenanceTaskCount,
+  trajectoryCounts,
+  intentJournalCounts,
+  retrievalTraceSampleCounts,
+  latestActivity,
+}) {
+  return {
+    semanticCount,
+    episodeCount,
+    domainCount,
+    observationCount,
+    ...mapStatFields(semanticScopes, SEMANTIC_SCOPE_STAT_FIELDS),
+    ...mapStatFields(episodeScopes, EPISODE_SCOPE_STAT_FIELDS),
+    daySummaryCount,
+    schemaVersion,
+    dbPath: config.paths.derivedStorePath,
+    backupDir: config.paths.backupDir,
+    lastBackupPath,
+    overrideAuditCount,
+    ...mapStatFields(semanticGrowth, SEMANTIC_GROWTH_STAT_FIELDS),
+    ...mapStatFields(improvementCounts, IMPROVEMENT_STAT_FIELDS),
+    ...mapStatFields(backfillCounts, BACKFILL_STAT_FIELDS),
+    ...mapStatFields(deferredCounts, DEFERRED_STAT_FIELDS),
+    ...mapStatFields(maintenanceCounts, MAINTENANCE_STAT_FIELDS),
+    maintenanceTaskStateCount: maintenanceTaskCount,
+    lastMaintenanceStatus: maintenanceLatest?.status ?? null,
+    lastMaintenanceStartedAt: maintenanceLatest?.started_at ?? null,
+    lastMaintenanceCompletedAt: maintenanceLatest?.completed_at ?? null,
+    ...mapStatFields(trajectoryCounts, TRAJECTORY_STAT_FIELDS),
+    ...mapStatFields(intentJournalCounts, INTENT_JOURNAL_STAT_FIELDS),
+    ...mapStatFields(retrievalTraceSampleCounts, RETRIEVAL_TRACE_SAMPLE_STAT_FIELDS),
+    lastSuccessActivity: serializeLastSuccessActivity(latestActivity),
+  };
+}
+
+export function querySemanticMemoryStats(db) {
+  const semanticCount = readTableCount(db, "semantic_memory");
+  const semanticGrowth = db.prepare(`
+    SELECT
+      SUM(CASE WHEN canonical_key IS NOT NULL THEN 1 ELSE 0 END) AS canonical_count,
+      SUM(CASE WHEN reinforcement_count > 1 THEN 1 ELSE 0 END) AS reinforced_count,
+      SUM(CASE WHEN type = 'assistant_goal' THEN 1 ELSE 0 END) AS assistant_goal_count,
+      SUM(CASE WHEN type = 'recurring_mistake' THEN 1 ELSE 0 END) AS recurring_mistake_count,
+      SUM(CASE WHEN type = 'user_identity' THEN 1 ELSE 0 END) AS user_identity_count,
+      SUM(CASE WHEN type = 'workstream_overlay' THEN 1 ELSE 0 END) AS workstream_overlay_count,
+      SUM(CASE WHEN type = 'directive' THEN 1 ELSE 0 END) AS directive_count
+    FROM semantic_memory
+    WHERE superseded_by IS NULL
+  `).get();
+  const semanticScopes = db.prepare(`
+    SELECT
+      SUM(CASE WHEN scope = 'global' THEN 1 ELSE 0 END) AS global_count,
+      SUM(CASE WHEN scope = 'transferable' THEN 1 ELSE 0 END) AS transferable_count,
+      SUM(CASE WHEN scope = 'repo' THEN 1 ELSE 0 END) AS repo_count,
+      SUM(CASE WHEN scope_source = 'manual' THEN 1 ELSE 0 END) AS manual_count
+    FROM semantic_memory
+  `).get();
+  return { semanticCount, semanticGrowth, semanticScopes };
+}
+
+export function queryEpisodeDigestStats(db) {
+  const episodeCount = readTableCount(db, "episode_digest");
+  const episodeScopes = db.prepare(`
+    SELECT
+      SUM(CASE WHEN scope = 'global' THEN 1 ELSE 0 END) AS global_count,
+      SUM(CASE WHEN scope = 'transferable' THEN 1 ELSE 0 END) AS transferable_count,
+      SUM(CASE WHEN scope = 'repo' THEN 1 ELSE 0 END) AS repo_count,
+      SUM(CASE WHEN scope_source = 'manual' THEN 1 ELSE 0 END) AS manual_count
+    FROM episode_digest
+  `).get();
+  const daySummaryCount = db.prepare(`SELECT COUNT(*) AS count FROM day_summary`).get().count;
+  return { episodeCount, episodeScopes, daySummaryCount };
+}
+
+export function queryExtractionJobStats(db) {
+  const deferredCounts = db.prepare(`
+    SELECT
+      SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pending_count,
+      SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running_count,
+      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
+      SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count
+    FROM deferred_extraction
+  `).get();
+  const backfillCounts = db.prepare(`
+    SELECT
+      SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running_count,
+      SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count,
+      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
+      SUM(CASE WHEN dry_run = 1 THEN 1 ELSE 0 END) AS dry_run_count
+    FROM backfill_run
+    `).get();
+  return { deferredCounts, backfillCounts };
+}
+
+export function queryMaintenanceRunStats(db) {
+  const maintenanceCounts = db.prepare(`
+    SELECT
+      SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count,
+      SUM(CASE WHEN status = 'needs_attention' THEN 1 ELSE 0 END) AS needs_attention_count,
+      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
+      SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END) AS skipped_count
+    FROM maintenance_run
+    WHERE dry_run = 0
+  `).get();
+  const maintenanceLatest = db.prepare(`
+    SELECT status, started_at, completed_at
+    FROM maintenance_run
+    WHERE dry_run = 0
+    ORDER BY updated_at DESC
+    LIMIT 1
+  `).get();
+  const maintenanceTaskCount = db.prepare(`
+    SELECT COUNT(*) AS count
+    FROM maintenance_task_state
+  `).get().count;
+  return { maintenanceCounts, maintenanceLatest, maintenanceTaskCount };
+}
+
+export function queryImprovementBacklogStats(db) {
+  return db.prepare(`
+    SELECT
+      COUNT(*) AS total_count,
+      SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS active_count,
+      SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) AS resolved_count,
+      SUM(CASE WHEN status = 'superseded' THEN 1 ELSE 0 END) AS superseded_count,
+      SUM(CASE WHEN proposal_path IS NOT NULL THEN 1 ELSE 0 END) AS proposal_count,
+      SUM(CASE WHEN review_state = 'draft' THEN 1 ELSE 0 END) AS draft_proposal_count,
+      SUM(CASE WHEN review_state = 'approved' THEN 1 ELSE 0 END) AS approved_proposal_count,
+      SUM(CASE WHEN review_state = 'rejected' THEN 1 ELSE 0 END) AS rejected_proposal_count,
+      SUM(CASE WHEN review_state = 'superseded' THEN 1 ELSE 0 END) AS superseded_proposal_count
+    FROM improvement_backlog
+  `).get();
+}
+
+export function querySignalStats(db) {
+  const trajectoryCounts = db.prepare(`
+    SELECT
+      COUNT(*) AS total_count,
+      SUM(CASE WHEN kind = 'replay_failure' THEN 1 ELSE 0 END) AS replay_failure_count,
+      SUM(CASE WHEN kind = 'validation_miss' THEN 1 ELSE 0 END) AS validation_miss_count,
+      SUM(CASE WHEN kind = 'proposal_failure' THEN 1 ELSE 0 END) AS proposal_failure_count,
+      SUM(CASE WHEN kind = 'latency_outlier' THEN 1 ELSE 0 END) AS latency_outlier_count
+    FROM trajectory_artifact
+  `).get();
+  const intentJournalCounts = db.prepare(`
+    SELECT
+      COUNT(*) AS total_count,
+      SUM(CASE WHEN intent_kind = 'routing' THEN 1 ELSE 0 END) AS routing_count,
+      SUM(CASE WHEN intent_kind = 'rollout' THEN 1 ELSE 0 END) AS rollout_count,
+      SUM(CASE WHEN intent_kind = 'reviewer' THEN 1 ELSE 0 END) AS reviewer_count,
+      SUM(CASE WHEN intent_kind = 'fallback' THEN 1 ELSE 0 END) AS fallback_count,
+      SUM(CASE WHEN intent_kind = 'serendipity' THEN 1 ELSE 0 END) AS serendipity_count
+    FROM intent_journal
+  `).get();
+  const retrievalTraceSampleCounts = db.prepare(`
+    SELECT
+      COUNT(*) AS total_count,
+      SUM(CASE WHEN repository IS NULL OR repository = '' THEN 1 ELSE 0 END) AS global_count,
+      SUM(CASE WHEN repository IS NOT NULL AND repository != '' THEN 1 ELSE 0 END) AS repository_count
+    FROM retrieval_trace_sample
+  `).get();
+  return { trajectoryCounts, intentJournalCounts, retrievalTraceSampleCounts };
+}
+
+export function getStats(owner) {
+  owner.ensureOpen();
+  const { semanticCount, semanticGrowth, semanticScopes } = querySemanticMemoryStats(owner.db);
+  const { episodeCount, episodeScopes, daySummaryCount } = queryEpisodeDigestStats(owner.db);
+  const domainCount = readTableCount(owner.db, "memory_domain");
+  const observationCount = readTableCount(owner.db, "refreshable_observation");
+  const { deferredCounts, backfillCounts } = queryExtractionJobStats(owner.db);
+  const schemaVersion = owner.getCurrentVersion();
+  const overrideAuditCount = readTableCount(owner.db, "scope_override_audit");
+  const improvementCounts = queryImprovementBacklogStats(owner.db);
+  const { maintenanceCounts, maintenanceLatest, maintenanceTaskCount } = queryMaintenanceRunStats(owner.db);
+  const { trajectoryCounts, intentJournalCounts, retrievalTraceSampleCounts } = querySignalStats(owner.db);
+  const latestActivity = queryActivityStateRow(owner.db, "global");
+
+  return buildLoreStatsPayload({
+    config: owner.config,
+    lastBackupPath: owner.lastBackupPath,
+    semanticCount,
+    episodeCount,
+    domainCount,
+    observationCount,
+    semanticScopes,
+    episodeScopes,
+    daySummaryCount,
+    schemaVersion,
+    overrideAuditCount,
+    semanticGrowth,
+    improvementCounts,
+    backfillCounts,
+    deferredCounts,
+    maintenanceCounts,
+    maintenanceLatest,
+    maintenanceTaskCount,
+    trajectoryCounts,
+    intentJournalCounts,
+    retrievalTraceSampleCounts,
+    latestActivity,
+  });
+}

--- a/lib/db/db-trace-samples.mjs
+++ b/lib/db/db-trace-samples.mjs
@@ -36,7 +36,7 @@ function normalizeTraceJsonFields({ promptNeed, eligibility, lookups, omissions,
 
 // --- Retrieval trace sample operations (called by class methods) ---
 
-export function buildRetrievalTraceSampleRecordImpl(instance, {
+function buildRetrievalTraceSampleRecordImpl(instance, {
   id = null,
   repository = null,
   scopeType = "repo",
@@ -70,7 +70,7 @@ export function buildRetrievalTraceSampleRecordImpl(instance, {
   };
 }
 
-export function pruneRetrievalTraceSamplesImpl(db, {
+function pruneRetrievalTraceSamplesImpl(db, {
   repository = null,
   maxRowsPerRepository = 120,
   maxRowsGlobal = 240,
@@ -131,7 +131,7 @@ export function pruneRetrievalTraceSamplesImpl(db, {
   return { removed };
 }
 
-export function listRetrievalTraceSamplesImpl(db, {
+function listRetrievalTraceSamplesImpl(db, {
   repository,
   includeGlobal = true,
   limit = 10,

--- a/lib/db/db-trace-samples.mjs
+++ b/lib/db/db-trace-samples.mjs
@@ -196,3 +196,137 @@ export function listRetrievalTraceSamplesImpl(db, {
     recordedAt: row.recorded_at,
   }));
 }
+
+export function normalizeRetrievalTraceHook(owner, hook) {
+  return String(hook || "").trim();
+}
+
+export function normalizeRetrievalTraceScopeType(owner, scopeType) {
+  return scopeType === "global" ? "global" : "repo";
+}
+
+export function normalizeRetrievalTraceSectionTitles(owner, sectionTitles) {
+  if (!Array.isArray(sectionTitles)) {
+    return [];
+  }
+  return sectionTitles
+    .slice(0, 8)
+    .map((title) => (title == null ? "" : String(title)));
+}
+
+export function buildRetrievalTraceSampleRecord(owner, {
+  id = null,
+  repository = null,
+  scopeType = "repo",
+  hook,
+  route = null,
+  routeReason = null,
+  contextInjected = false,
+  latencyMs = null,
+  promptPreview = "",
+  sectionTitles = [],
+  promptNeed = {},
+  eligibility = {},
+  lookups = {},
+  omissions = [],
+  output = {},
+  trace = {},
+  recordedAt = nowIso(),
+}) {
+  return buildRetrievalTraceSampleRecordImpl(owner, {
+    id,
+    repository,
+    scopeType,
+    hook,
+    route,
+    routeReason,
+    contextInjected,
+    latencyMs,
+    promptPreview,
+    sectionTitles,
+    promptNeed,
+    eligibility,
+    lookups,
+    omissions,
+    output,
+    trace,
+    recordedAt,
+  });
+}
+
+export function writeRetrievalTraceSample(owner, record) {
+  owner.db.prepare(`
+    INSERT INTO retrieval_trace_sample (
+      id,
+      repository,
+      scope_type,
+      hook,
+      route,
+      route_reason,
+      context_injected,
+      latency_ms,
+      prompt_preview,
+      section_titles_json,
+      prompt_need_json,
+      eligibility_json,
+      lookups_json,
+      omissions_json,
+      output_json,
+      trace_json,
+      recorded_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    record.id,
+    record.repository,
+    record.scopeType,
+    record.hook,
+    record.route,
+    record.routeReason,
+    record.contextInjected,
+    record.latencyMs,
+    record.promptPreview,
+    JSON.stringify(record.sectionTitles),
+    record.promptNeed,
+    record.eligibility,
+    record.lookups,
+    record.omissions,
+    record.output,
+    record.trace,
+    record.recordedAt,
+  );
+}
+
+export function insertRetrievalTraceSample(owner, sample = {}) {
+  owner.ensureOpen();
+  const record = owner.buildRetrievalTraceSampleRecord(sample);
+  owner.writeRetrievalTraceSample(record);
+  return record.id;
+}
+
+export function pruneRetrievalTraceSamples(owner, {
+  repository = null,
+  maxRowsPerRepository = 120,
+  maxRowsGlobal = 240,
+  maxAgeMs = 14 * 24 * 60 * 60 * 1000,
+} = {}) {
+  owner.ensureOpen();
+  return pruneRetrievalTraceSamplesImpl(owner.db, {
+    repository,
+    maxRowsPerRepository,
+    maxRowsGlobal,
+    maxAgeMs,
+  });
+}
+
+export function listRetrievalTraceSamples(owner, {
+  repository,
+  includeGlobal = true,
+  limit = 10,
+} = {}) {
+  owner.ensureOpen();
+  return listRetrievalTraceSamplesImpl(owner.db, {
+    repository,
+    includeGlobal,
+    limit,
+  });
+}

--- a/lib/db/db-trace-serializers.mjs
+++ b/lib/db/db-trace-serializers.mjs
@@ -1,0 +1,30 @@
+import { MEMORY_SCOPE } from "../memory/memory-scope.mjs";
+import { parseJsonArray } from "../utils/json-array-utils.mjs";
+import { normalizeText } from "../utils/text-normalizer.mjs";
+import { isCrossRepoRow } from "./db-temporal.mjs";
+
+export function serializeEpisodeTraceRow(episode, currentRepository = null) {
+  return {
+    id: episode.id ?? null,
+    sessionId: episode.session_id ?? null,
+    scope: episode.scope ?? null,
+    scopeSource: episode.scope_source ?? null,
+    repository: episode.repository ?? null,
+    updatedAt: episode.updated_at ?? null,
+    dateKey: episode.date_key ?? null,
+    significance: episode.significance ?? 0,
+    crossRepo: isCrossRepoRow(episode, currentRepository),
+    summary: normalizeText(episode.summary),
+    decisions: parseJsonArray(episode.decisions_json).map(normalizeText).filter(Boolean).slice(0, 6),
+    actions: parseJsonArray(episode.actions_json).map(normalizeText).filter(Boolean).slice(0, 6),
+    openItems: parseJsonArray(episode.open_items_json).map(normalizeText).filter(Boolean).slice(0, 6),
+    themes: parseJsonArray(episode.themes_json).map(normalizeText).filter(Boolean).slice(0, 6),
+  };
+}
+
+export function buildLocalEligibility(repository) {
+  if (repository) {
+    return [MEMORY_SCOPE.GLOBAL, `${MEMORY_SCOPE.REPO}:${repository}`];
+  }
+  return [MEMORY_SCOPE.GLOBAL];
+}

--- a/lib/db/db.mjs
+++ b/lib/db/db.mjs
@@ -1,31 +1,14 @@
-import { promptSearchQuery, extractMeaningfulPromptTerms, expandPromptSearchTerms, scorePromptFallbackRows } from "../context/prompt-search-query.mjs";
 import crypto from "node:crypto";
 import { chmodSync, existsSync, lstatSync, mkdirSync, rmSync, renameSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
-
-import { detectPromptContextNeed } from "../context/prompt-need.mjs";
-import { formatSemanticContextLine, renderPromptContext } from "../context/prompt-context-render.mjs";
-import {
-  buildSemanticCanonicalKey,
-  classifyEpisodeDigest,
-  classifySemanticMemory,
-  detectAssistantIdentityName,
-  MEMORY_SCOPE,
-  normalizeScope,
-} from "../memory/memory-scope.mjs";
-import { buildMemoryDomain } from "../memory/memory-domains.mjs";
-import { buildRefreshableObservation } from "../sessions/observations.mjs";
 import { SCHEMA_VERSION } from "./schema.mjs";
 import {
-  findActiveSuppression as findLifecycleSuppression,
   forgetMemory as forgetLifecycleMemory,
   getIngestionCheckpoint as getLifecycleCheckpoint,
   getRepositoryMappings as getLifecycleRepositoryMappings,
-  isExplicitLifecycleWrite,
   listCaptureHealth as listLifecycleCaptureHealth,
   listSemanticEvidence as listLifecycleSemanticEvidence,
-  normalizeEvidence,
   reconcileGeneratedMemories as reconcileLifecycleMemories,
   saveIngestionCheckpoint as saveLifecycleCheckpoint,
   setRepositoryMapping as setLifecycleRepositoryMapping,
@@ -34,917 +17,174 @@ import {
 import { resolveLorePaths } from "../core/lore-paths.mjs";
 import { MigrationRunner } from "./db-migration-runner.mjs";
 import { readCurrentSuppressions, prepareSnapshotStage } from "./db-snapshot-lifecycle.mjs";
+import { registerRetrievalPolicyFunctions } from "./db-retrieval-policy.mjs";
+import { nowIso } from "./db-shared.mjs";
+import { getStats } from "./db-stats.mjs";
 import {
-  buildStyleAddressingSection,
-  isStyleAddressingMemory,
-} from "../context/style-addressing.mjs";
-import { readTemporalQueryNormalizationEnabled } from "../rollout/rollout-flags.mjs";
-import { parseJsonArray } from "../utils/json-array-utils.mjs";
-import { parseJsonObject } from "../utils/json-object-utils.mjs";
-import { jsonText } from "../utils/json-text-utils.mjs";
-import { clampInteger } from "../utils/numeric-utils.mjs";
-import { normalizeRepository } from "../utils/repository-utils.mjs";
-import { addStringFilter } from "../utils/sql-filter-utils.mjs";
-import { validateRequiredStringField } from "../utils/required-field-utils.mjs";
+  insertIntentJournalEntry,
+  listIntentJournalEntries,
+  insertTrajectoryArtifact,
+  listTrajectoryArtifacts,
+} from "./db-intent-trajectory.mjs";
 import {
-  buildFtsOrRetryQuery,
-  extractFtsTerms as extractNormalizedFtsTerms,
-  extractDirectTerms as extractNormalizedDirectTerms,
-  extractTemporalContentTerms as extractNormalizedTemporalContentTerms,
-  inferDateFromPrompt as inferNormalizedDateFromPrompt,
-  normalizeFtsToken,
-  QUERY_ALIASES,
-  sanitizeFtsQuery as sanitizeNormalizedFtsQuery,
-  tokenizeText,
-} from "../utils/query-normalizer.mjs";
-import { normalizeText } from "../utils/text-normalizer.mjs";
+  upsertActivitySuccess,
+  collectDirectActivityRows,
+  collectFallbackActivityRows,
+  getActivityState,
+  deriveActivityStateFallback,
+  buildActivityFallbackScope,
+  readActivityFallbackRows,
+  serializeActivityStateFallback,
+  serializeActivityFallbackContext,
+  serializeActivityFallbackExtraction,
+  serializeActivityFallbackMaintenance,
+  serializeActivityFallbackTrace,
+  resolveActivityFallbackUpdatedAt,
+  readLatestContextFallbackRow,
+  readLatestTraceFallbackRow,
+  readLatestMaintenanceFallbackRow,
+  readLatestExtractionFallbackRow,
+  collectActivityFallbackTimestamps,
+  buildActivityStateFallbackRow,
+} from "./db-activity-state.mjs";
 import {
-  isCrossRepoRow,
-  serializeSessionTraceRow,
-  setPromptTemporalVerifierTraceState,
-} from "./db-temporal.mjs";
+  normalizeRetrievalTraceHook,
+  normalizeRetrievalTraceScopeType,
+  normalizeRetrievalTraceSectionTitles,
+  buildRetrievalTraceSampleRecord,
+  writeRetrievalTraceSample,
+  insertRetrievalTraceSample,
+  pruneRetrievalTraceSamples,
+  listRetrievalTraceSamples,
+} from "./db-trace-samples.mjs";
+import { insertErrorTelemetry, pruneErrorTelemetry } from "./db-error-telemetry.mjs";
 import {
-  buildEpisodeQueryTermsets,
-  buildTermWeights,
-  explainEpisodeExclusionReason,
-  isGenericWorkSummary,
-  isPlaceholderSummary,
-  isToolInvocationSummary,
-  scoreAndRankEpisodeCandidates,
-} from "./db-episode-scoring.mjs";
+  getSemanticMemoryByIds,
+  getEpisodeDigestsByIds,
+  previewScopeChanges,
+  insertScopeOverrideAudit,
+  applyScopeChanges,
+  listScopeOverrideAudit,
+} from "./db-scope-management.mjs";
 import {
-  buildImprovementArtifactEpisode,
-  buildImprovementArtifactFilters,
-  buildBackfillRunSummaryUpdateImpl,
-  normalizeImprovementStatus,
-  setImprovementArtifactProposalImpl,
-  upsertImprovementArtifactImpl,
-  IMPROVEMENT_SOURCE_KIND,
-  IMPROVEMENT_STATUS,
-  IMPROVEMENT_REVIEW_STATE,
+  upsertImprovementArtifact,
+  updateImprovementArtifactStatus,
+  getImprovementArtifact,
+  setImprovementArtifactProposal,
+  listImprovementArtifacts,
 } from "./db-improvement-artifacts.mjs";
 import {
-  buildRetrievalTraceSampleRecordImpl,
-  listRetrievalTraceSamplesImpl,
-  pruneRetrievalTraceSamplesImpl,
-} from "./db-trace-samples.mjs";
-import { buildSemanticEligibilitySql, buildScopeEligibilitySql, isSemanticMemoryRowEligible, registerRetrievalPolicyFunctions } from "./db-retrieval-policy.mjs";
-
-const SCOPE_SOURCE = Object.freeze({
-  AUTO: "auto",
-  MANUAL: "manual",
-});
+  countGeneratedSemanticMemoriesBySession,
+  getEpisodeDigestBySession,
+  createBackfillRun,
+  insertBackfillRunItems,
+  getBackfillRun,
+  listBackfillRunItems,
+  updateBackfillRunItem,
+  getBackfillRunCounts,
+  deriveBackfillRunStatus,
+  deriveBackfillRunLastError,
+  buildBackfillRunSummaryUpdate,
+  writeBackfillRunSummary,
+  refreshBackfillRunSummary,
+  listBackfillRuns,
+} from "./db-backfill-runs.mjs";
+import {
+  createMaintenanceRun,
+  reclaimStaleMaintenanceRuns,
+  completeMaintenanceRun,
+  listMaintenanceRuns,
+  listMaintenanceTaskStates,
+  recordMaintenanceTaskStart,
+  recordMaintenanceTaskResult,
+} from "./db-maintenance-runs.mjs";
+import {
+  buildSemanticMemoryWriteContext,
+  findActiveSuppression,
+  isMemorySuppressed,
+  listActiveMemorySuppressions,
+  findManualSemanticMemoryMatch,
+  findScopedSemanticMemoryMatch,
+  buildSemanticMemoryMetadata,
+  updateManualSemanticMemoryMatch,
+  updateProtectedSemanticMemoryMatch,
+  updateScopedSemanticMemoryMatch,
+  insertNewSemanticMemory,
+  upsertManualSemanticMemory,
+  upsertScopedSemanticMemory,
+  insertSemanticMemory,
+  withSemanticMemoryTransaction,
+  verifySemanticMemoryDurability,
+} from "./db-semantic-memory-write.mjs";
+import {
+  upsertMemoryDomain,
+  getMemoryDomain,
+  listMemoryDomains,
+  upsertObservation,
+  getObservation,
+  listObservations,
+  deleteGeneratedSemanticMemories,
+} from "./db-memory-domain-observation.mjs";
+import {
+  enqueueDeferredExtraction,
+  listDeferredExtractions,
+  markDeferredExtractionRunning,
+  claimDeferredExtraction,
+  heartbeatDeferredExtraction,
+  reclaimStaleDeferredExtractions,
+  completeDeferredExtraction,
+  failDeferredExtraction,
+} from "./db-deferred-extraction.mjs";
+import {
+  listActiveStabilisationMemories,
+  listMemoryHygieneEpisodes,
+  restoreMemoriesBySupersessionMarker,
+} from "./db-memory-hygiene.mjs";
+import {
+  hasEpisodeDigest,
+  upsertEpisodeDigest,
+  refreshDaySummary,
+  mapRetrievalRepositories,
+  searchSemantic,
+  searchEpisodes,
+  findRelevantEpisodesDetailed,
+  findRelevantEpisodes,
+  getDaySummary,
+  getDaySummaries,
+  findRelevantEpisodesByDateDetailed,
+} from "./db-episode-search.mjs";
+import {
+  ensureMemoryEmbeddingTable,
+  listSemanticMemoriesForEmbedding,
+  countSemanticMemoriesForEmbedding,
+  getMemoryEmbedding,
+  setMemoryEmbedding,
+} from "./db-embedding.mjs";
+import {
+  searchPromptSemanticRows,
+  searchPromptSemanticFallback,
+  buildPromptSemanticContext,
+  buildEffectivePromptStyleSection,
+  filterPromptDaySummaries,
+  buildIdentityOnlyEpisodeDetails,
+  buildPromptEpisodeContext,
+  buildPromptTemporalContext,
+  buildPromptCrossRepoContext,
+  determinePromptDaySummaryReason,
+  buildPromptTemporalVerifier,
+  buildPromptContextFlags,
+  buildLexicalPrompt,
+  resolvePromptRenderTerms,
+  buildExplainComputedState,
+  collectPromptContext,
+  explainPromptContext,
+  buildPromptContext,
+} from "./db-prompt-context.mjs";
 
 const PRIMARY_SCHEMA_VERSION_TABLE = "lore_schema_version";
 
-function nowIso() {
-  return new Date().toISOString();
-}
-
-const MS_PER_HOUR = 60 * 60 * 1000;
-const VOLATILE_TTL_MS = Object.freeze({
-  assistant_goal: 24 * MS_PER_HOUR,
-  open_loop: 7 * 24 * MS_PER_HOUR,
-  blocker: 7 * 24 * MS_PER_HOUR,
-});
-
-function defaultVolatileExpiry(type, timestamp) {
-  const ttlMs = VOLATILE_TTL_MS[type];
-  if (!ttlMs) {
-    return null;
-  }
-  const start = Date.parse(timestamp);
-  if (!Number.isFinite(start)) {
-    return null;
-  }
-  return new Date(start + ttlMs).toISOString();
-}
-
 function escapeSqlString(value) {
   return String(value || "").replace(/'/g, "''");
-}
-
-function buildDefaultPromptNeed(prompt, includeOtherRepositories = false) {
-  const detected = detectPromptContextNeed(prompt);
-  return {
-    ...detected,
-    allowCrossRepoFallback: detected.allowCrossRepoFallback || includeOtherRepositories,
-  };
-}
-
-function resolveTimestamp(value, fallback) {
-  return typeof value === "string" && value.length > 0 ? value : fallback;
-}
-
-function withCurrentRepository(rows, repository) {
-  return rows.map((row) => ({
-    ...row,
-    currentRepository: repository,
-  }));
-}
-
-function extractTemporalContentTerms(query, config = null) {
-  if (!readTemporalQueryNormalizationEnabled(config)) {
-    return extractNormalizedDirectTerms(query);
-  }
-  return extractNormalizedTemporalContentTerms(query);
-}
-
-function ensureArray(value) {
-  return Array.isArray(value) ? value : [];
-}
-
-const ACTIVITY_SUCCESS_VALUE_FIELDS = Object.freeze([
-  ["lastContextInjectionAt", "last_context_injection_at"],
-  ["lastContextInjectionHook", "last_context_injection_hook"],
-  ["lastContextInjectionTraceId", "last_context_injection_trace_id"],
-  ["lastExtractionCompletionAt", "last_extraction_completion_at"],
-  ["lastMaintenanceCompletionAt", "last_maintenance_completion_at"],
-  ["lastMaintenanceStatus", "last_maintenance_status"],
-  ["lastMaintenanceRunId", "last_maintenance_run_id"],
-  ["lastTraceRecordedAt", "last_trace_recorded_at"],
-  ["lastTraceHook", "last_trace_hook"],
-  ["lastTraceId", "last_trace_id"],
-]);
-
-function mergeActivitySuccessValues(updates, existing) {
-  return Object.fromEntries(
-    ACTIVITY_SUCCESS_VALUE_FIELDS.map(([updateKey, existingKey]) => [
-      updateKey,
-      updates[updateKey] ?? existing?.[existingKey] ?? null,
-    ]),
-  );
-}
-
-function mergeActivitySuccessSections(updates, existing) {
-  return Array.isArray(updates.lastContextInjectionSections)
-    ? updates.lastContextInjectionSections.slice(0, 8)
-    : parseJsonArray(existing?.last_context_injection_sections_json);
-}
-
-function mergeActivitySuccessDuration(updates, existing) {
-  return Number.isFinite(updates.lastContextInjectionDurationMs)
-    ? Math.round(updates.lastContextInjectionDurationMs)
-    : (existing?.last_context_injection_duration_ms ?? null);
-}
-
-function mergeActivitySuccessExtractionRepository(updates, existing, repo) {
-  return normalizeRepository(updates.lastExtractionRepository)
-    ?? existing?.last_extraction_repository
-    ?? repo;
-}
-
-function buildActivitySuccessState({ updates, existing, repo }) {
-  return {
-    ...mergeActivitySuccessValues(updates, existing),
-    lastContextInjectionSections: mergeActivitySuccessSections(updates, existing),
-    lastContextInjectionDurationMs: mergeActivitySuccessDuration(updates, existing),
-    lastExtractionRepository: mergeActivitySuccessExtractionRepository(updates, existing, repo),
-  };
-}
-
-function normalizeDaySummaryRepository(repository) {
-  return normalizeRepository(repository) ?? "";
-}
-
-function normalizeScopeSource(value, fallback = SCOPE_SOURCE.AUTO) {
-  return value === SCOPE_SOURCE.MANUAL ? SCOPE_SOURCE.MANUAL : fallback;
-}
-
-function applyScopeFilter(sql, params, repo, includeOtherRepositories, alias = "") {
-  const policy = buildScopeEligibilitySql({
-    alias: alias || "",
-    repository: repo,
-    includeOtherRepositories,
-  });
-  params.push(...policy.params);
-  return `${sql} AND (${policy.sql}) `;
-}
-
-const LAST_SEEN_AT_CASE_SQL = "last_seen_at = CASE WHEN ? IS NULL THEN COALESCE(last_seen_at, ?) WHEN last_seen_at IS NULL OR ? > last_seen_at THEN ? ELSE last_seen_at END";
-
-function lastSeenAtParams(value) {
-  return [value, value, value, value];
-}
-
-function dedupeSemanticRows(rows) {
-  const seen = new Set();
-  const deduped = [];
-  for (const row of rows) {
-    const key = `${row.type}::${normalizeText(row.content).toLowerCase()}::${row.scope ?? MEMORY_SCOPE.REPO}::${row.repository ?? ""}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    deduped.push(row);
-  }
-  return deduped;
-}
-
-function mergeTagText(existingTags, incomingTags) {
-  const tags = new Set(
-    `${existingTags || ""} ${incomingTags || ""}`
-      .trim()
-      .split(/\s+/)
-      .filter(Boolean),
-  );
-  return [...tags].join(" ");
-}
-
-function normalizeTraceMemoryRow(memory) {
-  return memory && typeof memory === "object" ? memory : {};
-}
-
-function buildSemanticTraceIdentity(memory) {
-  return {
-    id: memory.id ?? null,
-    type: memory.type ?? null,
-    scope: memory.scope ?? null,
-    scopeSource: memory.scope_source ?? null,
-    repository: memory.repository ?? null,
-  };
-}
-
-function buildSemanticTraceMetadata(memory) {
-  return {
-    updatedAt: memory.updated_at ?? null,
-    canonicalKey: memory.canonical_key ?? null,
-    reinforcementCount: memory.reinforcement_count ?? 1,
-    lastSeenAt: memory.last_seen_at ?? null,
-  };
-}
-
-function serializeSemanticRows(rows, repository) {
-  return rows.map((memory) => serializeSemanticTraceRow(memory, repository));
-}
-
-function serializeEpisodeRows(rows, repository) {
-  return rows.map((episode) => serializeEpisodeTraceRow(episode, repository));
-}
-
-function serializeSessionRows(rows, repository) {
-  return rows.map((session) => serializeSessionTraceRow(session, repository));
-}
-
-
-function serializeSemanticTraceRow(memory, currentRepository = null) {
-  const normalizedMemory = normalizeTraceMemoryRow(memory);
-  return {
-    ...buildSemanticTraceIdentity(normalizedMemory),
-    ...buildSemanticTraceMetadata(normalizedMemory),
-    crossRepo: isCrossRepoRow(normalizedMemory, currentRepository),
-    content: normalizeText(normalizedMemory.content),
-  };
-}
-
-function buildStyleAddressingTraceLookup({
-  effectiveStyleSection,
-  assistantPersonaRows,
-  relationshipPreferenceRows,
-  repository,
-}) {
-  const styleRows = [
-    ...serializeSemanticRows(assistantPersonaRows, repository),
-    ...serializeSemanticRows(relationshipPreferenceRows, repository),
-  ];
-  return {
-    enabled: effectiveStyleSection.trace.enabled,
-    ambientEnabled: effectiveStyleSection.trace.ambientEnabled,
-    includeAmbient: effectiveStyleSection.trace.includeAmbient,
-    promptLocal: effectiveStyleSection.trace.promptLocal,
-    rows: styleRows,
-    includedRows: effectiveStyleSection.trace.includeAmbient ? styleRows : [],
-    reason: effectiveStyleSection.trace.reason,
-  };
-}
-
-function buildCrossRepoPreferencesTraceLookup({
-  allowGenericCrossRepoFallback,
-  crossRepoPreferenceRows,
-  crossRepoPreferences,
-  repository,
-}) {
-  return {
-    enabled: allowGenericCrossRepoFallback,
-    scopes: [MEMORY_SCOPE.TRANSFERABLE],
-    rows: serializeSemanticRows(crossRepoPreferenceRows, repository),
-    includedRows: serializeSemanticRows(crossRepoPreferences, repository),
-    filtered: crossRepoPreferenceRows
-      .filter((memory) => !isCrossRepoRow(memory, repository))
-      .map((memory) => ({
-        stage: "cross_repo_filter",
-        reason: "same_repository",
-        row: serializeSemanticTraceRow(memory, repository),
-      })),
-    reason: null,
-  };
-}
-
-function buildCrossRepoEpisodesTraceLookup({
-  allowGenericCrossRepoFallback,
-  crossRepoEpisodeDetails,
-  crossRepoEpisodes,
-  repository,
-}) {
-  return {
-    enabled: allowGenericCrossRepoFallback,
-    scopes: [MEMORY_SCOPE.TRANSFERABLE],
-    rankedRows: crossRepoEpisodeDetails?.trace?.rankedRows ?? [],
-    includedRows: serializeEpisodeRows(crossRepoEpisodes, repository),
-    filtered: [
-      ...(crossRepoEpisodeDetails?.trace?.filtered ?? []),
-      ...((crossRepoEpisodeDetails?.episodes ?? [])
-        .filter((episode) => !isCrossRepoRow(episode, repository))
-        .map((episode) => ({
-          stage: "cross_repo_filter",
-          reason: "same_repository",
-          row: serializeEpisodeTraceRow(episode, repository),
-        }))),
-    ],
-    reason: null,
-  };
-}
-
-function serializeEpisodeTraceRow(episode, currentRepository = null) {
-  return {
-    id: episode.id ?? null,
-    sessionId: episode.session_id ?? null,
-    scope: episode.scope ?? null,
-    scopeSource: episode.scope_source ?? null,
-    repository: episode.repository ?? null,
-    updatedAt: episode.updated_at ?? null,
-    dateKey: episode.date_key ?? null,
-    significance: episode.significance ?? 0,
-    crossRepo: isCrossRepoRow(episode, currentRepository),
-    summary: normalizeText(episode.summary),
-    decisions: parseJsonArray(episode.decisions_json).map(normalizeText).filter(Boolean).slice(0, 6),
-    actions: parseJsonArray(episode.actions_json).map(normalizeText).filter(Boolean).slice(0, 6),
-    openItems: parseJsonArray(episode.open_items_json).map(normalizeText).filter(Boolean).slice(0, 6),
-    themes: parseJsonArray(episode.themes_json).map(normalizeText).filter(Boolean).slice(0, 6),
-  };
-}
-
-function serializeDaySummaryTraceRow(summary, currentRepository = null) {
-  return {
-    repository: summary.repository ?? null,
-    dateKey: summary.date_key ?? null,
-    computedAt: summary.computed_at ?? null,
-    crossRepo: isCrossRepoRow(summary, currentRepository),
-    summary: normalizeText(summary.summary),
-  };
-}
-
-function buildLocalEligibility(repository) {
-  if (repository) {
-    return [MEMORY_SCOPE.GLOBAL, `${MEMORY_SCOPE.REPO}:${repository}`];
-  }
-  return [MEMORY_SCOPE.GLOBAL];
-}
-
-const SEMANTIC_SCOPE_STAT_FIELDS = Object.freeze([
-  ["semanticGlobalCount", "global_count"],
-  ["semanticTransferableCount", "transferable_count"],
-  ["semanticRepoCount", "repo_count"],
-  ["semanticManualCount", "manual_count"],
-]);
-
-const EPISODE_SCOPE_STAT_FIELDS = Object.freeze([
-  ["episodeGlobalCount", "global_count"],
-  ["episodeTransferableCount", "transferable_count"],
-  ["episodeRepoCount", "repo_count"],
-  ["episodeManualCount", "manual_count"],
-]);
-
-const SEMANTIC_GROWTH_STAT_FIELDS = Object.freeze([
-  ["semanticCanonicalCount", "canonical_count"],
-  ["semanticReinforcedCount", "reinforced_count"],
-  ["assistantGoalCount", "assistant_goal_count"],
-  ["recurringMistakeCount", "recurring_mistake_count"],
-  ["userIdentityCount", "user_identity_count"],
-  ["workstreamOverlayCount", "workstream_overlay_count"],
-  ["directiveCount", "directive_count"],
-]);
-
-const IMPROVEMENT_STAT_FIELDS = Object.freeze([
-  ["improvementCount", "total_count"],
-  ["improvementActiveCount", "active_count"],
-  ["improvementResolvedCount", "resolved_count"],
-  ["improvementSupersededCount", "superseded_count"],
-  ["improvementProposalCount", "proposal_count"],
-  ["draftProposalCount", "draft_proposal_count"],
-  ["approvedProposalCount", "approved_proposal_count"],
-  ["rejectedProposalCount", "rejected_proposal_count"],
-  ["supersededProposalCount", "superseded_proposal_count"],
-]);
-
-const BACKFILL_STAT_FIELDS = Object.freeze([
-  ["backfillRunningCount", "running_count"],
-  ["backfillCompletedCount", "completed_count"],
-  ["backfillFailedCount", "failed_count"],
-  ["backfillDryRunCount", "dry_run_count"],
-]);
-
-const DEFERRED_STAT_FIELDS = Object.freeze([
-  ["deferredPendingCount", "pending_count"],
-  ["deferredRunningCount", "running_count"],
-  ["deferredFailedCount", "failed_count"],
-  ["deferredCompletedCount", "completed_count"],
-]);
-
-const MAINTENANCE_STAT_FIELDS = Object.freeze([
-  ["maintenanceCompletedCount", "completed_count"],
-  ["maintenanceNeedsAttentionCount", "needs_attention_count"],
-  ["maintenanceFailedCount", "failed_count"],
-  ["maintenanceSkippedCount", "skipped_count"],
-]);
-
-const TRAJECTORY_STAT_FIELDS = Object.freeze([
-  ["trajectoryArtifactCount", "total_count"],
-  ["trajectoryReplayFailureCount", "replay_failure_count"],
-  ["trajectoryValidationMissCount", "validation_miss_count"],
-  ["trajectoryProposalFailureCount", "proposal_failure_count"],
-  ["trajectoryLatencyOutlierCount", "latency_outlier_count"],
-]);
-
-const INTENT_JOURNAL_STAT_FIELDS = Object.freeze([
-  ["intentJournalCount", "total_count"],
-  ["intentRoutingCount", "routing_count"],
-  ["intentRolloutCount", "rollout_count"],
-  ["intentReviewerCount", "reviewer_count"],
-  ["intentFallbackCount", "fallback_count"],
-  ["intentSerendipityCount", "serendipity_count"],
-]);
-
-const RETRIEVAL_TRACE_SAMPLE_STAT_FIELDS = Object.freeze([
-  ["retrievalTraceSampleCount", "total_count"],
-  ["retrievalTraceSampleGlobalCount", "global_count"],
-  ["retrievalTraceSampleRepositoryCount", "repository_count"],
-]);
-
-function readTableCount(db, tableName) {
-  return db.prepare(`SELECT COUNT(*) AS count FROM ${tableName}`).get().count;
-}
-
-function mapStatFields(row, mappings) {
-  return Object.fromEntries(
-    mappings.map(([outputKey, rowKey]) => [outputKey, row?.[rowKey] ?? 0]),
-  );
-}
-
-function serializeLastSuccessActivity(row) {
-  if (!row) {
-    return null;
-  }
-  return mapActivityStateRow(row);
-}
-
-function buildLoreStatsPayload({
-  config,
-  lastBackupPath,
-  semanticCount,
-  episodeCount,
-  domainCount,
-  observationCount,
-  semanticScopes,
-  episodeScopes,
-  daySummaryCount,
-  schemaVersion,
-  overrideAuditCount,
-  semanticGrowth,
-  improvementCounts,
-  backfillCounts,
-  deferredCounts,
-  maintenanceCounts,
-  maintenanceLatest,
-  maintenanceTaskCount,
-  trajectoryCounts,
-  intentJournalCounts,
-  retrievalTraceSampleCounts,
-  latestActivity,
-}) {
-  return {
-    semanticCount,
-    episodeCount,
-    domainCount,
-    observationCount,
-    ...mapStatFields(semanticScopes, SEMANTIC_SCOPE_STAT_FIELDS),
-    ...mapStatFields(episodeScopes, EPISODE_SCOPE_STAT_FIELDS),
-    daySummaryCount,
-    schemaVersion,
-    dbPath: config.paths.derivedStorePath,
-    backupDir: config.paths.backupDir,
-    lastBackupPath,
-    overrideAuditCount,
-    ...mapStatFields(semanticGrowth, SEMANTIC_GROWTH_STAT_FIELDS),
-    ...mapStatFields(improvementCounts, IMPROVEMENT_STAT_FIELDS),
-    ...mapStatFields(backfillCounts, BACKFILL_STAT_FIELDS),
-    ...mapStatFields(deferredCounts, DEFERRED_STAT_FIELDS),
-    ...mapStatFields(maintenanceCounts, MAINTENANCE_STAT_FIELDS),
-    maintenanceTaskStateCount: maintenanceTaskCount,
-    lastMaintenanceStatus: maintenanceLatest?.status ?? null,
-    lastMaintenanceStartedAt: maintenanceLatest?.started_at ?? null,
-    lastMaintenanceCompletedAt: maintenanceLatest?.completed_at ?? null,
-    ...mapStatFields(trajectoryCounts, TRAJECTORY_STAT_FIELDS),
-    ...mapStatFields(intentJournalCounts, INTENT_JOURNAL_STAT_FIELDS),
-    ...mapStatFields(retrievalTraceSampleCounts, RETRIEVAL_TRACE_SAMPLE_STAT_FIELDS),
-    lastSuccessActivity: serializeLastSuccessActivity(latestActivity),
-  };
-}
-
-function createPromptContextTrace({
-  prompt,
-  repository,
-  allowCrossRepoFallback,
-  allowGenericCrossRepoFallback,
-  promptTerms,
-  identityName,
-  temporalDate,
-  memories,
-  localMemories,
-  identityMemories,
-  effectiveStyleSection,
-  assistantPersonaRows,
-  relationshipPreferenceRows,
-  daySummaryRows,
-  includedDaySummaryRows,
-  episodeDetails,
-  crossRepoPreferenceRows,
-  crossRepoPreferences,
-  crossRepoEpisodeDetails,
-  crossRepoEpisodes,
-  crossRepoHints,
-  sessionStore,
-}) {
-  return {
-    mode: "prompt_context",
-    repository,
-    includeOtherRepositories: allowCrossRepoFallback,
-    promptTerms,
-    identityName: identityName ?? null,
-    temporalDate,
-    temporal: null,
-    eligibility: {
-      localSemantic: buildLocalEligibility(repository),
-      localEpisodes: buildLocalEligibility(repository),
-      crossRepoFallback: allowCrossRepoFallback ? [MEMORY_SCOPE.TRANSFERABLE] : [],
-    },
-    lookups: {
-      localMemories: {
-        query: prompt,
-        types: ["commitment", "open_loop", "rejected_approach", "blocker", "user_preference", "assistant_identity", "user_identity", "assistant_goal", "recurring_mistake", "decision", "learned_rule"],
-        rows: serializeSemanticRows(memories, repository),
-        includedRows: serializeSemanticRows(localMemories, repository),
-      },
-      identityMemories: {
-        query: identityName ?? "",
-        scopes: [MEMORY_SCOPE.GLOBAL],
-        rows: serializeSemanticRows(identityMemories, repository),
-        includedRows: serializeSemanticRows(identityMemories, repository),
-      },
-      styleAddressing: buildStyleAddressingTraceLookup({
-        effectiveStyleSection,
-        assistantPersonaRows,
-        relationshipPreferenceRows,
-        repository,
-      }),
-      daySummary: {
-        date: temporalDate,
-        rows: daySummaryRows.map((summary) => serializeDaySummaryTraceRow(summary, repository)),
-        includedRows: includedDaySummaryRows.map((summary) => serializeDaySummaryTraceRow(summary, repository)),
-        included: false,
-        reason: null,
-      },
-      localEpisodes: episodeDetails.trace,
-      crossRepoPreferences: buildCrossRepoPreferencesTraceLookup({
-        allowGenericCrossRepoFallback,
-        crossRepoPreferenceRows,
-        crossRepoPreferences,
-        repository,
-      }),
-      crossRepoEpisodes: buildCrossRepoEpisodesTraceLookup({
-        allowGenericCrossRepoFallback,
-        crossRepoEpisodeDetails,
-        crossRepoEpisodes,
-        repository,
-      }),
-      crossRepoHints: {
-        enabled: allowGenericCrossRepoFallback && !!sessionStore,
-        rows: serializeSessionRows(crossRepoHints, repository),
-        includedRows: [],
-        reason: null,
-      },
-      temporalVerifier: {
-        enabled: !!sessionStore && temporalDate !== null,
-        date: temporalDate,
-        rows: [],
-        includedRows: [],
-        reason: null,
-      },
-    },
-    omissions: [],
-    output: {
-      sectionTitles: [],
-      sectionDetails: [],
-      estimatedTokens: 0,
-    },
-  };
-}
-
-
-function effectiveRepositoryForScope(scope, rowRepository, metadata = {}, fallbackRepository = null) {
-  if (scope === MEMORY_SCOPE.GLOBAL) {
-    return null;
-  }
-  return normalizeRepository(rowRepository)
-    ?? normalizeRepository(metadata?.originRepository)
-    ?? normalizeRepository(fallbackRepository);
-}
-
-function classifySemanticRow(row, { fallbackRepository = null, ignoreManualOverride = false } = {}) {
-  const metadata = parseJsonObject(row.metadata_json);
-  const scopeSource = normalizeScopeSource(row.scope_source);
-  if (!ignoreManualOverride && scopeSource === SCOPE_SOURCE.MANUAL) {
-    const scope = normalizeScope(row.scope, MEMORY_SCOPE.REPO);
-    return {
-      scope,
-      repository: effectiveRepositoryForScope(scope, row.repository, metadata, fallbackRepository),
-      metadata,
-      scopeSource,
-    };
-  }
-  const classification = classifySemanticMemory({
-    type: row.type,
-    content: row.content,
-    scope: null,
-    repository: row.repository ?? fallbackRepository ?? metadata.originRepository ?? null,
-    tags: row.tags ? row.tags.split(/\s+/).filter(Boolean) : [],
-    metadata,
-  });
-  return {
-    ...classification,
-    scopeSource: SCOPE_SOURCE.AUTO,
-  };
-}
-
-function classifyEpisodeRow(row, { fallbackRepository = null, ignoreManualOverride = false } = {}) {
-  const scopeSource = normalizeScopeSource(row.scope_source);
-  if (!ignoreManualOverride && scopeSource === SCOPE_SOURCE.MANUAL) {
-    const scope = normalizeScope(row.scope, MEMORY_SCOPE.REPO);
-    return {
-      scope,
-      repository: effectiveRepositoryForScope(scope, row.repository, {}, fallbackRepository),
-      scopeSource,
-    };
-  }
-  const classification = classifyEpisodeDigest({
-    scope: null,
-    repository: row.repository ?? fallbackRepository ?? null,
-    summary: row.summary,
-    actions: parseJsonArray(row.actions_json),
-    decisions: parseJsonArray(row.decisions_json),
-    learnings: parseJsonArray(row.learnings_json),
-    refs: parseJsonArray(row.refs_json),
-    themes: parseJsonArray(row.themes_json),
-    openItems: parseJsonArray(row.open_items_json),
-  });
-  return {
-    ...classification,
-    scopeSource: SCOPE_SOURCE.AUTO,
-  };
-}
-
-function dedupeSemanticContextRows(rows) {
-  const seen = new Set();
-  const deduped = [];
-  for (const row of rows) {
-    const key = `${row.type}::${normalizeText(row.content).toLowerCase()}::${row.scope ?? ""}::${row.repository ?? ""}`;
-    if (seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    deduped.push(row);
-  }
-  return deduped;
-}
-
-function mapMemoryDomainRow(row) {
-  return {
-    domainKey: row.domain_key,
-    kind: row.kind,
-    title: row.title,
-    mission: row.mission,
-    scope: row.scope,
-    repository: row.repository,
-    directives: parseJsonArray(row.directives_json),
-    disposition: parseJsonObject(row.disposition_json),
-    metadata: parseJsonObject(row.metadata_json),
-    status: row.status,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-    lastUsedAt: row.last_used_at,
-  };
-}
-
-function mapObservationRow(row) {
-  return {
-    observationKey: row.observation_key,
-    domainKey: row.domain_key,
-    title: row.title,
-    prompt: row.prompt,
-    focus: row.focus,
-    summary: row.summary,
-    confidence: row.confidence,
-    scope: row.scope,
-    repository: row.repository,
-    freshnessHours: row.freshness_hours,
-    status: row.status,
-    source: row.source,
-    trace: parseJsonObject(row.trace_json),
-    metadata: parseJsonObject(row.metadata_json),
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-    lastRefreshedAt: row.last_refreshed_at,
-  };
-}
-
-// --- Stats query helpers (todo 3) ---
-
-function querySemanticMemoryStats(db) {
-  const semanticCount = readTableCount(db, "semantic_memory");
-  const semanticGrowth = db.prepare(`
-    SELECT
-      SUM(CASE WHEN canonical_key IS NOT NULL THEN 1 ELSE 0 END) AS canonical_count,
-      SUM(CASE WHEN reinforcement_count > 1 THEN 1 ELSE 0 END) AS reinforced_count,
-      SUM(CASE WHEN type = 'assistant_goal' THEN 1 ELSE 0 END) AS assistant_goal_count,
-      SUM(CASE WHEN type = 'recurring_mistake' THEN 1 ELSE 0 END) AS recurring_mistake_count,
-      SUM(CASE WHEN type = 'user_identity' THEN 1 ELSE 0 END) AS user_identity_count,
-      SUM(CASE WHEN type = 'workstream_overlay' THEN 1 ELSE 0 END) AS workstream_overlay_count,
-      SUM(CASE WHEN type = 'directive' THEN 1 ELSE 0 END) AS directive_count
-    FROM semantic_memory
-    WHERE superseded_by IS NULL
-  `).get();
-  const semanticScopes = db.prepare(`
-    SELECT
-      SUM(CASE WHEN scope = 'global' THEN 1 ELSE 0 END) AS global_count,
-      SUM(CASE WHEN scope = 'transferable' THEN 1 ELSE 0 END) AS transferable_count,
-      SUM(CASE WHEN scope = 'repo' THEN 1 ELSE 0 END) AS repo_count,
-      SUM(CASE WHEN scope_source = 'manual' THEN 1 ELSE 0 END) AS manual_count
-    FROM semantic_memory
-  `).get();
-  return { semanticCount, semanticGrowth, semanticScopes };
-}
-
-function queryEpisodeDigestStats(db) {
-  const episodeCount = readTableCount(db, "episode_digest");
-  const episodeScopes = db.prepare(`
-    SELECT
-      SUM(CASE WHEN scope = 'global' THEN 1 ELSE 0 END) AS global_count,
-      SUM(CASE WHEN scope = 'transferable' THEN 1 ELSE 0 END) AS transferable_count,
-      SUM(CASE WHEN scope = 'repo' THEN 1 ELSE 0 END) AS repo_count,
-      SUM(CASE WHEN scope_source = 'manual' THEN 1 ELSE 0 END) AS manual_count
-    FROM episode_digest
-  `).get();
-  const daySummaryCount = db.prepare(`SELECT COUNT(*) AS count FROM day_summary`).get().count;
-  return { episodeCount, episodeScopes, daySummaryCount };
-}
-
-function queryExtractionJobStats(db) {
-  const deferredCounts = db.prepare(`
-    SELECT
-      SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pending_count,
-      SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running_count,
-      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
-      SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count
-    FROM deferred_extraction
-  `).get();
-  const backfillCounts = db.prepare(`
-    SELECT
-      SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END) AS running_count,
-      SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count,
-      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
-      SUM(CASE WHEN dry_run = 1 THEN 1 ELSE 0 END) AS dry_run_count
-    FROM backfill_run
-    `).get();
-  return { deferredCounts, backfillCounts };
-}
-
-function queryMaintenanceRunStats(db) {
-  const maintenanceCounts = db.prepare(`
-    SELECT
-      SUM(CASE WHEN status = 'completed' THEN 1 ELSE 0 END) AS completed_count,
-      SUM(CASE WHEN status = 'needs_attention' THEN 1 ELSE 0 END) AS needs_attention_count,
-      SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
-      SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END) AS skipped_count
-    FROM maintenance_run
-    WHERE dry_run = 0
-  `).get();
-  const maintenanceLatest = db.prepare(`
-    SELECT status, started_at, completed_at
-    FROM maintenance_run
-    WHERE dry_run = 0
-    ORDER BY updated_at DESC
-    LIMIT 1
-  `).get();
-  const maintenanceTaskCount = db.prepare(`
-    SELECT COUNT(*) AS count
-    FROM maintenance_task_state
-  `).get().count;
-  return { maintenanceCounts, maintenanceLatest, maintenanceTaskCount };
-}
-
-function queryImprovementBacklogStats(db) {
-  return db.prepare(`
-    SELECT
-      COUNT(*) AS total_count,
-      SUM(CASE WHEN status = 'active' THEN 1 ELSE 0 END) AS active_count,
-      SUM(CASE WHEN status = 'resolved' THEN 1 ELSE 0 END) AS resolved_count,
-      SUM(CASE WHEN status = 'superseded' THEN 1 ELSE 0 END) AS superseded_count,
-      SUM(CASE WHEN proposal_path IS NOT NULL THEN 1 ELSE 0 END) AS proposal_count,
-      SUM(CASE WHEN review_state = 'draft' THEN 1 ELSE 0 END) AS draft_proposal_count,
-      SUM(CASE WHEN review_state = 'approved' THEN 1 ELSE 0 END) AS approved_proposal_count,
-      SUM(CASE WHEN review_state = 'rejected' THEN 1 ELSE 0 END) AS rejected_proposal_count,
-      SUM(CASE WHEN review_state = 'superseded' THEN 1 ELSE 0 END) AS superseded_proposal_count
-    FROM improvement_backlog
-  `).get();
-}
-
-function querySignalStats(db) {
-  const trajectoryCounts = db.prepare(`
-    SELECT
-      COUNT(*) AS total_count,
-      SUM(CASE WHEN kind = 'replay_failure' THEN 1 ELSE 0 END) AS replay_failure_count,
-      SUM(CASE WHEN kind = 'validation_miss' THEN 1 ELSE 0 END) AS validation_miss_count,
-      SUM(CASE WHEN kind = 'proposal_failure' THEN 1 ELSE 0 END) AS proposal_failure_count,
-      SUM(CASE WHEN kind = 'latency_outlier' THEN 1 ELSE 0 END) AS latency_outlier_count
-    FROM trajectory_artifact
-  `).get();
-  const intentJournalCounts = db.prepare(`
-    SELECT
-      COUNT(*) AS total_count,
-      SUM(CASE WHEN intent_kind = 'routing' THEN 1 ELSE 0 END) AS routing_count,
-      SUM(CASE WHEN intent_kind = 'rollout' THEN 1 ELSE 0 END) AS rollout_count,
-      SUM(CASE WHEN intent_kind = 'reviewer' THEN 1 ELSE 0 END) AS reviewer_count,
-      SUM(CASE WHEN intent_kind = 'fallback' THEN 1 ELSE 0 END) AS fallback_count,
-      SUM(CASE WHEN intent_kind = 'serendipity' THEN 1 ELSE 0 END) AS serendipity_count
-    FROM intent_journal
-  `).get();
-  const retrievalTraceSampleCounts = db.prepare(`
-    SELECT
-      COUNT(*) AS total_count,
-      SUM(CASE WHEN repository IS NULL OR repository = '' THEN 1 ELSE 0 END) AS global_count,
-      SUM(CASE WHEN repository IS NOT NULL AND repository != '' THEN 1 ELSE 0 END) AS repository_count
-    FROM retrieval_trace_sample
-  `).get();
-  return { trajectoryCounts, intentJournalCounts, retrievalTraceSampleCounts };
-}
-
-// --- Activity state helpers (todos 3+4) ---
-
-function queryActivityStateRow(db, scopeKey) {
-  return db.prepare(`
-    SELECT
-      scope_key,
-      scope_type,
-      repository,
-      last_context_injection_at,
-      last_context_injection_hook,
-      last_context_injection_sections_json,
-      last_context_injection_trace_id,
-      last_context_injection_duration_ms,
-      last_extraction_completion_at,
-      last_extraction_repository,
-      last_maintenance_completion_at,
-      last_maintenance_status,
-      last_maintenance_run_id,
-      last_trace_recorded_at,
-      last_trace_hook,
-      last_trace_id,
-      updated_at
-    FROM lore_activity_state
-    WHERE scope_key = ?
-  `).get(scopeKey);
-}
-
-function mapActivityStateRow(row) {
-  return {
-    scopeKey: row.scope_key,
-    scopeType: row.scope_type,
-    repository: row.repository,
-    lastContextInjectionAt: row.last_context_injection_at,
-    lastContextInjectionHook: row.last_context_injection_hook,
-    lastContextInjectionSections: parseJsonArray(row.last_context_injection_sections_json),
-    lastContextInjectionTraceId: row.last_context_injection_trace_id,
-    lastContextInjectionDurationMs: row.last_context_injection_duration_ms,
-    lastExtractionCompletionAt: row.last_extraction_completion_at,
-    lastExtractionRepository: row.last_extraction_repository,
-    lastMaintenanceCompletionAt: row.last_maintenance_completion_at,
-    lastMaintenanceStatus: row.last_maintenance_status,
-    lastMaintenanceRunId: row.last_maintenance_run_id,
-    lastTraceRecordedAt: row.last_trace_recorded_at,
-    lastTraceHook: row.last_trace_hook,
-    lastTraceId: row.last_trace_id,
-    updatedAt: row.updated_at,
-  };
 }
 
 export class LoreDb {
@@ -1324,1992 +564,324 @@ export class LoreDb {
     registerRetrievalPolicyFunctions(this.db);
   }
 
-  getStats() {
-    this.ensureOpen();
-    const { semanticCount, semanticGrowth, semanticScopes } = querySemanticMemoryStats(this.db);
-    const { episodeCount, episodeScopes, daySummaryCount } = queryEpisodeDigestStats(this.db);
-    const domainCount = readTableCount(this.db, "memory_domain");
-    const observationCount = readTableCount(this.db, "refreshable_observation");
-    const { deferredCounts, backfillCounts } = queryExtractionJobStats(this.db);
-    const schemaVersion = this.getCurrentVersion();
-    const overrideAuditCount = readTableCount(this.db, "scope_override_audit");
-    const improvementCounts = queryImprovementBacklogStats(this.db);
-    const { maintenanceCounts, maintenanceLatest, maintenanceTaskCount } = queryMaintenanceRunStats(this.db);
-    const { trajectoryCounts, intentJournalCounts, retrievalTraceSampleCounts } = querySignalStats(this.db);
-    const latestActivity = queryActivityStateRow(this.db, "global");
-
-    return buildLoreStatsPayload({
-      config: this.config,
-      lastBackupPath: this.lastBackupPath,
-      semanticCount,
-      episodeCount,
-      domainCount,
-      observationCount,
-      semanticScopes,
-      episodeScopes,
-      daySummaryCount,
-      schemaVersion,
-      overrideAuditCount,
-      semanticGrowth,
-      improvementCounts,
-      backfillCounts,
-      deferredCounts,
-      maintenanceCounts,
-      maintenanceLatest,
-      maintenanceTaskCount,
-      trajectoryCounts,
-      intentJournalCounts,
-      retrievalTraceSampleCounts,
-      latestActivity,
-    });
-  }
-
-  insertIntentJournalEntry({
-    repository = null,
-    sessionId = null,
-    turnHint = null,
-    intentKind = "journal",
-    summary,
-    rationale = null,
-    context = {},
-  }) {
-    this.ensureOpen();
-    const normalizedSummary = String(summary || "").trim();
-    if (!normalizedSummary) {
-      throw new Error("summary is required");
-    }
-    const normalizeIntentKind = (value) => {
-      const normalized = String(value || "").trim().toLowerCase() || "journal";
-      const allowedKinds = new Set(["journal", "routing", "rollout", "reviewer", "fallback", "serendipity"]);
-      return allowedKinds.has(normalized) ? normalized : "journal";
-    };
-    const normalizeOptionalString = (value) => (
-      typeof value === "string" && value.trim().length > 0 ? value.trim() : null
-    );
-    const id = crypto.randomUUID();
-    this.db.prepare(`
-      INSERT INTO intent_journal (
-        id,
-        repository,
-        session_id,
-        turn_hint,
-        intent_kind,
-        summary,
-        rationale,
-        context_json,
-        created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      id,
-      normalizeRepository(repository),
-      normalizeOptionalString(sessionId),
-      normalizeOptionalString(turnHint),
-      normalizeIntentKind(intentKind),
-      normalizedSummary,
-      normalizeOptionalString(rationale),
-      JSON.stringify(context ?? {}),
-      nowIso(),
-    );
-    return id;
-  }
-
-  listIntentJournalEntries({
-    repository,
-    sessionId,
-    intentKind,
-    limit = 10,
-  } = {}) {
-    this.ensureOpen();
-    const where = [];
-    const params = [];
-    addStringFilter(where, params, "repository", repository);
-    addStringFilter(where, params, "session_id", sessionId);
-    addStringFilter(where, params, "intent_kind", intentKind, (v) => v.toLowerCase());
-    params.push(limit);
-    const rows = this.db.prepare(`
-      SELECT
-        id,
-        repository,
-        session_id,
-        turn_hint,
-        intent_kind,
-        summary,
-        rationale,
-        context_json,
-        created_at
-      FROM intent_journal
-      ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
-      ORDER BY created_at DESC
-      LIMIT ?
-    `).all(...params);
-    return rows.map((row) => ({
-      ...row,
-      context: parseJsonObject(row.context_json),
-    }));
-  }
-
-  insertTrajectoryArtifact({
-    kind,
-    repository = null,
-    sourceCaseId = null,
-    sourceKind = null,
-    improvementArtifactId = null,
-    eventKey = null,
-    summary,
-    severity = "info",
-    outcome = "captured",
-    latencyMs = null,
-    targetMs = null,
-    context = {},
-    trace = {},
-  }) {
-    this.ensureOpen();
-    const normalizedKind = validateRequiredStringField(kind, "kind");
-    const normalizedSummary = validateRequiredStringField(summary, "summary");
-    const normalizeOptionalValue = (value) => (value ? String(value) : null);
-    const roundIfFinite = (value) => (Number.isFinite(value) ? Math.round(value) : null);
-    const id = crypto.randomUUID();
-    this.db.prepare(`
-      INSERT INTO trajectory_artifact (
-        id,
-        kind,
-        repository,
-        source_case_id,
-        source_kind,
-        improvement_artifact_id,
-        event_key,
-        summary,
-        severity,
-        outcome,
-        latency_ms,
-        target_ms,
-        context_json,
-        trace_json,
-        created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      id,
-      normalizedKind,
-      normalizeRepository(repository),
-      normalizeOptionalValue(sourceCaseId),
-      normalizeOptionalValue(sourceKind),
-      normalizeOptionalValue(improvementArtifactId),
-      normalizeOptionalValue(eventKey),
-      normalizedSummary,
-      String(severity || "info"),
-      String(outcome || "captured"),
-      roundIfFinite(latencyMs),
-      roundIfFinite(targetMs),
-      JSON.stringify(context ?? {}),
-      JSON.stringify(trace ?? {}),
-      nowIso(),
-    );
-    return id;
-  }
-
-  listTrajectoryArtifacts({
-    kind,
-    sourceKind,
-    sourceCaseId,
-    repository,
-    limit = 10,
-  } = {}) {
-    this.ensureOpen();
-    const where = [];
-    const params = [];
-    addStringFilter(where, params, "kind", kind);
-    addStringFilter(where, params, "source_kind", sourceKind);
-    addStringFilter(where, params, "source_case_id", sourceCaseId);
-    addStringFilter(where, params, "repository", repository);
-    params.push(limit);
-    const rows = this.db.prepare(`
-      SELECT
-        id,
-        kind,
-        repository,
-        source_case_id,
-        source_kind,
-        improvement_artifact_id,
-        event_key,
-        summary,
-        severity,
-        outcome,
-        latency_ms,
-        target_ms,
-        context_json,
-        trace_json,
-        created_at
-      FROM trajectory_artifact
-      ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
-      ORDER BY created_at DESC
-      LIMIT ?
-    `).all(...params);
-    return rows.map((row) => ({
-      ...row,
-      context: parseJsonObject(row.context_json),
-      trace: parseJsonObject(row.trace_json),
-    }));
-  }
-
-
-  upsertActivitySuccess({
-    repository = null,
-    updates = {},
-  } = {}) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const scopeKey = repo ? `repo:${repo}` : "global";
-    const scopeType = repo ? "repo" : "global";
-    const timestamp = nowIso();
-    const normalizedUpdates = updates && typeof updates === "object" ? updates : {};
-
-    const existing = this.db.prepare(`
-      SELECT *
-      FROM lore_activity_state
-      WHERE scope_key = ?
-      LIMIT 1
-    `).get(scopeKey);
-
-    const next = buildActivitySuccessState({
-      updates: normalizedUpdates,
-      existing,
-      repo,
-    });
-
-    this.db.prepare(`
-      INSERT INTO lore_activity_state (
-        scope_key,
-        scope_type,
-        repository,
-        last_context_injection_at,
-        last_context_injection_hook,
-        last_context_injection_sections_json,
-        last_context_injection_trace_id,
-        last_context_injection_duration_ms,
-        last_extraction_completion_at,
-        last_extraction_repository,
-        last_maintenance_completion_at,
-        last_maintenance_status,
-        last_maintenance_run_id,
-        last_trace_recorded_at,
-        last_trace_hook,
-        last_trace_id,
-        updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(scope_key) DO UPDATE SET
-        scope_type = excluded.scope_type,
-        repository = excluded.repository,
-        last_context_injection_at = excluded.last_context_injection_at,
-        last_context_injection_hook = excluded.last_context_injection_hook,
-        last_context_injection_sections_json = excluded.last_context_injection_sections_json,
-        last_context_injection_trace_id = excluded.last_context_injection_trace_id,
-        last_context_injection_duration_ms = excluded.last_context_injection_duration_ms,
-        last_extraction_completion_at = excluded.last_extraction_completion_at,
-        last_extraction_repository = excluded.last_extraction_repository,
-        last_maintenance_completion_at = excluded.last_maintenance_completion_at,
-        last_maintenance_status = excluded.last_maintenance_status,
-        last_maintenance_run_id = excluded.last_maintenance_run_id,
-        last_trace_recorded_at = excluded.last_trace_recorded_at,
-        last_trace_hook = excluded.last_trace_hook,
-        last_trace_id = excluded.last_trace_id,
-        updated_at = excluded.updated_at
-    `).run(
-      scopeKey,
-      scopeType,
-      repo,
-      next.lastContextInjectionAt,
-      next.lastContextInjectionHook,
-      jsonText(next.lastContextInjectionSections),
-      next.lastContextInjectionTraceId,
-      next.lastContextInjectionDurationMs,
-      next.lastExtractionCompletionAt,
-      next.lastExtractionRepository,
-      next.lastMaintenanceCompletionAt,
-      next.lastMaintenanceStatus,
-      next.lastMaintenanceRunId,
-      next.lastTraceRecordedAt,
-      next.lastTraceHook,
-      next.lastTraceId,
-      timestamp,
-    );
-
-    return this.getActivityState({ repository: repo, includeGlobal: false });
-  }
-
-  collectDirectActivityRows(repo, includeGlobal) {
-    const rows = [];
-    if (repo) {
-      const row = queryActivityStateRow(this.db, `repo:${repo}`);
-      if (row) rows.push(row);
-    }
-    if (includeGlobal) {
-      const row = queryActivityStateRow(this.db, "global");
-      if (row) rows.push(row);
-    }
-    return rows;
-  }
-
-  collectFallbackActivityRows(repo, includeGlobal) {
-    const rows = [];
-    if (repo) {
-      const fallback = this.deriveActivityStateFallback({ repository: repo, scopeKey: `repo:${repo}`, scopeType: "repo" });
-      if (fallback) rows.push(fallback);
-    }
-    if (includeGlobal) {
-      const fallback = this.deriveActivityStateFallback({ repository: null, scopeKey: "global", scopeType: "global" });
-      if (fallback) rows.push(fallback);
-    }
-    return rows;
-  }
-
-  getActivityState({ repository = null, includeGlobal = true } = {}) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const direct = this.collectDirectActivityRows(repo, includeGlobal);
-    const rows = direct.length > 0 ? direct : this.collectFallbackActivityRows(repo, includeGlobal);
-    return rows.map(mapActivityStateRow);
-  }
-
-  deriveActivityStateFallback({
-    repository = null,
-    scopeKey,
-    scopeType,
-  } = {}) {
-    this.ensureOpen();
-    const fallbackScope = this.buildActivityFallbackScope(repository);
-    const fallbackRows = this.readActivityFallbackRows(fallbackScope);
-    const timestamps = this.collectActivityFallbackTimestamps(fallbackRows);
-    return timestamps.length > 0
-      ? this.serializeActivityStateFallback({
-          scopeKey,
-          scopeType,
-          repository: fallbackScope.repo,
-          timestamps,
-          ...fallbackRows,
-        })
-      : null;
-  }
-
-  buildActivityFallbackScope(repository = null) {
-    const repo = normalizeRepository(repository);
-    return {
-      repo,
-      scopedWhere: repo ? "WHERE repository = ?" : "",
-      scopedParams: repo ? [repo] : [],
-    };
-  }
-
-  readActivityFallbackRows({ repo, scopedWhere, scopedParams }) {
-    return {
-      latestContextRow: this.readLatestContextFallbackRow(repo, scopedParams),
-      latestTraceRow: this.readLatestTraceFallbackRow(scopedWhere, scopedParams),
-      latestMaintenanceRow: this.readLatestMaintenanceFallbackRow(repo, scopedParams),
-      latestExtractionRow: this.readLatestExtractionFallbackRow(scopedWhere, scopedParams),
-    };
-  }
-
-  serializeActivityStateFallback({
-    scopeKey,
-    scopeType,
-    repository,
-    latestContextRow,
-    latestTraceRow,
-    latestMaintenanceRow,
-    latestExtractionRow,
-    timestamps,
-  }) {
-    return this.buildActivityStateFallbackRow({
-      scope_key: scopeKey,
-      scope_type: scopeType,
-      repository,
-      ...this.serializeActivityFallbackContext(latestContextRow),
-      ...this.serializeActivityFallbackExtraction(latestExtractionRow, repository),
-      ...this.serializeActivityFallbackMaintenance(latestMaintenanceRow),
-      ...this.serializeActivityFallbackTrace(latestTraceRow),
-      updated_at: this.resolveActivityFallbackUpdatedAt({
-        latestContextRow,
-        latestTraceRow,
-        latestMaintenanceRow,
-        latestExtractionRow,
-        timestamps,
-      }),
-    });
-  }
-
-  serializeActivityFallbackContext(latestContextRow) {
-    const row = latestContextRow ?? {};
-    return {
-      last_context_injection_at: row.recorded_at ?? null,
-      last_context_injection_hook: row.hook ?? null,
-      last_context_injection_sections_json: JSON.stringify(parseJsonArray(row.section_titles_json)),
-      last_context_injection_trace_id: row.id ?? null,
-      last_context_injection_duration_ms: row.latency_ms ?? null,
-    };
-  }
-
-  serializeActivityFallbackExtraction(latestExtractionRow, repository) {
-    return {
-      last_extraction_completion_at: latestExtractionRow?.updated_at ?? null,
-      last_extraction_repository: normalizeRepository(latestExtractionRow?.repository) ?? repository,
-    };
-  }
-
-  serializeActivityFallbackMaintenance(latestMaintenanceRow) {
-    return {
-      last_maintenance_completion_at: latestMaintenanceRow?.completed_at ?? null,
-      last_maintenance_status: latestMaintenanceRow?.status ?? null,
-      last_maintenance_run_id: latestMaintenanceRow?.id ?? null,
-    };
-  }
-
-  serializeActivityFallbackTrace(latestTraceRow) {
-    return {
-      last_trace_recorded_at: latestTraceRow?.recorded_at ?? null,
-      last_trace_hook: latestTraceRow?.hook ?? null,
-      last_trace_id: latestTraceRow?.id ?? null,
-    };
-  }
-
-  resolveActivityFallbackUpdatedAt({
-    latestContextRow,
-    latestTraceRow,
-    latestMaintenanceRow,
-    latestExtractionRow,
-    timestamps,
-  }) {
-    const effectiveTimestamps = Array.isArray(timestamps)
-      ? timestamps
-      : this.collectActivityFallbackTimestamps({
-          latestContextRow,
-          latestTraceRow,
-          latestMaintenanceRow,
-          latestExtractionRow,
-        });
-    return [...effectiveTimestamps].sort().at(-1) ?? nowIso();
-  }
-
-  readLatestContextFallbackRow(repo, scopedParams) {
-    return this.db.prepare(`
-      SELECT
-        id,
-        repository,
-        hook,
-        latency_ms,
-        section_titles_json,
-        recorded_at
-      FROM retrieval_trace_sample
-      WHERE context_injected = 1
-        ${repo ? "AND repository = ?" : ""}
-      ORDER BY recorded_at DESC
-      LIMIT 1
-    `).get(...scopedParams);
-  }
-
-  readLatestTraceFallbackRow(scopedWhere, scopedParams) {
-    return this.db.prepare(`
-      SELECT
-        id,
-        repository,
-        hook,
-        recorded_at
-      FROM retrieval_trace_sample
-      ${scopedWhere}
-      ORDER BY recorded_at DESC
-      LIMIT 1
-    `).get(...scopedParams);
-  }
-
-  readLatestMaintenanceFallbackRow(repo, scopedParams) {
-    return this.db.prepare(`
-      SELECT
-        id,
-        repository,
-        status,
-        completed_at
-      FROM maintenance_run
-      WHERE completed_at IS NOT NULL
-        ${repo ? "AND repository = ?" : ""}
-      ORDER BY completed_at DESC
-      LIMIT 1
-    `).get(...scopedParams);
-  }
-
-  readLatestExtractionFallbackRow(scopedWhere, scopedParams) {
-    return this.db.prepare(`
-      SELECT repository, updated_at
-      FROM (
-        SELECT repository, updated_at
-        FROM semantic_memory
-        ${scopedWhere}
-        UNION ALL
-        SELECT repository, updated_at
-        FROM episode_digest
-        ${scopedWhere}
-      )
-      ORDER BY updated_at DESC
-      LIMIT 1
-    `).get(...scopedParams, ...scopedParams);
-  }
-
-  collectActivityFallbackTimestamps({
-    latestContextRow,
-    latestTraceRow,
-    latestMaintenanceRow,
-    latestExtractionRow,
-  }) {
-    return [
-      latestContextRow?.recorded_at,
-      latestTraceRow?.recorded_at,
-      latestMaintenanceRow?.completed_at,
-      latestExtractionRow?.updated_at,
-    ].filter((value) => typeof value === "string" && value.length > 0);
-  }
-
-  buildActivityStateFallbackRow(row) {
-    return row;
-  }
-
-  normalizeRetrievalTraceHook(hook) {
-    return String(hook || "").trim();
-  }
-
-  normalizeRetrievalTraceScopeType(scopeType) {
-    return scopeType === "global" ? "global" : "repo";
-  }
-
-  normalizeRetrievalTraceSectionTitles(sectionTitles) {
-    if (!Array.isArray(sectionTitles)) {
-      return [];
-    }
-    return sectionTitles
-      .slice(0, 8)
-      .map((title) => (title == null ? "" : String(title)));
-  }
-
-  buildRetrievalTraceSampleRecord({
-    id = null,
-    repository = null,
-    scopeType = "repo",
-    hook,
-    route = null,
-    routeReason = null,
-    contextInjected = false,
-    latencyMs = null,
-    promptPreview = "",
-    sectionTitles = [],
-    promptNeed = {},
-    eligibility = {},
-    lookups = {},
-    omissions = [],
-    output = {},
-    trace = {},
-    recordedAt = nowIso(),
-  }) {
-    return buildRetrievalTraceSampleRecordImpl(this, {
-      id,
-      repository,
-      scopeType,
-      hook,
-      route,
-      routeReason,
-      contextInjected,
-      latencyMs,
-      promptPreview,
-      sectionTitles,
-      promptNeed,
-      eligibility,
-      lookups,
-      omissions,
-      output,
-      trace,
-      recordedAt,
-    });
-  }
-
-  writeRetrievalTraceSample(record) {
-    this.db.prepare(`
-      INSERT INTO retrieval_trace_sample (
-        id,
-        repository,
-        scope_type,
-        hook,
-        route,
-        route_reason,
-        context_injected,
-        latency_ms,
-        prompt_preview,
-        section_titles_json,
-        prompt_need_json,
-        eligibility_json,
-        lookups_json,
-        omissions_json,
-        output_json,
-        trace_json,
-        recorded_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      record.id,
-      record.repository,
-      record.scopeType,
-      record.hook,
-      record.route,
-      record.routeReason,
-      record.contextInjected,
-      record.latencyMs,
-      record.promptPreview,
-      JSON.stringify(record.sectionTitles),
-      record.promptNeed,
-      record.eligibility,
-      record.lookups,
-      record.omissions,
-      record.output,
-      record.trace,
-      record.recordedAt,
-    );
-  }
-
-  insertRetrievalTraceSample(sample = {}) {
-    this.ensureOpen();
-    const record = this.buildRetrievalTraceSampleRecord(sample);
-    this.writeRetrievalTraceSample(record);
-    return record.id;
-  }
-
-  pruneRetrievalTraceSamples({
-    repository = null,
-    maxRowsPerRepository = 120,
-    maxRowsGlobal = 240,
-    maxAgeMs = 14 * 24 * 60 * 60 * 1000,
-  } = {}) {
-    this.ensureOpen();
-    return pruneRetrievalTraceSamplesImpl(this.db, {
-      repository,
-      maxRowsPerRepository,
-      maxRowsGlobal,
-      maxAgeMs,
-    });
-  }
-
-  listRetrievalTraceSamples({
-    repository,
-    includeGlobal = true,
-    limit = 10,
-  } = {}) {
-    this.ensureOpen();
-    return listRetrievalTraceSamplesImpl(this.db, {
-      repository,
-      includeGlobal,
-      limit,
-    });
-  }
-
-  /**
-   * Persist a privacy-minimised error telemetry record.
-   * Accepts only categorical fields — never raw messages or stacks.
-   *
-   * @param {{ sessionId: string | null, contextCategory: string, recoverability: string, fingerprint: string }} record
-   * @returns {string} Generated record ID.
-   */
-  insertErrorTelemetry({ sessionId, contextCategory, recoverability, fingerprint }) {
-    this.ensureOpen();
-    const id = crypto.randomUUID();
-    this.db.prepare(`
-      INSERT INTO error_telemetry (id, session_id, context_category, recoverability, fingerprint, created_at)
-      VALUES (?, ?, ?, ?, ?, ?)
-    `).run(
-      id,
-      sessionId ?? null,
-      String(contextCategory || "unknown"),
-      String(recoverability || "unknown"),
-      String(fingerprint || ""),
-      nowIso(),
-    );
-    return id;
-  }
-
-  /**
-   * Prune old error telemetry rows for retention compliance.
-   * Deletes rows older than maxAgeMs and trims to maxRowsGlobal.
-   *
-   * @param {{ maxRowsGlobal?: number, maxAgeMs?: number }} options
-   * @returns {{ deletedByAge: number, deletedByLimit: number }}
-   */
-  pruneErrorTelemetry({
-    maxRowsGlobal = 500,
-    maxAgeMs = 30 * 24 * 60 * 60 * 1000,
-  } = {}) {
-    this.ensureOpen();
-    const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
-    const byAge = this.db.prepare(
-      `DELETE FROM error_telemetry WHERE created_at < ?`,
-    ).run(cutoff);
-    const byLimit = this.db.prepare(`
-      DELETE FROM error_telemetry WHERE id NOT IN (
-        SELECT id FROM error_telemetry ORDER BY created_at DESC LIMIT ?
-      )
-    `).run(maxRowsGlobal);
-    return {
-      deletedByAge: byAge.changes ?? 0,
-      deletedByLimit: byLimit.changes ?? 0,
-    };
-  }
-
-  getSemanticMemoryByIds(ids) {
-    this.ensureOpen();
-    if (!Array.isArray(ids) || ids.length === 0) {
-      return [];
-    }
-    const placeholders = ids.map(() => "?").join(", ");
-    return this.db.prepare(`
-      SELECT
-        id, type, content, confidence, source_session_id, source_turn_index,
-        scope, scope_source, scope_override_actor, scope_override_reason, scope_override_source, scope_override_at,
-        repository, tags, created_at, updated_at, superseded_by, canonical_key, reinforcement_count,
-        last_seen_at, expires_at, metadata_json
-      FROM semantic_memory
-      WHERE id IN (${placeholders})
-      ORDER BY updated_at DESC
-    `).all(...ids);
-  }
-
-  getEpisodeDigestsByIds(ids) {
-    this.ensureOpen();
-    if (!Array.isArray(ids) || ids.length === 0) {
-      return [];
-    }
-    const placeholders = ids.map(() => "?").join(", ");
-    return this.db.prepare(`
-      SELECT
-        id, session_id, scope, scope_source, scope_override_actor, scope_override_reason, scope_override_source, scope_override_at,
-        repository, branch, summary, actions_json, decisions_json, learnings_json, files_changed_json,
-        refs_json, significance, themes_json, open_items_json, source, date_key, created_at, updated_at
-      FROM episode_digest
-      WHERE id IN (${placeholders})
-      ORDER BY updated_at DESC
-    `).all(...ids);
-  }
-
-  previewScopeChanges({
-    targetType,
-    ids,
-    action = "set",
-    scope,
-    repository,
-  }) {
-    this.ensureOpen();
-    const targetIds = Array.isArray(ids) ? [...new Set(ids.filter((value) => typeof value === "string" && value.trim().length > 0))] : [];
-    if (targetIds.length === 0) {
-      throw new Error("ids must include at least one target id");
-    }
-    const normalizedAction = action === "clear" ? "clear" : "set";
-    const nextScope = normalizedAction === "set" ? normalizeScope(scope, null) : null;
-    if (normalizedAction === "set" && !nextScope) {
-      throw new Error("scope must be one of: global, transferable, repo");
-    }
-    const fallbackRepository = normalizeRepository(repository);
-    const rows = targetType === "episode"
-      ? this.getEpisodeDigestsByIds(targetIds)
-      : this.getSemanticMemoryByIds(targetIds);
-
-    const foundIds = new Set(rows.map((row) => row.id));
-    const missingIds = targetIds.filter((id) => !foundIds.has(id));
-    const previews = rows.map((row) => {
-      const currentMetadata = targetType === "semantic" ? parseJsonObject(row.metadata_json) : {};
-      const current = {
-        scope: row.scope,
-        repository: row.repository,
-        scopeSource: normalizeScopeSource(row.scope_source),
-      };
-      const next = normalizedAction === "clear"
-        ? (targetType === "episode"
-            ? classifyEpisodeRow(row, { fallbackRepository, ignoreManualOverride: true })
-            : classifySemanticRow(row, { fallbackRepository, ignoreManualOverride: true }))
-        : {
-            scope: nextScope,
-            repository: effectiveRepositoryForScope(nextScope, row.repository, currentMetadata, fallbackRepository),
-            scopeSource: SCOPE_SOURCE.MANUAL,
-          };
-      return {
-        id: row.id,
-        targetType,
-        current,
-        next,
-        changed: current.scope !== next.scope
-          || (current.repository ?? null) !== (next.repository ?? null)
-          || current.scopeSource !== next.scopeSource,
-      };
-    });
-
-    return {
-      action: normalizedAction,
-      targetType,
-      requestedCount: targetIds.length,
-      matchedCount: previews.length,
-      missingIds,
-      rows: previews,
-    };
-  }
-
-  insertScopeOverrideAudit({
-    targetType,
-    targetId,
-    action,
-    previousScope,
-    nextScope,
-    previousRepository,
-    nextRepository,
-    actor,
-    reason,
-    source,
-  }) {
-    this.db.prepare(`
-      INSERT INTO scope_override_audit (
-        id, target_type, target_id, action, previous_scope, next_scope,
-        previous_repository, next_repository, actor, reason, source, created_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      crypto.randomUUID(),
-      targetType,
-      targetId,
-      action,
-      previousScope ?? null,
-      nextScope ?? null,
-      normalizeRepository(previousRepository),
-      normalizeRepository(nextRepository),
-      actor,
-      reason,
-      source,
-      nowIso(),
-    );
-  }
-
-  applyScopeChanges({
-    targetType,
-    ids,
-    action = "set",
-    scope,
-    repository,
-    actor,
-    reason,
-    source,
-  }) {
-    this.ensureOpen();
-    const preview = this.previewScopeChanges({
-      targetType,
-      ids,
-      action,
-      scope,
-      repository,
-    });
-    const timestamp = nowIso();
-    const normalizedAction = preview.action;
-    const updateSemantic = this.db.prepare(`
-      UPDATE semantic_memory
-      SET scope = ?,
-          repository = ?,
-          scope_source = ?,
-          scope_override_actor = ?,
-          scope_override_reason = ?,
-          scope_override_source = ?,
-          scope_override_at = ?,
-          updated_at = ?
-      WHERE id = ?
-    `);
-    const updateEpisode = this.db.prepare(`
-      UPDATE episode_digest
-      SET scope = ?,
-          repository = ?,
-          scope_source = ?,
-          scope_override_actor = ?,
-          scope_override_reason = ?,
-          scope_override_source = ?,
-          scope_override_at = ?,
-          updated_at = ?
-      WHERE id = ?
-    `);
-
-    for (const row of preview.rows) {
-      const nextScopeSource = normalizedAction === "clear" ? SCOPE_SOURCE.AUTO : SCOPE_SOURCE.MANUAL;
-      const overrideActor = normalizedAction === "clear" ? null : actor;
-      const overrideReason = normalizedAction === "clear" ? null : reason;
-      const overrideSource = normalizedAction === "clear" ? null : source;
-      const overrideAt = normalizedAction === "clear" ? null : timestamp;
-      if (targetType === "episode") {
-        updateEpisode.run(
-          row.next.scope,
-          row.next.repository,
-          nextScopeSource,
-          overrideActor,
-          overrideReason,
-          overrideSource,
-          overrideAt,
-          timestamp,
-          row.id,
-        );
-      } else {
-        updateSemantic.run(
-          row.next.scope,
-          row.next.repository,
-          nextScopeSource,
-          overrideActor,
-          overrideReason,
-          overrideSource,
-          overrideAt,
-          timestamp,
-          row.id,
-        );
-      }
-      this.insertScopeOverrideAudit({
-        targetType,
-        targetId: row.id,
-        action: normalizedAction,
-        previousScope: row.current.scope,
-        nextScope: row.next.scope,
-        previousRepository: row.current.repository,
-        nextRepository: row.next.repository,
-        actor,
-        reason,
-        source,
-      });
-    }
-
-    return preview;
-  }
-
-  listScopeOverrideAudit({ targetType, targetId, limit = 10 }) {
-    this.ensureOpen();
-    const params = [];
-    const where = [];
-    addStringFilter(where, params, "target_type", targetType);
-    addStringFilter(where, params, "target_id", targetId);
-    params.push(limit);
-    return this.db.prepare(`
-      SELECT
-        id, target_type, target_id, action, previous_scope, next_scope,
-        previous_repository, next_repository, actor, reason, source, created_at
-      FROM scope_override_audit
-      ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
-      ORDER BY created_at DESC
-      LIMIT ?
-    `).all(...params);
-  }
-
-  upsertImprovementArtifact({
-    sourceCaseId,
-    sourceKind,
-    title,
-    summary,
-    evidence = {},
-    trace = {},
-    linkedMemoryId = null,
-    repository = null,
-  }) {
-    this.ensureOpen();
-    return upsertImprovementArtifactImpl(this.db, {
-      sourceCaseId,
-      sourceKind,
-      title,
-      summary,
-      evidence,
-      trace,
-      linkedMemoryId,
-      repository,
-    });
-  }
-
-  updateImprovementArtifactStatus({
-    id,
-    status,
-    supersededBy = null,
-  }) {
-    this.ensureOpen();
-    const normalizedId = String(id || "").trim();
-    if (!normalizedId) {
-      throw new Error("id is required");
-    }
-    const nextStatus = normalizeImprovementStatus(status, IMPROVEMENT_STATUS.ACTIVE);
-    const timestamp = nowIso();
-    const resolvedAt = nextStatus === IMPROVEMENT_STATUS.RESOLVED ? timestamp : null;
-    this.db.prepare(`
-      UPDATE improvement_backlog
-      SET status = ?,
-          superseded_by = CASE
-            WHEN ? = 'superseded' THEN COALESCE(?, superseded_by)
-            ELSE NULL
-          END,
-          review_state = CASE
-            WHEN ? = 'superseded' AND proposal_path IS NOT NULL THEN 'superseded'
-            ELSE review_state
-          END,
-          resolved_at = ?,
-          updated_at = ?
-      WHERE id = ?
-    `).run(
-      nextStatus,
-      nextStatus,
-      supersededBy ?? null,
-      nextStatus,
-      resolvedAt,
-      timestamp,
-      normalizedId,
-    );
-  }
-
-  getImprovementArtifact(id) {
-    this.ensureOpen();
-    const normalizedId = String(id || "").trim();
-    if (!normalizedId) {
-      return null;
-    }
-    const row = this.db.prepare(`
-      SELECT
-        id,
-        source_case_id,
-        source_kind,
-        title,
-        summary,
-        evidence_json,
-        trace_json,
-        status,
-        linked_memory_id,
-        repository,
-        superseded_by,
-        proposal_type,
-        proposal_path,
-        proposal_hash,
-        review_state,
-        review_requested_at,
-        review_requested_by,
-        reviewer_decision,
-        reviewer_notes_json,
-        created_at,
-        updated_at,
-        resolved_at
-      FROM improvement_backlog
-      WHERE id = ?
-      LIMIT 1
-    `).get(normalizedId);
-    if (!row) {
-      return null;
-    }
-    return {
-      ...row,
-      evidence: parseJsonObject(row.evidence_json),
-      trace: parseJsonObject(row.trace_json),
-      reviewer_notes: parseJsonObject(row.reviewer_notes_json),
-    };
-  }
-
-  setImprovementArtifactProposal({
-    id,
-    proposalType,
-    proposalPath,
-    proposalHash,
-    reviewState = IMPROVEMENT_REVIEW_STATE.DRAFT,
-    reviewRequestedAt = null,
-    reviewRequestedBy = null,
-    reviewerDecision = null,
-    reviewerNotes = {},
-  }) {
-    this.ensureOpen();
-    setImprovementArtifactProposalImpl(this.db, {
-      id,
-      proposalType,
-      proposalPath,
-      proposalHash,
-      reviewState,
-      reviewRequestedAt,
-      reviewRequestedBy,
-      reviewerDecision,
-      reviewerNotes,
-    });
-  }
-
-  listImprovementArtifacts({
-    sourceKind,
-    sourceCaseId,
-    status,
-    reviewState,
-    hasProposal,
-    updatedBefore,
-    repository,
-    sort = "updated_desc",
-    limit = 10,
-  } = {}) {
-    this.ensureOpen();
-    const { where, params } = buildImprovementArtifactFilters({
-      sourceKind,
-      sourceCaseId,
-      status,
-      reviewState,
-      hasProposal,
-      updatedBefore,
-      repository,
-    });
-    params.push(limit);
-    const rows = this.db.prepare(`
-      SELECT
-        id,
-        source_case_id,
-        source_kind,
-        title,
-        summary,
-        evidence_json,
-        trace_json,
-        status,
-        linked_memory_id,
-        repository,
-        superseded_by,
-        proposal_type,
-        proposal_path,
-        proposal_hash,
-        review_state,
-        review_requested_at,
-        review_requested_by,
-        reviewer_decision,
-        reviewer_notes_json,
-        created_at,
-        updated_at,
-        resolved_at
-      FROM improvement_backlog
-      ${where.length > 0 ? `WHERE ${where.join(" AND ")}` : ""}
-      ORDER BY updated_at ${sort === "updated_asc" ? "ASC" : "DESC"}
-      LIMIT ?
-    `).all(...params);
-    return rows.map((row) => ({
-      ...row,
-      evidence: parseJsonObject(row.evidence_json),
-      trace: parseJsonObject(row.trace_json),
-      reviewer_notes: parseJsonObject(row.reviewer_notes_json),
-    }));
-  }
-
-  countGeneratedSemanticMemoriesBySession(sessionId) {
-    this.ensureOpen();
-    return this.db.prepare(`
-      SELECT COUNT(*) AS count
-      FROM semantic_memory
-      WHERE source_session_id = ?
-        AND superseded_by IS NULL
-        AND COALESCE(json_extract(metadata_json, '$.source'), '') NOT IN ('memory_save', 'lore_retain', 'onboarding', 'pi', 'pi:command')
-    `).get(sessionId).count;
-  }
-
-  getEpisodeDigestBySession(sessionId) {
-    this.ensureOpen();
-    return this.db.prepare(`
-      SELECT id, session_id, scope, scope_source, repository, updated_at
-      FROM episode_digest
-      WHERE session_id = ?
-    `).get(sessionId);
-  }
-
-  createBackfillRun({
-    strategy = "session_refresh",
-    dryRun = false,
-    repository = null,
-    includeOtherRepositories = false,
-    refreshExisting = true,
-    batchSize = 10,
-    totalCandidates = 0,
-    snapshotPath = null,
-    metadata = {},
-  }) {
-    this.ensureOpen();
-    const id = crypto.randomUUID();
-    const timestamp = nowIso();
-    this.db.prepare(`
-      INSERT INTO backfill_run (
-        id, strategy, status, dry_run, repository, include_other_repositories, refresh_existing,
-        batch_size, total_candidates, snapshot_path, metadata_json, started_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      id,
-      strategy,
-      dryRun ? "preview" : "running",
-      dryRun ? 1 : 0,
-      normalizeRepository(repository),
-      includeOtherRepositories ? 1 : 0,
-      refreshExisting ? 1 : 0,
-      batchSize,
-      totalCandidates,
-      snapshotPath,
-      JSON.stringify(metadata),
-      timestamp,
-      timestamp,
-    );
-    return id;
-  }
-
-  insertBackfillRunItems(runId, items) {
-    this.ensureOpen();
-    const insert = this.db.prepare(`
-      INSERT INTO backfill_run_item (
-        run_id, session_id, repository, ordinal, planned_action, status
-      ) VALUES (?, ?, ?, ?, ?, 'pending')
-    `);
-    for (const item of items) {
-      insert.run(
-        runId,
-        item.sessionId,
-        normalizeRepository(item.repository),
-        item.ordinal,
-        item.plannedAction,
-      );
-    }
-  }
-
-  getBackfillRun(runId) {
-    this.ensureOpen();
-    return this.db.prepare(`
-      SELECT
-        id, strategy, status, dry_run, repository, include_other_repositories,
-        refresh_existing, batch_size, total_candidates, processed_count,
-        created_episode_count, refreshed_episode_count, skipped_count,
-        failed_count, snapshot_path, metadata_json, started_at, updated_at,
-        completed_at, last_error
-      FROM backfill_run
-      WHERE id = ?
-    `).get(runId);
-  }
-
-  listBackfillRunItems({ runId, statuses = [], limit = 10 }) {
-    this.ensureOpen();
-    const params = [runId];
-    let sql = `
-      SELECT
-        run_id, session_id, repository, ordinal, planned_action, status,
-        semantic_before_count, semantic_after_count, semantic_delta,
-        episode_before_scope, episode_after_scope, processed_at, error
-      FROM backfill_run_item
-      WHERE run_id = ?
-    `;
-    if (Array.isArray(statuses) && statuses.length > 0) {
-      sql += ` AND status IN (${statuses.map(() => "?").join(", ")}) `;
-      params.push(...statuses);
-    }
-    sql += ` ORDER BY ordinal ASC LIMIT ? `;
-    params.push(limit);
-    return this.db.prepare(sql).all(...params);
-  }
-
-  updateBackfillRunItem({
-    runId,
-    sessionId,
-    status,
-    semanticBeforeCount = null,
-    semanticAfterCount = null,
-    semanticDelta = null,
-    episodeBeforeScope = null,
-    episodeAfterScope = null,
-    error = null,
-  }) {
-    this.ensureOpen();
-    this.db.prepare(`
-      UPDATE backfill_run_item
-      SET status = ?,
-          semantic_before_count = ?,
-          semantic_after_count = ?,
-          semantic_delta = ?,
-          episode_before_scope = ?,
-          episode_after_scope = ?,
-          processed_at = ?,
-          error = ?
-      WHERE run_id = ? AND session_id = ?
-    `).run(
-      status,
-      semanticBeforeCount,
-      semanticAfterCount,
-      semanticDelta,
-      episodeBeforeScope,
-      episodeAfterScope,
-      nowIso(),
-      error,
-      runId,
-      sessionId,
-    );
-  }
-
-  getBackfillRunCounts(runId) {
-    return this.db.prepare(`
-      SELECT
-        SUM(CASE WHEN status IN ('completed', 'skipped', 'failed') THEN 1 ELSE 0 END) AS processed_count,
-        SUM(CASE WHEN status = 'failed' THEN 1 ELSE 0 END) AS failed_count,
-        SUM(CASE WHEN planned_action = 'create' AND status = 'completed' THEN 1 ELSE 0 END) AS created_episode_count,
-        SUM(CASE WHEN planned_action = 'refresh' AND status = 'completed' THEN 1 ELSE 0 END) AS refreshed_episode_count,
-        SUM(CASE WHEN status = 'skipped' THEN 1 ELSE 0 END) AS skipped_count,
-        SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pending_count
-      FROM backfill_run_item
-      WHERE run_id = ?
-    `).get(runId);
-  }
-
-  deriveBackfillRunStatus(counts) {
-    if ((counts?.pending_count ?? 0) > 0) {
-      return "running";
-    }
-    if ((counts?.failed_count ?? 0) > 0) {
-      return "failed";
-    }
-    return "completed";
-  }
-
-  deriveBackfillRunLastError(runId, lastError) {
-    if (typeof lastError === "string" && lastError.length > 0) {
-      return lastError;
-    }
-    return this.db.prepare(`
-      SELECT error
-      FROM backfill_run_item
-      WHERE run_id = ?
-        AND status = 'failed'
-        AND error IS NOT NULL
-        AND error != ''
-      ORDER BY COALESCE(processed_at, '') DESC, ordinal DESC
-      LIMIT 1
-    `).get(runId)?.error ?? null;
-  }
-
-  buildBackfillRunSummaryUpdate(runId, { lastError = null } = {}) {
-    return buildBackfillRunSummaryUpdateImpl(this.db, runId, { lastError });
-  }
-
-  writeBackfillRunSummary(runId, summaryUpdate) {
-    this.db.prepare(`
-      UPDATE backfill_run
-      SET status = ?,
-          processed_count = ?,
-          created_episode_count = ?,
-          refreshed_episode_count = ?,
-          skipped_count = ?,
-          failed_count = ?,
-          completed_at = COALESCE(?, completed_at),
-          updated_at = ?,
-          last_error = COALESCE(?, last_error)
-      WHERE id = ?
-    `).run(
-      summaryUpdate.status,
-      summaryUpdate.processedCount,
-      summaryUpdate.createdEpisodeCount,
-      summaryUpdate.refreshedEpisodeCount,
-      summaryUpdate.skippedCount,
-      summaryUpdate.failedCount,
-      summaryUpdate.completedAt,
-      summaryUpdate.updatedAt,
-      summaryUpdate.lastError,
-      runId,
-    );
-  }
-
-  refreshBackfillRunSummary(runId, options = {}) {
-    this.ensureOpen();
-    const summaryUpdate = this.buildBackfillRunSummaryUpdate(runId, options);
-    this.writeBackfillRunSummary(runId, summaryUpdate);
-    return this.getBackfillRun(runId);
-  }
-
-  listBackfillRuns({ limit = 10 }) {
-    this.ensureOpen();
-    return this.db.prepare(`
-      SELECT
-        id, strategy, status, dry_run, repository, include_other_repositories,
-        refresh_existing, batch_size, total_candidates, processed_count,
-        created_episode_count, refreshed_episode_count, skipped_count,
-        failed_count, snapshot_path, started_at, updated_at, completed_at, last_error
-      FROM backfill_run
-      ORDER BY updated_at DESC
-      LIMIT ?
-    `).all(limit);
-  }
-
-  createMaintenanceRun({
-    trigger,
-    repository = null,
-    dryRun = false,
-    plannedTasks = [],
-  }) {
-    this.ensureOpen();
-    const id = crypto.randomUUID();
-    const timestamp = nowIso();
-    this.db.prepare(`
-      INSERT INTO maintenance_run (
-        id, trigger, repository, dry_run, status, planned_tasks_json, summary_json,
-        started_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      id,
-      String(trigger || "manual"),
-      normalizeRepository(repository),
-      dryRun ? 1 : 0,
-      dryRun ? "planned" : "running",
-      JSON.stringify(ensureArray(plannedTasks)),
-      JSON.stringify({}),
-      timestamp,
-      timestamp,
-    );
-    return id;
-  }
-
-  reclaimStaleMaintenanceRuns({ staleAfterMs = 30 * 60 * 1000 } = {}) {
-    this.ensureOpen();
-    const numericStaleAfterMs = Number(staleAfterMs);
-    const boundedStaleAfterMs = Number.isFinite(numericStaleAfterMs)
-      ? Math.max(1, numericStaleAfterMs)
-      : 30 * 60 * 1000;
-    const staleCutoff = new Date(Date.now() - boundedStaleAfterMs).toISOString();
-    const recoveredAt = nowIso();
-    const staleRuns = this.db.prepare(`
-      SELECT id, repository, planned_tasks_json, started_at, updated_at
-      FROM maintenance_run
-      WHERE status = 'running'
-        AND updated_at < ?
-      ORDER BY updated_at ASC
-    `).all(staleCutoff);
-    if (staleRuns.length === 0) {
-      return 0;
-    }
-
-    const updateRun = this.db.prepare(`
-      UPDATE maintenance_run
-      SET status = 'failed',
-          summary_json = ?,
-          failed_count = ?,
-          completed_at = ?,
-          updated_at = ?
-      WHERE id = ?
-        AND status = 'running'
-    `);
-    const updateTaskState = this.db.prepare(`
-      UPDATE maintenance_task_state
-      SET last_status = 'failed',
-          last_trigger = 'recovery',
-          last_repository = ?,
-          last_started_at = ?,
-          last_completed_at = ?,
-          last_duration_ms = 0,
-          total_runs = total_runs + 1,
-          total_failures = total_failures + 1,
-          last_summary_json = ?,
-          updated_at = ?
-      WHERE task_name = ?
-        AND last_status = 'running'
-        AND (last_started_at IS NULL OR last_started_at <= ?)
-    `);
-
-    this.db.exec("BEGIN IMMEDIATE");
-    try {
-      let recoveredCount = 0;
-      for (const run of staleRuns) {
-        const plannedTasks = parseJsonArray(run.planned_tasks_json)
-          .filter((taskName) => typeof taskName === "string" && taskName.length > 0);
-        const summary = {
-          recovery: "stale maintenance run reclaimed",
-          originalStatus: "running",
-          startedAt: run.started_at ?? null,
-          lastUpdatedAt: run.updated_at ?? null,
-          recoveredAt,
-          plannedTasks,
-        };
-        const failedCount = Math.max(1, plannedTasks.length);
-        const updated = updateRun.run(
-          JSON.stringify(summary),
-          failedCount,
-          recoveredAt,
-          recoveredAt,
-          run.id,
-        );
-        if (updated.changes === 0) {
-          continue;
-        }
-        recoveredCount += 1;
-        for (const taskName of plannedTasks) {
-          updateTaskState.run(
-            normalizeRepository(run.repository),
-            recoveredAt,
-            recoveredAt,
-            JSON.stringify(summary),
-            recoveredAt,
-            taskName,
-            run.updated_at ?? recoveredAt,
-          );
-        }
-      }
-      this.db.exec("COMMIT");
-      return recoveredCount;
-    } catch (error) {
-      try {
-        this.db.exec("ROLLBACK");
-      } catch {
-        // best-effort rollback before surfacing the original failure
-      }
-      throw error;
-    }
-  }
-
-  completeMaintenanceRun({
-    runId,
-    status,
-    repository = null,
-    completedAt = null,
-    completedCount = 0,
-    needsAttentionCount = 0,
-    failedCount = 0,
-    skippedCount = 0,
-    summary = {},
-  }) {
-    this.ensureOpen();
-    const result = this.db.prepare(`
-      UPDATE maintenance_run
-      SET status = ?,
-          summary_json = ?,
-          completed_count = ?,
-          needs_attention_count = ?,
-          failed_count = ?,
-          skipped_count = ?,
-          completed_at = ?,
-          updated_at = ?
-      WHERE id = ?
-        AND status = 'running'
-    `).run(
-      String(status || "completed"),
-      JSON.stringify(summary ?? {}),
-      completedCount,
-      needsAttentionCount,
-      failedCount,
-      skippedCount,
-      completedAt,
-      nowIso(),
-      runId,
-    );
-    if (completedAt && result.changes > 0) {
-      this.upsertActivitySuccess({
-        repository,
-        updates: {
-          lastMaintenanceCompletionAt: completedAt,
-          lastMaintenanceStatus: String(status || "completed"),
-          lastMaintenanceRunId: runId,
-        },
-      });
-      this.upsertActivitySuccess({
-        repository: null,
-        updates: {
-          lastMaintenanceCompletionAt: completedAt,
-          lastMaintenanceStatus: String(status || "completed"),
-          lastMaintenanceRunId: runId,
-        },
-      });
-    }
-  }
-
-  listMaintenanceRuns({ limit = 10 } = {}) {
-    this.ensureOpen();
-    const rows = this.db.prepare(`
-      SELECT
-        id, trigger, repository, dry_run, status, planned_tasks_json, summary_json,
-        completed_count, needs_attention_count, failed_count, skipped_count,
-        started_at, updated_at, completed_at
-      FROM maintenance_run
-      ORDER BY updated_at DESC
-      LIMIT ?
-    `).all(limit);
-    return rows.map((row) => ({
-      ...row,
-      plannedTasks: parseJsonArray(row.planned_tasks_json),
-      summary: parseJsonObject(row.summary_json),
-    }));
-  }
-
-  listMaintenanceTaskStates() {
-    this.ensureOpen();
-    const rows = this.db.prepare(`
-      SELECT
-        task_name, last_status, last_trigger, last_repository, last_started_at,
-        last_completed_at, last_duration_ms, cursor, total_runs, total_failures,
-        total_needs_attention, last_summary_json, updated_at
-      FROM maintenance_task_state
-      ORDER BY task_name ASC
-    `).all();
-    return rows.map((row) => ({
-      ...row,
-      lastSummary: parseJsonObject(row.last_summary_json),
-    }));
-  }
-
-  recordMaintenanceTaskStart({
-    taskName,
-    trigger,
-    repository = null,
-    startedAt = nowIso(),
-  }) {
-    this.ensureOpen();
-    this.db.prepare(`
-      INSERT INTO maintenance_task_state (
-        task_name, last_status, last_trigger, last_repository, last_started_at,
-        last_completed_at, last_duration_ms, cursor, total_runs, total_failures,
-        total_needs_attention, last_summary_json, updated_at
-      ) VALUES (?, 'running', ?, ?, ?, NULL, 0, 0, 0, 0, 0, '{}', ?)
-      ON CONFLICT(task_name) DO UPDATE SET
-        last_status = 'running',
-        last_trigger = excluded.last_trigger,
-        last_repository = excluded.last_repository,
-        last_started_at = excluded.last_started_at,
-        updated_at = excluded.updated_at
-    `).run(
-      taskName,
-      String(trigger || "manual"),
-      normalizeRepository(repository),
-      startedAt,
-      startedAt,
-    );
-  }
-
-  recordMaintenanceTaskResult({
-    taskName,
-    status,
-    trigger,
-    repository = null,
-    startedAt = null,
-    completedAt = nowIso(),
-    durationMs = 0,
-    cursor = 0,
-    summary = {},
-  }) {
-    this.ensureOpen();
-    const normalizedStatus = String(status || "completed");
-    this.db.prepare(`
-      INSERT INTO maintenance_task_state (
-        task_name, last_status, last_trigger, last_repository, last_started_at,
-        last_completed_at, last_duration_ms, cursor, total_runs, total_failures,
-        total_needs_attention, last_summary_json, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?)
-      ON CONFLICT(task_name) DO UPDATE SET
-        last_status = excluded.last_status,
-        last_trigger = excluded.last_trigger,
-        last_repository = excluded.last_repository,
-        last_started_at = COALESCE(excluded.last_started_at, maintenance_task_state.last_started_at),
-        last_completed_at = excluded.last_completed_at,
-        last_duration_ms = excluded.last_duration_ms,
-        cursor = excluded.cursor,
-        total_runs = maintenance_task_state.total_runs + 1,
-        total_failures = maintenance_task_state.total_failures
-          + CASE WHEN excluded.last_status = 'failed' THEN 1 ELSE 0 END,
-        total_needs_attention = maintenance_task_state.total_needs_attention
-          + CASE WHEN excluded.last_status = 'needs_attention' THEN 1 ELSE 0 END,
-        last_summary_json = excluded.last_summary_json,
-        updated_at = excluded.updated_at
-      WHERE maintenance_task_state.last_started_at IS NULL
-        OR maintenance_task_state.last_started_at = excluded.last_started_at
-    `).run(
-      taskName,
-      normalizedStatus,
-      String(trigger || "manual"),
-      normalizeRepository(repository),
-      startedAt,
-      completedAt,
-      clampInteger(durationMs, 0, { min: 0, max: 24 * 60 * 60 * 1000 }),
-      clampInteger(cursor, 0, { min: 0, max: Number.MAX_SAFE_INTEGER }),
-      normalizedStatus === "failed" ? 1 : 0,
-      normalizedStatus === "needs_attention" ? 1 : 0,
-      JSON.stringify(summary ?? {}),
-      completedAt,
-    );
-  }
-
-  buildSemanticMemoryWriteContext(memory, timestamp) {
-    const classification = classifySemanticMemory(memory);
-    const evidence = normalizeEvidence({
-      sessionId: memory.sourceSessionId,
-      memory,
-      repository: classification.repository,
-    });
-    return {
-      id: memory.id ?? crypto.randomUUID(),
-      type: memory.type,
-      content: memory.content,
-      classification,
-      repository: normalizeRepository(classification.repository),
-      scope: classification.scope,
-      domainKey: normalizeText(memory.domainKey).toLowerCase() || null,
-      tagsText: Array.isArray(memory.tags) ? memory.tags.join(" ") : "",
-      sourceText: typeof classification.metadata?.source === "string" ? classification.metadata.source : "",
-      canonicalKey: buildSemanticCanonicalKey({
-        ...memory,
-        metadata: classification.metadata,
-        content: memory.content,
-        type: memory.type,
-      }),
-      incomingReinforcement: Number.isInteger(memory.reinforcementCount)
-        ? Math.max(1, memory.reinforcementCount)
-        : 1,
-      incomingLastSeenAt: memory.lastSeenAt ?? timestamp,
-      incomingConfidence: typeof memory.confidence === "number" ? memory.confidence : 1.0,
-      insertedUpdatedAt: resolveTimestamp(memory.updatedAt, timestamp),
-      evidence,
-      explicitWrite: isExplicitLifecycleWrite(memory, classification.metadata),
-      hasExpiresAt: Object.hasOwn(memory ?? {}, "expiresAt") || Object.hasOwn(memory ?? {}, "expires_at"),
-      expiresAt: Object.hasOwn(memory ?? {}, "expiresAt") ? memory.expiresAt : memory.expires_at,
-    };
-  }
-
-  findActiveSuppression(write) {
-    return findLifecycleSuppression(this, write);
-  }
-
-  isMemorySuppressed(id) {
-    return !!this.db.prepare(`
-      SELECT 1 FROM memory_suppression
-      WHERE memory_id = ? AND superseded_at IS NULL AND COALESCE(repair_candidate, 0) = 0
-      LIMIT 1
-    `).get(id);
-  }
-
-  listActiveMemorySuppressions() {
-    this.ensureOpen();
-    return this.db.prepare(`
-      SELECT memory_id, canonical_fingerprint, evidence_fingerprint, scope, repository
-      FROM memory_suppression
-      WHERE superseded_at IS NULL AND COALESCE(repair_candidate, 0) = 0
-    `).all();
-  }
-
-  findManualSemanticMemoryMatch(memory, canonicalKey, scope, repository) {
-    return this.db.prepare(`
-      SELECT
-        id, tags, metadata_json, scope, repository, scope_source, confidence,
-        reinforcement_count, last_seen_at, expires_at
-      FROM semantic_memory
-      WHERE superseded_by IS NULL
-        AND type = ?
-        AND (
-          (? IS NOT NULL AND canonical_key = ?)
-          OR (canonical_key IS NULL AND content = ?)
-        )
-        AND scope_source = 'manual'
-        AND scope = ?
-        AND IFNULL(repository, '') = IFNULL(?, '')
-      ORDER BY CASE WHEN canonical_key IS NOT NULL THEN 0 ELSE 1 END, updated_at DESC
-      LIMIT 1
-    `).get(
-      memory.type,
-      canonicalKey,
-      canonicalKey,
-      memory.content,
-      scope,
-      repository,
-    );
-  }
-
-  findScopedSemanticMemoryMatch(memory, canonicalKey, scope, repository) {
-    return this.db.prepare(`
-      SELECT id, content, tags, metadata_json, scope_source, reinforcement_count, last_seen_at, expires_at
-      FROM semantic_memory
-      WHERE superseded_by IS NULL
-        AND type = ?
-        AND (
-          (? IS NOT NULL AND canonical_key = ?)
-          OR (canonical_key IS NULL AND content = ?)
-        )
-        AND scope = ?
-        AND IFNULL(repository, '') = IFNULL(?, '')
-      ORDER BY CASE WHEN canonical_key IS NOT NULL THEN 0 ELSE 1 END, updated_at DESC
-      LIMIT 1
-    `).get(
-      memory.type,
-      canonicalKey,
-      canonicalKey,
-      memory.content,
-      scope,
-      repository,
-    );
-  }
-
-  buildSemanticMemoryMetadata(existingMetadata, domainKey, classificationMetadata, evidence = null) {
-    return {
-      ...existingMetadata,
-      ...(domainKey ? { domainKey } : {}),
-      ...classificationMetadata,
-      ...(evidence ? {
-        evidence: {
-          key: evidence.key,
-          sourceRecordId: evidence.sourceRecordId,
-          sourceKind: evidence.sourceKind,
-          revision: evidence.revision,
-          contentHash: evidence.contentHash,
-        },
-      } : {}),
-    };
-  }
-
-  updateManualSemanticMemoryMatch(memory, write, timestamp, match) {
-    const mergedMetadata = this.buildSemanticMemoryMetadata(
-      parseJsonObject(match.metadata_json),
-      write.domainKey,
-      write.classification.metadata,
-      write.explicitWrite ? null : write.evidence,
-    );
-    this.db.prepare(`
-      UPDATE semantic_memory
-      SET confidence = MAX(confidence, ?),
-          updated_at = ?,
-          source_session_id = COALESCE(?, source_session_id),
-          source_turn_index = COALESCE(?, source_turn_index),
-          domain_key = COALESCE(?, domain_key),
-          tags = ?,
-          metadata_json = ?,
-          canonical_key = COALESCE(canonical_key, ?),
-          reinforcement_count = MAX(1, COALESCE(reinforcement_count, 1) + ?),
-          expires_at = CASE WHEN ? = 1 THEN ? ELSE expires_at END,
-          ${LAST_SEEN_AT_CASE_SQL}
-      WHERE id = ?
-    `).run(
-      write.incomingConfidence,
-      timestamp,
-      memory.sourceSessionId ?? null,
-      Number.isInteger(memory.sourceTurnIndex) ? memory.sourceTurnIndex : null,
-      write.domainKey,
-      mergeTagText(match.tags, write.tagsText),
-      JSON.stringify(mergedMetadata),
-      write.canonicalKey,
-      write.incomingReinforcement,
-      write.hasExpiresAt ? 1 : 0,
-      write.hasExpiresAt ? write.expiresAt ?? null : null,
-      ...lastSeenAtParams(write.incomingLastSeenAt),
-      match.id,
-    );
-    return match.id;
-  }
-
-  updateProtectedSemanticMemoryMatch(existing) {
-    // Inferred evidence can share an explicit proposition, but it must not
-    // rewrite the explicit row's provenance, confidence, or reinforcement.
-    return existing.id;
-  }
-
-  updateScopedSemanticMemoryMatch(memory, existing, write, timestamp) {
-    const mergedMetadata = this.buildSemanticMemoryMetadata(
-      parseJsonObject(existing.metadata_json),
-      write.domainKey,
-      write.classification.metadata,
-      write.explicitWrite ? null : write.evidence,
-    );
-    this.db.prepare(`
-      UPDATE semantic_memory
-      SET confidence = ?,
-          updated_at = ?,
-          source_session_id = COALESCE(?, source_session_id),
-          source_turn_index = COALESCE(?, source_turn_index),
-          domain_key = COALESCE(?, domain_key),
-          tags = ?,
-          metadata_json = ?,
-          canonical_key = COALESCE(canonical_key, ?),
-          reinforcement_count = MAX(1, COALESCE(reinforcement_count, 1) + ?),
-          expires_at = CASE WHEN ? = 1 THEN ? ELSE expires_at END,
-          ${LAST_SEEN_AT_CASE_SQL}
-      WHERE id = ?
-    `).run(
-      write.incomingConfidence,
-      timestamp,
-      memory.sourceSessionId ?? null,
-      Number.isInteger(memory.sourceTurnIndex) ? memory.sourceTurnIndex : null,
-      write.domainKey,
-      mergeTagText(existing.tags, write.tagsText),
-      JSON.stringify(mergedMetadata),
-      write.canonicalKey,
-      write.incomingReinforcement,
-      write.hasExpiresAt ? 1 : 0,
-      write.hasExpiresAt ? write.expiresAt ?? null : null,
-      ...lastSeenAtParams(write.incomingLastSeenAt),
-      existing.id,
-    );
-    return existing.id;
-  }
-
-  insertNewSemanticMemory(memory, write, timestamp) {
-    const expiresAt = write.hasExpiresAt
-      ? write.expiresAt ?? null
-      : defaultVolatileExpiry(memory.type, timestamp);
-    this.db.prepare(`
-      INSERT INTO semantic_memory (
-        id, type, content, confidence, source_session_id, source_turn_index,
-        scope, repository, domain_key, tags, created_at, updated_at, superseded_by, canonical_key,
-        reinforcement_count, last_seen_at, expires_at, metadata_json
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      write.id,
-      memory.type,
-      memory.content,
-      write.incomingConfidence,
-      memory.sourceSessionId ?? null,
-      Number.isInteger(memory.sourceTurnIndex) ? memory.sourceTurnIndex : null,
-      write.scope,
-      write.repository,
-      write.domainKey,
-      write.tagsText,
-      memory.createdAt ?? timestamp,
-      write.insertedUpdatedAt,
-      memory.supersededBy ?? null,
-      write.canonicalKey,
-      write.incomingReinforcement,
-      write.incomingLastSeenAt,
-      expiresAt,
-      JSON.stringify(this.buildSemanticMemoryMetadata({}, write.domainKey, write.classification.metadata,
-        write.explicitWrite ? null : write.evidence)),
-    );
-    return write.id;
-  }
-
-  upsertManualSemanticMemory(memory, write, timestamp) {
-    const manualScopeMatch = this.findManualSemanticMemoryMatch(memory, write.canonicalKey, write.scope, write.repository);
-    if (!manualScopeMatch?.id) return null;
-    return write.explicitWrite
-      ? this.updateManualSemanticMemoryMatch(memory, write, timestamp, manualScopeMatch)
-      : this.updateProtectedSemanticMemoryMatch(manualScopeMatch, write, timestamp);
-  }
-
-  upsertScopedSemanticMemory(memory, write, timestamp) {
-    const existing = this.findScopedSemanticMemoryMatch(
-      memory,
-      write.canonicalKey,
-      write.scope,
-      write.repository,
-    );
-    if (!existing?.id) {
-      return null;
-    }
-    // An explicit save is an intentional restore. Keep the suppressed
-    // generated row immutable and create a fresh manual row so retrieval can
-    // distinguish the restoration from the forgotten proposition.
-    if (write.explicitWrite && (this.isMemorySuppressed(existing.id) || this.findActiveSuppression(write))) {
-      return null;
-    }
-    const existingMetadata = parseJsonObject(existing.metadata_json);
-    const manualExisting = ["memory_save", "lore_retain", "onboarding", "pi", "pi:command"].includes(existingMetadata.source);
-    const manualIncoming = write.explicitWrite;
-    const lockedScope = normalizeScopeSource(existing.scope_source) === SCOPE_SOURCE.MANUAL;
-    if ((manualExisting || lockedScope) && !manualIncoming) return this.updateProtectedSemanticMemoryMatch(existing, write, timestamp);
-    if (write.preserveProposition && existing.content !== memory.content) return null;
-    return this.updateScopedSemanticMemoryMatch(memory, existing, write, timestamp);
-  }
-
-  insertSemanticMemory(memory, { preserveProposition = false } = {}) {
-    this.ensureOpen();
-    const timestamp = nowIso();
-    const write = this.buildSemanticMemoryWriteContext(memory, timestamp);
-    if (write.hasExpiresAt && write.expiresAt !== null && write.expiresAt !== undefined
-      && (typeof write.expiresAt !== "string" || !Number.isFinite(Date.parse(write.expiresAt)))) {
-      throw new Error("expiresAt must be a valid timestamp or null");
-    }
-    if (typeof write.expiresAt === "string") write.expiresAt = new Date(write.expiresAt).toISOString();
-    write.preserveProposition = preserveProposition;
-    if (!write.explicitWrite && this.findActiveSuppression(write)) {
-      return null;
-    }
-    const id = this.upsertManualSemanticMemory(memory, write, timestamp)
-      ?? this.upsertScopedSemanticMemory(memory, write, timestamp)
-      ?? this.insertNewSemanticMemory(memory, write, timestamp);
-    if (this.pendingSemanticDurability) this.pendingSemanticDurability.add(id);
-    else this.verifySemanticMemoryDurability(id);
-    return id;
+  getStats(...args) {
+    return getStats(this, ...args);
+  }
+
+  insertIntentJournalEntry(...args) {
+    return insertIntentJournalEntry(this, ...args);
+  }
+
+  listIntentJournalEntries(...args) {
+    return listIntentJournalEntries(this, ...args);
+  }
+
+  insertTrajectoryArtifact(...args) {
+    return insertTrajectoryArtifact(this, ...args);
+  }
+
+  listTrajectoryArtifacts(...args) {
+    return listTrajectoryArtifacts(this, ...args);
+  }
+
+  upsertActivitySuccess(...args) {
+    return upsertActivitySuccess(this, ...args);
+  }
+
+  collectDirectActivityRows(...args) {
+    return collectDirectActivityRows(this, ...args);
+  }
+
+  collectFallbackActivityRows(...args) {
+    return collectFallbackActivityRows(this, ...args);
+  }
+
+  getActivityState(...args) {
+    return getActivityState(this, ...args);
+  }
+
+  deriveActivityStateFallback(...args) {
+    return deriveActivityStateFallback(this, ...args);
+  }
+
+  buildActivityFallbackScope(...args) {
+    return buildActivityFallbackScope(this, ...args);
+  }
+
+  readActivityFallbackRows(...args) {
+    return readActivityFallbackRows(this, ...args);
+  }
+
+  serializeActivityStateFallback(...args) {
+    return serializeActivityStateFallback(this, ...args);
+  }
+
+  serializeActivityFallbackContext(...args) {
+    return serializeActivityFallbackContext(this, ...args);
+  }
+
+  serializeActivityFallbackExtraction(...args) {
+    return serializeActivityFallbackExtraction(this, ...args);
+  }
+
+  serializeActivityFallbackMaintenance(...args) {
+    return serializeActivityFallbackMaintenance(this, ...args);
+  }
+
+  serializeActivityFallbackTrace(...args) {
+    return serializeActivityFallbackTrace(this, ...args);
+  }
+
+  resolveActivityFallbackUpdatedAt(...args) {
+    return resolveActivityFallbackUpdatedAt(this, ...args);
+  }
+
+  readLatestContextFallbackRow(...args) {
+    return readLatestContextFallbackRow(this, ...args);
+  }
+
+  readLatestTraceFallbackRow(...args) {
+    return readLatestTraceFallbackRow(this, ...args);
+  }
+
+  readLatestMaintenanceFallbackRow(...args) {
+    return readLatestMaintenanceFallbackRow(this, ...args);
+  }
+
+  readLatestExtractionFallbackRow(...args) {
+    return readLatestExtractionFallbackRow(this, ...args);
+  }
+
+  collectActivityFallbackTimestamps(...args) {
+    return collectActivityFallbackTimestamps(this, ...args);
+  }
+
+  buildActivityStateFallbackRow(...args) {
+    return buildActivityStateFallbackRow(this, ...args);
+  }
+
+  normalizeRetrievalTraceHook(...args) {
+    return normalizeRetrievalTraceHook(this, ...args);
+  }
+
+  normalizeRetrievalTraceScopeType(...args) {
+    return normalizeRetrievalTraceScopeType(this, ...args);
+  }
+
+  normalizeRetrievalTraceSectionTitles(...args) {
+    return normalizeRetrievalTraceSectionTitles(this, ...args);
+  }
+
+  buildRetrievalTraceSampleRecord(...args) {
+    return buildRetrievalTraceSampleRecord(this, ...args);
+  }
+
+  writeRetrievalTraceSample(...args) {
+    return writeRetrievalTraceSample(this, ...args);
+  }
+
+  insertRetrievalTraceSample(...args) {
+    return insertRetrievalTraceSample(this, ...args);
+  }
+
+  pruneRetrievalTraceSamples(...args) {
+    return pruneRetrievalTraceSamples(this, ...args);
+  }
+
+  listRetrievalTraceSamples(...args) {
+    return listRetrievalTraceSamples(this, ...args);
+  }
+
+  insertErrorTelemetry(...args) {
+    return insertErrorTelemetry(this, ...args);
+  }
+
+  pruneErrorTelemetry(...args) {
+    return pruneErrorTelemetry(this, ...args);
+  }
+
+  getSemanticMemoryByIds(...args) {
+    return getSemanticMemoryByIds(this, ...args);
+  }
+
+  getEpisodeDigestsByIds(...args) {
+    return getEpisodeDigestsByIds(this, ...args);
+  }
+
+  previewScopeChanges(...args) {
+    return previewScopeChanges(this, ...args);
+  }
+
+  insertScopeOverrideAudit(...args) {
+    return insertScopeOverrideAudit(this, ...args);
+  }
+
+  applyScopeChanges(...args) {
+    return applyScopeChanges(this, ...args);
+  }
+
+  listScopeOverrideAudit(...args) {
+    return listScopeOverrideAudit(this, ...args);
+  }
+
+  upsertImprovementArtifact(...args) {
+    return upsertImprovementArtifact(this, ...args);
+  }
+
+  updateImprovementArtifactStatus(...args) {
+    return updateImprovementArtifactStatus(this, ...args);
+  }
+
+  getImprovementArtifact(...args) {
+    return getImprovementArtifact(this, ...args);
+  }
+
+  setImprovementArtifactProposal(...args) {
+    return setImprovementArtifactProposal(this, ...args);
+  }
+
+  listImprovementArtifacts(...args) {
+    return listImprovementArtifacts(this, ...args);
+  }
+
+  countGeneratedSemanticMemoriesBySession(...args) {
+    return countGeneratedSemanticMemoriesBySession(this, ...args);
+  }
+
+  getEpisodeDigestBySession(...args) {
+    return getEpisodeDigestBySession(this, ...args);
+  }
+
+  createBackfillRun(...args) {
+    return createBackfillRun(this, ...args);
+  }
+
+  insertBackfillRunItems(...args) {
+    return insertBackfillRunItems(this, ...args);
+  }
+
+  getBackfillRun(...args) {
+    return getBackfillRun(this, ...args);
+  }
+
+  listBackfillRunItems(...args) {
+    return listBackfillRunItems(this, ...args);
+  }
+
+  updateBackfillRunItem(...args) {
+    return updateBackfillRunItem(this, ...args);
+  }
+
+  getBackfillRunCounts(...args) {
+    return getBackfillRunCounts(this, ...args);
+  }
+
+  deriveBackfillRunStatus(...args) {
+    return deriveBackfillRunStatus(this, ...args);
+  }
+
+  deriveBackfillRunLastError(...args) {
+    return deriveBackfillRunLastError(this, ...args);
+  }
+
+  buildBackfillRunSummaryUpdate(...args) {
+    return buildBackfillRunSummaryUpdate(this, ...args);
+  }
+
+  writeBackfillRunSummary(...args) {
+    return writeBackfillRunSummary(this, ...args);
+  }
+
+  refreshBackfillRunSummary(...args) {
+    return refreshBackfillRunSummary(this, ...args);
+  }
+
+  listBackfillRuns(...args) {
+    return listBackfillRuns(this, ...args);
+  }
+
+  createMaintenanceRun(...args) {
+    return createMaintenanceRun(this, ...args);
+  }
+
+  reclaimStaleMaintenanceRuns(...args) {
+    return reclaimStaleMaintenanceRuns(this, ...args);
+  }
+
+  completeMaintenanceRun(...args) {
+    return completeMaintenanceRun(this, ...args);
+  }
+
+  listMaintenanceRuns(...args) {
+    return listMaintenanceRuns(this, ...args);
+  }
+
+  listMaintenanceTaskStates(...args) {
+    return listMaintenanceTaskStates(this, ...args);
+  }
+
+  recordMaintenanceTaskStart(...args) {
+    return recordMaintenanceTaskStart(this, ...args);
+  }
+
+  recordMaintenanceTaskResult(...args) {
+    return recordMaintenanceTaskResult(this, ...args);
+  }
+
+  buildSemanticMemoryWriteContext(...args) {
+    return buildSemanticMemoryWriteContext(this, ...args);
+  }
+
+  findActiveSuppression(...args) {
+    return findActiveSuppression(this, ...args);
+  }
+
+  isMemorySuppressed(...args) {
+    return isMemorySuppressed(this, ...args);
+  }
+
+  listActiveMemorySuppressions(...args) {
+    return listActiveMemorySuppressions(this, ...args);
+  }
+
+  findManualSemanticMemoryMatch(...args) {
+    return findManualSemanticMemoryMatch(this, ...args);
+  }
+
+  findScopedSemanticMemoryMatch(...args) {
+    return findScopedSemanticMemoryMatch(this, ...args);
+  }
+
+  buildSemanticMemoryMetadata(...args) {
+    return buildSemanticMemoryMetadata(this, ...args);
+  }
+
+  updateManualSemanticMemoryMatch(...args) {
+    return updateManualSemanticMemoryMatch(this, ...args);
+  }
+
+  updateProtectedSemanticMemoryMatch(...args) {
+    return updateProtectedSemanticMemoryMatch(this, ...args);
+  }
+
+  updateScopedSemanticMemoryMatch(...args) {
+    return updateScopedSemanticMemoryMatch(this, ...args);
+  }
+
+  insertNewSemanticMemory(...args) {
+    return insertNewSemanticMemory(this, ...args);
+  }
+
+  upsertManualSemanticMemory(...args) {
+    return upsertManualSemanticMemory(this, ...args);
+  }
+
+  upsertScopedSemanticMemory(...args) {
+    return upsertScopedSemanticMemory(this, ...args);
+  }
+
+  insertSemanticMemory(...args) {
+    return insertSemanticMemory(this, ...args);
   }
 
   upsertSessionEvidence(evidence, capturedAt = nowIso()) {
@@ -3344,1988 +916,223 @@ export class LoreDb {
     return setLifecycleRepositoryMapping(this, options);
   }
 
-  // Capture hooks can race at turn/session end. Commit the complete refresh
-  // atomically, then perform the usual independent-connection durability check.
-  withSemanticMemoryTransaction(callback) {
-    this.ensureOpen();
-    if (this.pendingSemanticDurability) throw new Error("Nested semantic transactions are not supported");
-    this.db.exec("BEGIN IMMEDIATE");
-    const pending = new Set();
-    this.pendingSemanticDurability = pending;
-    let committed = false;
-    try {
-      const result = callback();
-      if (result?.then) throw new Error("Semantic transaction callbacks must be synchronous");
-      this.db.exec("COMMIT");
-      committed = true;
-      for (const id of pending) this.verifySemanticMemoryDurability(id);
-      return result;
-    } catch (error) {
-      if (!committed) this.db.exec("ROLLBACK");
-      throw error;
-    } finally {
-      this.pendingSemanticDurability = null;
-    }
+  withSemanticMemoryTransaction(...args) {
+    return withSemanticMemoryTransaction(this, ...args);
   }
 
-  // Re-reads the row via an independent connection right after writing it.
-  // A same-connection read can't catch a cross-process WAL checkpoint race
-  // (multiple Copilot CLI processes can hold lore.db open concurrently);
-  // this call, from a fresh connection, mirrors what an external reader
-  // would actually see and turns a silent data-loss into a real failure
-  // instead of a false "Retained semantic memory <id>" success message.
-  verifySemanticMemoryDurability(id) {
-    const dbPath = this.config.paths.derivedStorePath;
-    let verifyDb;
-    try {
-      verifyDb = new DatabaseSync(dbPath, { readOnly: true });
-      verifyDb.exec("PRAGMA busy_timeout = 2000;");
-      const row = verifyDb.prepare(`
-        SELECT id FROM semantic_memory WHERE id = ? LIMIT 1
-      `).get(id);
-      if (!row) {
-        throw new Error(
-          `semantic memory ${id} did not durably persist: not visible via an ` +
-          "independent connection immediately after insert. This can happen when " +
-          "multiple concurrent Copilot CLI processes hold lore.db open and a WAL " +
-          "checkpoint races an in-flight write. The memory was NOT saved - retry.",
-        );
-      }
-    } finally {
-      try {
-        verifyDb?.close();
-      } catch {
-        // best-effort close of the verification connection
-      }
-    }
+  verifySemanticMemoryDurability(...args) {
+    return verifySemanticMemoryDurability(this, ...args);
   }
 
-  upsertMemoryDomain(domain) {
-    this.ensureOpen();
-    const normalized = buildMemoryDomain(domain);
-    if (!normalized) {
-      throw new Error("invalid memory domain");
-    }
-    const timestamp = nowIso();
-    this.db.prepare(`
-      INSERT INTO memory_domain (
-        domain_key, kind, title, mission, scope, repository, directives_json,
-        disposition_json, metadata_json, status, created_at, updated_at, last_used_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(domain_key) DO UPDATE SET
-        kind = excluded.kind,
-        title = excluded.title,
-        mission = excluded.mission,
-        scope = excluded.scope,
-        repository = excluded.repository,
-        directives_json = excluded.directives_json,
-        disposition_json = excluded.disposition_json,
-        metadata_json = excluded.metadata_json,
-        status = excluded.status,
-        updated_at = excluded.updated_at,
-        last_used_at = COALESCE(excluded.last_used_at, memory_domain.last_used_at)
-    `).run(
-      normalized.domainKey,
-      normalized.kind,
-      normalized.title,
-      normalized.mission,
-      normalized.scope,
-      normalized.repository,
-      JSON.stringify(normalized.directives),
-      JSON.stringify(normalized.disposition),
-      JSON.stringify(normalized.metadata),
-      normalized.status,
-      timestamp,
-      timestamp,
-      domain.lastUsedAt ?? null,
-    );
-    return normalized.domainKey;
+  upsertMemoryDomain(...args) {
+    return upsertMemoryDomain(this, ...args);
   }
 
-  getMemoryDomain(domainKey) {
-    this.ensureOpen();
-    const normalizedDomainKey = normalizeText(domainKey).toLowerCase();
-    if (!normalizedDomainKey) {
-      return null;
-    }
-    const row = this.db.prepare(`
-      SELECT
-        domain_key, kind, title, mission, scope, repository, directives_json,
-        disposition_json, metadata_json, status, created_at, updated_at, last_used_at
-      FROM memory_domain
-      WHERE domain_key = ?
-      LIMIT 1
-    `).get(normalizedDomainKey);
-    if (!row) {
-      return null;
-    }
-    return mapMemoryDomainRow(row);
+  getMemoryDomain(...args) {
+    return getMemoryDomain(this, ...args);
   }
 
-  listMemoryDomains({ repository, includeOtherRepositories = false, scopes = [], status } = {}) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const params = [];
-    let sql = `
-      SELECT
-        domain_key, kind, title, mission, scope, repository, directives_json,
-        disposition_json, metadata_json, status, created_at, updated_at, last_used_at
-      FROM memory_domain
-      WHERE 1 = 1
-    `;
-    sql = applyScopeFilter(sql, params, repo, includeOtherRepositories);
-    if (scopes.length > 0) {
-      sql += ` AND scope IN (${scopes.map(() => "?").join(", ")}) `;
-      params.push(...scopes);
-    }
-    if (status) {
-      sql += ` AND status = ? `;
-      params.push(normalizeText(status).toLowerCase());
-    }
-    sql += ` ORDER BY updated_at DESC, domain_key ASC `;
-    return this.db.prepare(sql).all(...params).map(mapMemoryDomainRow);
+  listMemoryDomains(...args) {
+    return listMemoryDomains(this, ...args);
   }
 
-  upsertObservation(observation) {
-    this.ensureOpen();
-    const normalized = buildRefreshableObservation(observation);
-    if (!normalized) {
-      throw new Error("invalid refreshable observation");
-    }
-    const timestamp = nowIso();
-    const lastRefreshedAt = observation.lastRefreshedAt ?? timestamp;
-    this.db.prepare(`
-      INSERT INTO refreshable_observation (
-        observation_key, domain_key, title, prompt, focus, summary, confidence, scope,
-        repository, freshness_hours, status, source, trace_json, metadata_json,
-        created_at, updated_at, last_refreshed_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(observation_key) DO UPDATE SET
-        domain_key = excluded.domain_key,
-        title = excluded.title,
-        prompt = excluded.prompt,
-        focus = excluded.focus,
-        summary = excluded.summary,
-        confidence = excluded.confidence,
-        scope = excluded.scope,
-        repository = excluded.repository,
-        freshness_hours = excluded.freshness_hours,
-        status = excluded.status,
-        source = excluded.source,
-        trace_json = excluded.trace_json,
-        metadata_json = excluded.metadata_json,
-        updated_at = excluded.updated_at,
-        last_refreshed_at = excluded.last_refreshed_at
-    `).run(
-      normalized.observationKey,
-      normalized.domainKey,
-      normalized.title,
-      normalized.prompt,
-      normalized.focus,
-      normalized.summary,
-      normalized.confidence,
-      normalized.scope,
-      normalized.repository,
-      normalized.freshnessHours,
-      normalized.status,
-      normalized.source,
-      JSON.stringify(normalized.trace),
-      JSON.stringify(normalized.metadata),
-      timestamp,
-      timestamp,
-      lastRefreshedAt,
-    );
-    return normalized.observationKey;
+  upsertObservation(...args) {
+    return upsertObservation(this, ...args);
   }
 
-  getObservation(observationKey) {
-    this.ensureOpen();
-    const normalizedObservationKey = normalizeText(observationKey).toLowerCase();
-    if (!normalizedObservationKey) {
-      return null;
-    }
-    const row = this.db.prepare(`
-      SELECT
-        observation_key, domain_key, title, prompt, focus, summary, confidence, scope,
-        repository, freshness_hours, status, source, trace_json, metadata_json,
-        created_at, updated_at, last_refreshed_at
-      FROM refreshable_observation
-      WHERE observation_key = ?
-      LIMIT 1
-    `).get(normalizedObservationKey);
-    if (!row) {
-      return null;
-    }
-    return mapObservationRow(row);
+  getObservation(...args) {
+    return getObservation(this, ...args);
   }
 
-  listObservations({ repository, includeOtherRepositories = false, domainKey, scopes = [], status } = {}) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const normalizedDomainKey = normalizeText(domainKey).toLowerCase() || null;
-    const params = [];
-    let sql = `
-      SELECT
-        observation_key, domain_key, title, prompt, focus, summary, confidence, scope,
-        repository, freshness_hours, status, source, trace_json, metadata_json,
-        created_at, updated_at, last_refreshed_at
-      FROM refreshable_observation
-      WHERE 1 = 1
-    `;
-    sql = applyScopeFilter(sql, params, repo, includeOtherRepositories);
-    if (normalizedDomainKey) {
-      sql += ` AND domain_key = ? `;
-      params.push(normalizedDomainKey);
-    }
-    if (scopes.length > 0) {
-      sql += ` AND scope IN (${scopes.map(() => "?").join(", ")}) `;
-      params.push(...scopes);
-    }
-    if (status) {
-      sql += ` AND status = ? `;
-      params.push(normalizeText(status).toLowerCase());
-    }
-    sql += ` ORDER BY updated_at DESC, observation_key ASC `;
-    return this.db.prepare(sql).all(...params).map(mapObservationRow);
+  listObservations(...args) {
+    return listObservations(this, ...args);
   }
 
-  deleteGeneratedSemanticMemories(sessionId) {
-    this.ensureOpen();
-    this.db.prepare(`
-      DELETE FROM semantic_memory
-      WHERE source_session_id = ?
-        AND COALESCE(json_extract(metadata_json, '$.source'), '') NOT IN ('memory_save', 'lore_retain', 'onboarding', 'pi', 'pi:command')
-        AND COALESCE(scope_source, 'auto') != 'manual'
-    `).run(sessionId);
+  deleteGeneratedSemanticMemories(...args) {
+    return deleteGeneratedSemanticMemories(this, ...args);
   }
 
-  enqueueDeferredExtraction({
-    sessionId,
-    repository,
-    reason = "manual",
-    priority = 0,
-    delayMinutes = 0,
-    metadata = {},
-  }) {
-    this.ensureOpen();
-    const queuedAt = nowIso();
-    const availableAt = new Date(Date.now() + (delayMinutes * 60 * 1000)).toISOString();
-    this.db.prepare(`
-      INSERT INTO deferred_extraction (
-        session_id, repository, status, priority, reason, queued_at, available_at, metadata_json
-      ) VALUES (?, ?, 'pending', ?, ?, ?, ?, ?)
-      ON CONFLICT(session_id) DO UPDATE SET
-        repository = excluded.repository,
-        status = CASE
-          WHEN deferred_extraction.status = 'running' THEN deferred_extraction.status
-          ELSE 'pending'
-        END,
-        priority = CASE
-          WHEN excluded.priority > deferred_extraction.priority THEN excluded.priority
-          ELSE deferred_extraction.priority
-        END,
-        reason = excluded.reason,
-        queued_at = excluded.queued_at,
-        available_at = CASE
-          WHEN deferred_extraction.status = 'running' THEN deferred_extraction.available_at
-          ELSE excluded.available_at
-        END,
-        last_error = NULL,
-        metadata_json = excluded.metadata_json
-    `).run(
-      sessionId,
-      normalizeRepository(repository),
-      priority,
-      reason,
-      queuedAt,
-      availableAt,
-      JSON.stringify(metadata),
-    );
+  enqueueDeferredExtraction(...args) {
+    return enqueueDeferredExtraction(this, ...args);
   }
 
-  listDeferredExtractions({ repository, limit = 2 }) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const now = nowIso();
-    if (repo) {
-      return this.db.prepare(`
-        SELECT session_id, repository, status, priority, reason, queued_at, available_at, attempts, last_error, metadata_json
-        FROM deferred_extraction
-        WHERE repository = ?
-          AND status IN ('pending', 'failed')
-          AND available_at <= ?
-        ORDER BY priority DESC, available_at ASC, queued_at ASC
-        LIMIT ?
-      `).all(repo, now, limit);
-    }
-    return this.db.prepare(`
-      SELECT session_id, repository, status, priority, reason, queued_at, available_at, attempts, last_error, metadata_json
-      FROM deferred_extraction
-      WHERE status IN ('pending', 'failed')
-        AND available_at <= ?
-      ORDER BY priority DESC, available_at ASC, queued_at ASC
-      LIMIT ?
-    `).all(now, limit);
+  listDeferredExtractions(...args) {
+    return listDeferredExtractions(this, ...args);
   }
 
-  markDeferredExtractionRunning(sessionId) {
-    this.ensureOpen();
-    this.db.prepare(`
-      UPDATE deferred_extraction
-      SET status = 'running',
-          attempts = attempts + 1,
-          started_at = ?,
-          last_error = NULL
-      WHERE session_id = ?
-    `).run(nowIso(), sessionId);
+  markDeferredExtractionRunning(...args) {
+    return markDeferredExtractionRunning(this, ...args);
   }
 
-  /**
-   * Atomically claim a pending/failed deferred extraction job for exclusive
-   * processing.  Returns true when the job was successfully claimed by this
-   * caller, false when another worker already holds it or the job is not
-   * available (e.g. not yet due).
-   *
-   * The claim sets a 10-minute lease (configurable via leaseDurationMs) that
-   * must be renewed every ≤2 minutes via heartbeatDeferredExtraction.  If the
-   * lease expires, reclaimStaleDeferredExtractions will reset the job to
-   * "failed" so another worker can pick it up.
-   *
-   * @param {string} sessionId
-   * @param {string} ownerToken - Opaque token identifying the claiming worker
-   * @param {number} [leaseDurationMs=600000] - Lease TTL in milliseconds (default 10 min)
-   * @returns {boolean} true when claimed, false when already held or unavailable
-   */
-  claimDeferredExtraction(sessionId, ownerToken, leaseDurationMs = 10 * 60 * 1000) {
-    this.ensureOpen();
-    const now = nowIso();
-    const leaseExpiresAt = new Date(Date.now() + leaseDurationMs).toISOString();
-    const result = this.db.prepare(`
-      UPDATE deferred_extraction
-      SET status = 'running',
-          attempts = attempts + 1,
-          started_at = ?,
-          owner_token = ?,
-          lease_expires_at = ?,
-          heartbeat_at = ?,
-          last_error = NULL
-      WHERE session_id = ?
-        AND status IN ('pending', 'failed')
-        AND available_at <= ?
-    `).run(now, ownerToken, leaseExpiresAt, now, sessionId, now);
-    return result.changes > 0;
+  claimDeferredExtraction(...args) {
+    return claimDeferredExtraction(this, ...args);
   }
 
-  /**
-   * Renew the lease for an active deferred extraction job.  Only succeeds when
-   * the caller still owns the job (owner_token matches) and the job is still
-   * in "running" state.
-   *
-   * Must be called at least once per 10-minute lease window; a 2-minute
-   * heartbeat interval keeps the lease well within its expiry.
-   *
-   * @param {string} sessionId
-   * @param {string} ownerToken
-   * @param {number} [leaseDurationMs=600000] - Renewed lease TTL (default 10 min)
-   * @returns {boolean} true when renewed, false when the lease is already lost
-   */
-  heartbeatDeferredExtraction(sessionId, ownerToken, leaseDurationMs = 10 * 60 * 1000) {
-    this.ensureOpen();
-    const now = nowIso();
-    const leaseExpiresAt = new Date(Date.now() + leaseDurationMs).toISOString();
-    const result = this.db.prepare(`
-      UPDATE deferred_extraction
-      SET heartbeat_at = ?,
-          lease_expires_at = ?
-      WHERE session_id = ?
-        AND owner_token = ?
-        AND status = 'running'
-    `).run(now, leaseExpiresAt, sessionId, ownerToken);
-    return result.changes > 0;
+  heartbeatDeferredExtraction(...args) {
+    return heartbeatDeferredExtraction(this, ...args);
   }
 
-  /**
-   * Reclaim running deferred extraction jobs that are no longer making
-   * progress. Lease-aware jobs are reclaimed when their lease expires; legacy
-   * rows without lease metadata are reclaimed after the bounded stale window.
-   * Resets each to "failed" so the next processing cycle can retry it.
-   *
-   * @param {{ staleAfterMs?: number }} [options]
-   * @returns {number} Number of jobs reclaimed
-   */
-  reclaimStaleDeferredExtractions({ staleAfterMs = 30 * 60 * 1000 } = {}) {
-    this.ensureOpen();
-    const now = nowIso();
-    const numericStaleAfterMs = Number(staleAfterMs);
-    const boundedStaleAfterMs = Number.isFinite(numericStaleAfterMs)
-      ? Math.max(1, numericStaleAfterMs)
-      : 30 * 60 * 1000;
-    const staleCutoff = new Date(Date.now() - boundedStaleAfterMs).toISOString();
-    const result = this.db.prepare(`
-      UPDATE deferred_extraction
-      SET status = 'failed',
-          last_error = CASE
-            WHEN lease_expires_at IS NOT NULL AND lease_expires_at < ?
-              THEN 'lease expired'
-            ELSE 'stale running job reclaimed'
-          END,
-          available_at = ?,
-          completed_at = NULL,
-          owner_token = NULL,
-          lease_expires_at = NULL,
-          heartbeat_at = NULL
-      WHERE status = 'running'
-        AND (
-          (lease_expires_at IS NOT NULL AND lease_expires_at < ?)
-          OR (
-            lease_expires_at IS NULL
-            AND COALESCE(started_at, queued_at) IS NOT NULL
-            AND COALESCE(started_at, queued_at) < ?
-          )
-        )
-    `).run(now, now, now, staleCutoff);
-    return result.changes;
+  reclaimStaleDeferredExtractions(...args) {
+    return reclaimStaleDeferredExtractions(this, ...args);
   }
 
-  completeDeferredExtraction(sessionId, ownerToken = null) {
-    this.ensureOpen();
-    const completedAt = nowIso();
-    const row = this.db.prepare(`
-      SELECT repository
-      FROM deferred_extraction
-      WHERE session_id = ?
-      LIMIT 1
-    `).get(sessionId);
-    // When an ownerToken is provided, guard against stale workers completing
-    // a job that has already been reclaimed by another caller.  Without a
-    // token (legacy callers), behave as before.
-    const result = ownerToken
-      ? this.db.prepare(`
-          UPDATE deferred_extraction
-          SET status = 'completed',
-              completed_at = ?,
-              last_error = NULL
-          WHERE session_id = ?
-            AND owner_token = ?
-            AND status = 'running'
-        `).run(completedAt, sessionId, ownerToken)
-      : this.db.prepare(`
-          UPDATE deferred_extraction
-          SET status = 'completed',
-              completed_at = ?,
-              last_error = NULL
-          WHERE session_id = ?
-        `).run(completedAt, sessionId);
-    // Only update activity state when the completion actually landed.
-    if (!ownerToken || result.changes > 0) {
-      this.upsertActivitySuccess({
-        repository: row?.repository ?? null,
-        updates: {
-          lastExtractionCompletionAt: completedAt,
-          lastExtractionRepository: row?.repository ?? null,
-        },
-      });
-      this.upsertActivitySuccess({
-        repository: null,
-        updates: {
-          lastExtractionCompletionAt: completedAt,
-          lastExtractionRepository: row?.repository ?? null,
-        },
-      });
-    }
+  completeDeferredExtraction(...args) {
+    return completeDeferredExtraction(this, ...args);
   }
 
-  failDeferredExtraction(sessionId, { errorMessage, retryDelayMinutes = 15, ownerToken = null }) {
-    this.ensureOpen();
-    const availableAt = new Date(Date.now() + (retryDelayMinutes * 60 * 1000)).toISOString();
-    // Guard by ownerToken when provided so a stale worker cannot clobber the
-    // state of a job that has already been reclaimed by a new worker.
-    if (ownerToken) {
-      this.db.prepare(`
-        UPDATE deferred_extraction
-        SET status = 'failed',
-            available_at = ?,
-            last_error = ?,
-            owner_token = NULL,
-            lease_expires_at = NULL
-        WHERE session_id = ?
-          AND owner_token = ?
-          AND status = 'running'
-      `).run(availableAt, errorMessage, sessionId, ownerToken);
-    } else {
-      this.db.prepare(`
-        UPDATE deferred_extraction
-        SET status = 'failed',
-            available_at = ?,
-            last_error = ?
-        WHERE session_id = ?
-      `).run(availableAt, errorMessage, sessionId);
-    }
+  failDeferredExtraction(...args) {
+    return failDeferredExtraction(this, ...args);
   }
 
   forgetMemory({ id, supersededBy, actor = "user", reason = "manual_forget" }) {
     return forgetLifecycleMemory(this, { id, supersededBy, actor, reason });
   }
 
-  listActiveStabilisationMemories({
-    repository,
-    includeGlobal = true,
-    limit = 50,
-  } = {}) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const eligibility = buildSemanticEligibilitySql({
-      alias: "",
-      repository: repo,
-      includeOtherRepositories: false,
-    });
-    return this.db.prepare(`
-      SELECT
-        id,
-        type,
-        content,
-        scope,
-        repository,
-      confidence,
-      updated_at,
-        expires_at,
-      source_session_id,
-      metadata_json
-      FROM semantic_memory
-      WHERE ${eligibility.sql}
-        AND type IN ('open_loop', 'assistant_goal')
-        ${includeGlobal ? "" : "AND scope = 'repo'"}
-      ORDER BY updated_at DESC
-      LIMIT ?
-    `).all(
-      ...eligibility.params,
-      clampInteger(limit, 50, { min: 1, max: 200 }),
-    ).map((row) => ({
-      ...row,
-      metadata: parseJsonObject(row.metadata_json),
-    }));
+  listActiveStabilisationMemories(...args) {
+    return listActiveStabilisationMemories(this, ...args);
   }
 
-  listMemoryHygieneEpisodes({
-    repository,
-    includeOtherRepositories = true,
-    limit = 100,
-  } = {}) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const boundedLimit = clampInteger(limit, 100, { min: 1, max: 500 });
-    const mapRows = (rows) => rows.map((row) => ({
-      sessionId: row.session_id,
-      scope: row.scope,
-      repository: row.repository,
-      summary: row.summary,
-      actions: parseJsonArray(row.actions_json),
-      decisions: parseJsonArray(row.decisions_json),
-      openItems: parseJsonArray(row.open_items_json),
-      updatedAt: row.updated_at,
-    }));
-    const selectSql = `
-      SELECT
-        session_id,
-        scope,
-        repository,
-        summary,
-        actions_json,
-        decisions_json,
-        open_items_json,
-        updated_at
-      FROM episode_digest
-    `;
-    if (!includeOtherRepositories) {
-      return mapRows(this.db.prepare(`
-        ${selectSql}
-        WHERE IFNULL(repository, '') = IFNULL(?, '')
-        ORDER BY updated_at DESC
-        LIMIT ?
-      `).all(repo, boundedLimit));
-    }
-
-    const primaryLimit = Math.max(1, Math.ceil(boundedLimit / 2));
-    const otherLimit = Math.max(0, boundedLimit - primaryLimit);
-    const primaryRows = this.db.prepare(`
-      ${selectSql}
-      WHERE IFNULL(repository, '') = IFNULL(?, '')
-      ORDER BY updated_at DESC
-      LIMIT ?
-    `).all(repo, primaryLimit);
-    const otherRows = otherLimit > 0
-      ? this.db.prepare(`
-          ${selectSql}
-          WHERE IFNULL(repository, '') != IFNULL(?, '')
-          ORDER BY updated_at DESC
-          LIMIT ?
-        `).all(repo, otherLimit)
-      : [];
-    return mapRows([...primaryRows, ...otherRows]);
+  listMemoryHygieneEpisodes(...args) {
+    return listMemoryHygieneEpisodes(this, ...args);
   }
 
-  restoreMemoriesBySupersessionMarker(marker) {
-    this.ensureOpen();
-    const normalizedMarker = String(marker ?? "").trim();
-    if (!normalizedMarker.startsWith("auto-hygiene:")) {
-      throw new Error("marker must start with auto-hygiene:");
-    }
-    const rows = this.db.prepare(`
-      SELECT id
-      FROM semantic_memory
-      WHERE superseded_by = ?
-      ORDER BY id
-    `).all(normalizedMarker);
-    if (rows.length === 0) {
-      return [];
-    }
-    this.db.prepare(`
-      UPDATE semantic_memory
-      SET superseded_by = NULL, updated_at = ?
-      WHERE superseded_by = ?
-    `).run(nowIso(), normalizedMarker);
-    return rows.map((row) => row.id);
+  restoreMemoriesBySupersessionMarker(...args) {
+    return restoreMemoriesBySupersessionMarker(this, ...args);
   }
 
-  hasEpisodeDigest(sessionId) {
-    this.ensureOpen();
-    const row = this.db.prepare(`
-      SELECT id FROM episode_digest WHERE session_id = ?
-    `).get(sessionId);
-    return !!row;
+  hasEpisodeDigest(...args) {
+    return hasEpisodeDigest(this, ...args);
   }
 
-  upsertEpisodeDigest(digest) {
-    this.ensureOpen();
-    const timestamp = nowIso();
-    const classification = classifyEpisodeDigest(digest);
-    this.db.prepare(`
-      INSERT INTO episode_digest (
-        id, session_id, scope, scope_source, repository, branch, summary, actions_json, decisions_json,
-        learnings_json, files_changed_json, refs_json, significance, themes_json,
-        open_items_json, source, date_key, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      ON CONFLICT(session_id) DO UPDATE SET
-        scope = CASE
-          WHEN episode_digest.scope_source = 'manual' THEN episode_digest.scope
-          ELSE excluded.scope
-        END,
-        repository = CASE
-          WHEN episode_digest.scope_source = 'manual' THEN episode_digest.repository
-          ELSE excluded.repository
-        END,
-        branch = excluded.branch,
-        summary = excluded.summary,
-        actions_json = excluded.actions_json,
-        decisions_json = excluded.decisions_json,
-        learnings_json = excluded.learnings_json,
-        files_changed_json = excluded.files_changed_json,
-        refs_json = excluded.refs_json,
-        significance = excluded.significance,
-        themes_json = excluded.themes_json,
-        open_items_json = excluded.open_items_json,
-        source = excluded.source,
-        date_key = excluded.date_key,
-        updated_at = excluded.updated_at
-    `).run(
-      digest.id ?? digest.sessionId,
-      digest.sessionId,
-      classification.scope,
-      SCOPE_SOURCE.AUTO,
-      classification.repository,
-      digest.branch ?? null,
-      digest.summary,
-      jsonText(digest.actions),
-      jsonText(digest.decisions),
-      jsonText(digest.learnings),
-      jsonText(digest.filesChanged),
-      jsonText(digest.refs),
-      digest.significance ?? 5,
-      jsonText(digest.themes),
-      jsonText(digest.openItems),
-      digest.source ?? "rule",
-      digest.dateKey,
-      digest.createdAt ?? timestamp,
-      timestamp,
-    );
+  upsertEpisodeDigest(...args) {
+    return upsertEpisodeDigest(this, ...args);
   }
 
-  refreshDaySummary({ date, repository }) {
-    this.ensureOpen();
-    const repo = normalizeDaySummaryRepository(repository);
-    const rows = this.db.prepare(`
-      SELECT session_id, summary
-      FROM episode_digest
-      WHERE date_key = ? AND (
-        (? = '' AND (repository IS NULL OR repository = '')) OR repository = ?
-      )
-      ORDER BY updated_at DESC
-      LIMIT 8
-    `).all(date, repo, repo);
-
-    const summaries = rows
-      .map((row) => ({
-        session_id: row.session_id,
-        summary: normalizeText(row.summary),
-      }))
-      .filter((row) => row.summary.length > 0);
-
-    const preferred = summaries.some((row) => !isGenericWorkSummary(row.summary) && !isPlaceholderSummary(row.summary) && !isToolInvocationSummary(row.summary))
-      ? summaries.filter((row) => !isGenericWorkSummary(row.summary) && !isPlaceholderSummary(row.summary) && !isToolInvocationSummary(row.summary))
-      : summaries;
-
-    const summary = preferred.length === 0
-      ? "No remembered activity."
-      : preferred.map((row) => `- ${row.summary}`).join("\n");
-
-    this.db.prepare(`
-      INSERT INTO day_summary (date_key, repository, summary, episode_ids_json, computed_at)
-      VALUES (?, ?, ?, ?, ?)
-      ON CONFLICT(date_key, repository) DO UPDATE SET
-        summary = excluded.summary,
-        episode_ids_json = excluded.episode_ids_json,
-        computed_at = excluded.computed_at
-    `).run(
-      date,
-      repo,
-      summary,
-      JSON.stringify(preferred.map((row) => row.session_id)),
-      nowIso(),
-    );
+  refreshDaySummary(...args) {
+    return refreshDaySummary(this, ...args);
   }
 
-  mapRetrievalRepositories(rows, repository) {
-    if (!repository || rows.length === 0) return rows;
-    const aliases = new Set(this.db.prepare("SELECT legacy FROM repository_identity_mapping WHERE canonical = ?")
-      .all(repository).map((row) => row.legacy));
-    return rows.map((row) => aliases.has(row.repository)
-      ? { ...row, sourceRepository: row.repository, repository }
-      : row);
+  mapRetrievalRepositories(...args) {
+    return mapRetrievalRepositories(this, ...args);
   }
 
-  searchSemantic({
-    query,
-    repository,
-    includeOtherRepositories = false,
-    types = [],
-    scopes = [],
-    limit = 8,
-    includeTypedFallback = false,
-    expandAliases = true,
-    standingExtractorPolicy = false,
-    now = new Date(),
-  }) {
-    this.ensureOpen();
-    const sanitized = sanitizeNormalizedFtsQuery(query, {
-      aliases: expandAliases ? QUERY_ALIASES : {},
-      normalize: normalizeFtsToken,
-    });
-    const repo = normalizeRepository(repository);
-    const runSearch = (ftsQuery, effectiveLimit = limit, excludedIds = []) => {
-      const pageSize = Math.max(64, Math.min(256, Math.max(effectiveLimit, 8) * 8));
-      const collected = [];
-      for (let offset = 0; ; offset += pageSize) {
-        const params = [];
-        let sql = `
-        SELECT
-          sm.id,
-          sm.type,
-          sm.content,
-          sm.scope,
-          sm.scope_source,
-          sm.confidence,
-          sm.repository,
-          sm.domain_key,
-          sm.updated_at,
-          sm.source_session_id,
-          sm.canonical_key,
-          sm.superseded_by,
-          sm.reinforcement_count,
-          sm.last_seen_at,
-          sm.expires_at,
-          sm.tags,
-          sm.metadata_json
-        FROM semantic_memory sm
-        `;
-
-        if (ftsQuery) {
-          sql += ` JOIN semantic_fts ON semantic_fts.rowid = sm.rowid `;
-        }
-
-        const eligibility = buildSemanticEligibilitySql({
-        alias: "sm",
-        repository: repo,
-        includeOtherRepositories,
-        now,
-        });
-        sql += ` WHERE ${eligibility.sql} `;
-        params.push(...eligibility.params);
-
-        if (types.length > 0) {
-        sql += ` AND sm.type IN (${types.map(() => "?").join(", ")}) `;
-        params.push(...types);
-        }
-
-        if (scopes.length > 0) {
-        sql += ` AND sm.scope IN (${scopes.map(() => "?").join(", ")}) `;
-        params.push(...scopes);
-        }
-
-        if (standingExtractorPolicy) {
-        sql += ` AND COALESCE(json_extract(sm.metadata_json, '$.source'), '') = 'rule_extractor'
-          AND (
-            COALESCE(json_extract(sm.metadata_json, '$.confidenceBasis'), '') IN ('explicit_preference_sentence', 'standing_policy_sentence')
-            OR instr(' ' || lower(COALESCE(sm.tags, '')) || ' ', ' preference ') > 0
-            OR instr(' ' || lower(COALESCE(sm.tags, '')) || ' ', ' policy ') > 0
-          ) `;
-        }
-
-        if (excludedIds.length > 0) {
-        sql += ` AND sm.id NOT IN (${excludedIds.map(() => "?").join(", ")}) `;
-        params.push(...excludedIds);
-        }
-
-        if (ftsQuery) {
-        sql += ` AND semantic_fts MATCH ? `;
-        params.push(ftsQuery);
-        sql += ` ORDER BY bm25(semantic_fts), sm.updated_at DESC, sm.reinforcement_count DESC `;
-        } else {
-        sql += ` ORDER BY sm.updated_at DESC, sm.reinforcement_count DESC `;
-        }
-
-        params.push(pageSize, offset);
-        const page = this.mapRetrievalRepositories(this.db.prepare(`${sql} LIMIT ? OFFSET ?`).all(...params), repo);
-        collected.push(...page.filter((row) => isSemanticMemoryRowEligible(row, {
-          repository: repo,
-          includeOtherRepositories,
-          now,
-        }).eligible));
-        if (collected.length >= effectiveLimit || page.length < pageSize) break;
-      }
-      return collected.slice(0, effectiveLimit);
-    };
-
-    let lexicalRows = runSearch(sanitized);
-    if (sanitized && lexicalRows.length === 0) {
-      const orQuery = buildFtsOrRetryQuery(query);
-      if (orQuery && orQuery !== sanitized) {
-        lexicalRows = runSearch(orQuery);
-      }
-    }
-    const shouldRunTypedFallback = includeTypedFallback
-      && types.length > 0
-      && sanitized
-      && lexicalRows.length < limit;
-    const lexicalIds = lexicalRows.map((row) => row.id).filter(Boolean);
-    const fallbackRows = shouldRunTypedFallback
-      ? runSearch("", Math.max(1, limit - lexicalRows.length), lexicalIds)
-      : [];
-    const rows = fallbackRows.length > 0
-      ? dedupeSemanticRows([...lexicalRows, ...fallbackRows])
-      : lexicalRows;
-
-    const eligibleRows = rows.filter((row) => isSemanticMemoryRowEligible(row, {
-      repository: repo,
-      includeOtherRepositories,
-      now,
-    }).eligible);
-    return dedupeSemanticRows(eligibleRows).slice(0, limit)
-      .map((row) => ({
-        ...row,
-        domainKey: row.domain_key ?? null,
-        metadata: parseJsonObject(row.metadata_json),
-      }));
+  searchSemantic(...args) {
+    return searchSemantic(this, ...args);
   }
 
-  /**
-   * Ensure the memory_embedding table exists (semantic search cache).
-   * Additive side table owned by the semantic-search feature; created
-   * idempotently so existing databases adopt it without a full migration.
-   */
-  ensureMemoryEmbeddingTable() {
-    this.ensureOpen();
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS memory_embedding (
-        memory_id TEXT PRIMARY KEY,
-        content_hash TEXT,
-        provider TEXT,
-        model TEXT,
-        dimensions INTEGER,
-        vector TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      )
-    `);
-    // Existing databases may have the original memory_id/vector-only table.
-    // Add metadata columns in place so old rows remain readable but cannot be
-    // mistaken for a validated cache entry until they are refreshed.
-    for (const [column, definition] of [
-      ["content_hash", "TEXT"],
-      ["provider", "TEXT"],
-      ["model", "TEXT"],
-      ["dimensions", "INTEGER"],
-    ]) {
-      try {
-        this.ensureColumn("memory_embedding", column, definition);
-      } catch (error) {
-        // Another Lore process may have added the column between PRAGMA and
-        // ALTER TABLE. Re-check before surfacing a genuine schema failure.
-        if (!this.tableHasColumn("memory_embedding", column)) {
-          throw error;
-        }
-      }
-    }
+  ensureMemoryEmbeddingTable(...args) {
+    return ensureMemoryEmbeddingTable(this, ...args);
   }
 
-  /**
-   * List non-superseded semantic memories eligible for embedding-based search.
-   *
-   * @param {{ types?: string[], repository?: string | null }} [opts]
-   * @returns {Array<{ id: string, type: string, content: string, repository: string | null, updated_at: string }>}
-   */
-  listSemanticMemoriesForEmbedding({ types = [], scopes = [], repository = null, includeOtherRepositories = false, transferableFallback = false, embeddingState = "all", limit = 256, offset = null, after = null, stableOrder = false, now = new Date() } = {}) {
-    this.ensureOpen();
-    const params = [];
-    const hasEmbeddingTable = this.tableExists("memory_embedding");
-    const columns = `sm.rowid AS memory_rowid, sm.id, sm.type, sm.content, sm.repository, sm.scope, sm.scope_source, sm.updated_at,
-      sm.expires_at, sm.canonical_key, sm.metadata_json, sm.source_session_id${hasEmbeddingTable ? ", me.updated_at AS embedding_updated_at, me.vector, me.content_hash, me.provider, me.model, me.dimensions" : ""}`;
-    let sql = `SELECT ${columns} FROM semantic_memory sm ${hasEmbeddingTable ? "LEFT JOIN memory_embedding me ON me.memory_id = sm.id" : ""}`;
-    const eligibility = buildSemanticEligibilitySql({ alias: "sm", repository: normalizeRepository(repository), includeOtherRepositories, transferableFallback, now });
-    sql += ` WHERE ${eligibility.sql}`;
-    params.push(...eligibility.params);
-    if (types.length > 0) {
-      sql += ` AND sm.type IN (${types.map(() => "?").join(", ")})`;
-      params.push(...types);
-    }
-    if (scopes.length > 0) {
-      sql += ` AND sm.scope IN (${scopes.map(() => "?").join(", ")})`;
-      params.push(...scopes);
-    }
-    if (embeddingState === "missing" && hasEmbeddingTable) {
-      sql += " AND me.memory_id IS NULL";
-    } else if (embeddingState === "cached" && hasEmbeddingTable) {
-      sql += " AND me.memory_id IS NOT NULL";
-    }
-    if (after && typeof after === "object") {
-      if (stableOrder) {
-        sql += " AND (sm.updated_at > ? OR (sm.updated_at = ? AND sm.id > ?))";
-        params.push(after.updatedAt ?? "", after.updatedAt ?? "", after.id ?? "");
-      } else if (after.memoryRowid !== undefined && after.memoryRowid !== null) {
-        sql += " AND sm.rowid > ?";
-        params.push(Math.max(0, Math.trunc(Number(after.memoryRowid) || 0)));
-      } else {
-        sql += " AND (sm.updated_at > ? OR (sm.updated_at = ? AND sm.id > ?))";
-        params.push(after.updatedAt ?? "", after.updatedAt ?? "", after.id ?? "");
-      }
-    }
-    sql += stableOrder
-      ? " ORDER BY sm.updated_at ASC, sm.id ASC"
-      : hasEmbeddingTable
-      ? " ORDER BY sm.rowid ASC"
-      : " ORDER BY sm.updated_at ASC, sm.id ASC";
-    sql += " LIMIT ?";
-    params.push(Math.max(1, Math.min(256, Math.trunc(Number(limit) || 256))));
-    if ((!after || typeof after !== "object") && offset !== null) {
-      sql += " OFFSET ?";
-      params.push(Math.max(0, Math.trunc(Number(offset) || 0)));
-    }
-    return this.mapRetrievalRepositories(this.db.prepare(sql).all(...params), normalizeRepository(repository));
+  listSemanticMemoriesForEmbedding(...args) {
+    return listSemanticMemoriesForEmbedding(this, ...args);
   }
 
-  countSemanticMemoriesForEmbedding({ types = [], scopes = [], repository = null, includeOtherRepositories = false, now = new Date() } = {}) {
-    this.ensureOpen();
-    const eligibility = buildSemanticEligibilitySql({
-      alias: "sm",
-      repository: normalizeRepository(repository),
-      includeOtherRepositories,
-      now,
-    });
-    const params = [...eligibility.params];
-    let sql = `SELECT COUNT(*) AS count FROM semantic_memory sm WHERE ${eligibility.sql}`;
-    if (types.length > 0) {
-      sql += ` AND sm.type IN (${types.map(() => "?").join(", ")})`;
-      params.push(...types);
-    }
-    if (scopes.length > 0) {
-      sql += ` AND sm.scope IN (${scopes.map(() => "?").join(", ")})`;
-      params.push(...scopes);
-    }
-    return Number(this.db.prepare(sql).get(...params)?.count ?? 0);
+  countSemanticMemoriesForEmbedding(...args) {
+    return countSemanticMemoriesForEmbedding(this, ...args);
   }
 
-  /**
-   * Read the cached embedding vector for a memory, or null when absent.
-   *
-   * @param {string} memoryId
-   * @param {{ contentHash?: string, provider?: string, model?: string, dimensions?: number }} [key]
-   * @returns {string | null} JSON-encoded vector
-   */
-  getMemoryEmbedding(memoryId, key = null) {
-    this.ensureOpen();
-    const row = this.db.prepare(`
-      SELECT vector, content_hash, provider, model, dimensions
-      FROM memory_embedding
-      WHERE memory_id = ?
-    `).get(memoryId);
-    if (!row) {
-      return null;
-    }
-    if (key && (
-      row.content_hash !== key.contentHash
-      || row.provider !== key.provider
-      || row.model !== key.model
-      || Number(row.dimensions) !== Number(key.dimensions)
-    )) {
-      return null;
-    }
-    return row.vector ?? null;
+  getMemoryEmbedding(...args) {
+    return getMemoryEmbedding(this, ...args);
   }
 
-  /**
-   * Cache an embedding vector for a memory (insert or replace).
-   *
-   * @param {string} memoryId
-   * @param {number[]} vector
-   * @param {{ contentHash?: string, provider?: string, model?: string, dimensions?: number }} [key]
-   */
-  setMemoryEmbedding(memoryId, vector, key = {}) {
-    this.ensureOpen();
-    this.db.prepare(`
-      INSERT OR REPLACE INTO memory_embedding
-        (memory_id, content_hash, provider, model, dimensions, vector, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
-    `).run(
-      memoryId,
-      key.contentHash ?? null,
-      key.provider ?? null,
-      key.model ?? null,
-      Number.isInteger(Number(key.dimensions)) ? Number(key.dimensions) : null,
-      JSON.stringify(vector),
-      nowIso(),
-    );
+  setMemoryEmbedding(...args) {
+    return setMemoryEmbedding(this, ...args);
   }
 
-  searchEpisodes({ query, repository, includeOtherRepositories = false, scopes = [], limit = 5 }) {
-    this.ensureOpen();
-    const sanitized = sanitizeNormalizedFtsQuery(query, {
-      aliases: QUERY_ALIASES,
-      normalize: normalizeFtsToken,
-    });
-    const repo = normalizeRepository(repository);
-    const params = [];
-    let sql = `
-      SELECT
-        ed.id,
-        ed.session_id,
-        ed.scope,
-        ed.scope_source,
-        ed.repository,
-        ed.summary,
-        ed.actions_json,
-        ed.decisions_json,
-        ed.files_changed_json,
-        ed.themes_json,
-        ed.open_items_json,
-        ed.significance,
-        ed.date_key,
-        ed.updated_at
-      FROM episode_digest ed
-    `;
-
-    if (sanitized) {
-      sql += ` JOIN episode_fts ON episode_fts.rowid = ed.rowid `;
-    }
-
-    sql += ` WHERE 1 = 1 `;
-
-    sql = applyScopeFilter(sql, params, repo, includeOtherRepositories, "ed");
-
-    if (scopes.length > 0) {
-      sql += ` AND ed.scope IN (${scopes.map(() => "?").join(", ")}) `;
-      params.push(...scopes);
-    }
-
-    if (sanitized) {
-      sql += ` AND episode_fts MATCH ? `;
-      params.push(sanitized);
-      sql += ` ORDER BY bm25(episode_fts), ed.significance DESC, ed.updated_at DESC `;
-    } else {
-      sql += ` ORDER BY ed.updated_at DESC, ed.significance DESC `;
-    }
-
-    sql += ` LIMIT ? `;
-    params.push(limit);
-    return this.mapRetrievalRepositories(this.db.prepare(sql).all(...params), repo);
+  searchEpisodes(...args) {
+    return searchEpisodes(this, ...args);
   }
 
-  findRelevantEpisodesDetailed({ prompt, repository, includeOtherRepositories = false, scopes = [], limit = 5 }) {
-    const { entityTerms, hybridEnabled, effectivePrimaryTerms, effectiveTerms, lexicalQuery } =
-      buildEpisodeQueryTermsets(prompt, this.config);
-    const improvementRows = this.listImprovementArtifacts({
-      sourceKind: IMPROVEMENT_SOURCE_KIND.REPLAY,
-      status: IMPROVEMENT_STATUS.ACTIVE,
-      limit: Math.max(limit * 3, 12),
-    });
-    const improvementEpisodes = improvementRows
-      .filter((artifact) => {
-        const evidence = parseJsonObject(artifact.evidence_json);
-        return evidence.caseType === "ranking_target";
-      })
-      .map((artifact) => buildImprovementArtifactEpisode(artifact, repository))
-      .filter(Boolean);
-    const rawExactMatches = this.searchEpisodes({
-      query: lexicalQuery, repository, includeOtherRepositories, scopes, limit: Math.max(limit * 2, 8),
-    });
-    const { included: exactMatches, filtered: exactFiltered } =
-      filterEpisodePoolWithTrace([...rawExactMatches, ...improvementEpisodes], "exact_matches", repository);
-
-    const seen = new Set(exactMatches.map((episode) => episode.session_id));
-    const rawFallbackPool = this.searchEpisodes({
-      query: "", repository, includeOtherRepositories, scopes, limit: Math.max(limit * 8, 24),
-    });
-    const { included: fallbackPool, filtered: fallbackFiltered } =
-      filterEpisodePoolWithTrace([...rawFallbackPool, ...improvementEpisodes], "fallback_pool", repository);
-
-    const deduped = dedupeEpisodesWithTrace([...exactMatches, ...fallbackPool], repository);
-    const candidatePool = deduped.rows;
-    const exactMatchIds = new Set(exactMatches.map((episode) => episode.session_id));
-    const termWeights = buildTermWeights(candidatePool, effectiveTerms);
-
-    // Build rank maps for RRF fusion: preserve the FTS (BM25) order and the recency order
-    // so the final scoring blends both signals rather than discarding FTS rank.
-    const ftsRankMap = hybridEnabled
-      ? new Map(rawExactMatches.map((ep, i) => [ep.session_id, i]))
-      : new Map();
-    const recencyRankMap = hybridEnabled
-      ? new Map(rawFallbackPool.map((ep, i) => [ep.session_id, i]))
-      : new Map();
-    const ranked = scoreAndRankEpisodeCandidates({
-      candidatePool, seen, exactMatchIds, effectiveTerms, effectivePrimaryTerms, termWeights,
-      hybridEnabled, ftsRankMap, recencyRankMap,
-      ftsMissRank: rawExactMatches.length, recencyMissRank: rawFallbackPool.length,
-    });
-
-    const ordered = ranked.map((entry) => entry.episode);
-    const { preferred, genericFiltered } = separateGenericEpisodes(ordered, repository);
-    const includedRows = preferred.slice(0, limit);
-    return {
-      episodes: includedRows,
-      trace: {
-        prompt,
-        repository,
-        includeOtherRepositories,
-        eligibleScopes: scopes.length > 0 ? [...scopes] : buildLocalEligibility(repository),
-        primaryTerms: effectivePrimaryTerms,
-        entityTerms: hybridEnabled ? entityTerms : [],
-        hybridEnabled,
-        terms: effectiveTerms,
-        lexicalQuery,
-        rankedRows: ranked
-          .slice(0, Math.max(limit * 3, 12))
-          .map((entry) => ({
-            ...serializeEpisodeTraceRow(entry.episode, repository),
-            score: Number(entry.score.toFixed(2)),
-          })),
-        includedRows: includedRows.map((episode) => serializeEpisodeTraceRow(episode, repository)),
-        filtered: [
-          ...exactFiltered,
-          ...fallbackFiltered,
-          ...deduped.filtered,
-          ...genericFiltered,
-        ],
-      },
-    };
+  findRelevantEpisodesDetailed(...args) {
+    return findRelevantEpisodesDetailed(this, ...args);
   }
 
-  findRelevantEpisodes({ prompt, repository, includeOtherRepositories = false, scopes = [], limit = 5 }) {
-    return this.findRelevantEpisodesDetailed({
-      prompt,
-      repository,
-      includeOtherRepositories,
-      scopes,
-      limit,
-    }).episodes;
+  findRelevantEpisodes(...args) {
+    return findRelevantEpisodes(this, ...args);
   }
 
-  getDaySummary({ date, repository }) {
-    this.ensureOpen();
-    return this.getDaySummaries({ date, repository, limit: 1 })[0];
+  getDaySummary(...args) {
+    return getDaySummary(this, ...args);
   }
 
-  getDaySummaries({ date, repository, includeOtherRepositories = false, limit = 4 }) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const params = [date];
-    let sql = `
-      SELECT date_key, repository, summary, episode_ids_json, computed_at
-      FROM day_summary
-      WHERE date_key = ?
-    `;
-
-    if (!includeOtherRepositories) {
-      const scopedRepo = normalizeDaySummaryRepository(repository);
-      sql += ` AND ((? = '' AND repository = '') OR repository = ? OR repository IN (SELECT legacy FROM repository_identity_mapping WHERE canonical = ?)) `;
-      params.push(scopedRepo, scopedRepo, scopedRepo);
-    }
-
-    sql += `
-      ORDER BY
-        CASE
-          WHEN ? IS NOT NULL AND repository = ? THEN 0
-          WHEN repository IS NULL OR repository = '' THEN 1
-          ELSE 2
-        END,
-        computed_at DESC,
-        repository ASC
-      LIMIT ?
-    `;
-    params.push(repo, repo, limit);
-    return this.mapRetrievalRepositories(this.db.prepare(sql).all(...params), repo);
+  getDaySummaries(...args) {
+    return getDaySummaries(this, ...args);
   }
 
-  findRelevantEpisodesByDateDetailed({ date, repository, includeOtherRepositories = false, limit = 5 }) {
-    this.ensureOpen();
-    const repo = normalizeRepository(repository);
-    const params = [date];
-    let sql = `
-      SELECT
-        ed.id,
-        ed.session_id,
-        ed.scope,
-        ed.scope_source,
-        ed.repository,
-        ed.summary,
-        ed.actions_json,
-        ed.decisions_json,
-        ed.files_changed_json,
-        ed.themes_json,
-        ed.open_items_json,
-        ed.significance,
-        ed.date_key,
-        ed.updated_at
-      FROM episode_digest ed
-      WHERE ed.date_key = ?
-    `;
-
-    sql = applyScopeFilter(sql, params, repo, includeOtherRepositories, "ed");
-
-    sql += `
-      ORDER BY
-        CASE
-          WHEN ? IS NOT NULL AND ed.repository = ? THEN 0
-          WHEN ed.scope = ? THEN 1
-          ELSE 2
-        END,
-        ed.significance DESC,
-        ed.updated_at DESC
-      LIMIT ?
-    `;
-    params.push(repo, repo, MEMORY_SCOPE.GLOBAL, Math.max(limit * 3, 12));
-
-    const rawRows = this.mapRetrievalRepositories(this.db.prepare(sql).all(...params), repo);
-    const filtered = [];
-    const eligibleRows = rawRows.filter((episode) => {
-      const reason = explainEpisodeExclusionReason(episode);
-      if (!reason) {
-        return true;
-      }
-      filtered.push({
-        stage: "date_matches",
-        reason,
-        row: serializeEpisodeTraceRow(episode, repository),
-      });
-      return false;
-    });
-
-    const deduped = dedupeEpisodesWithTrace(eligibleRows, repository);
-    const ordered = deduped.rows;
-    const genericFiltered = ordered.some((episode) => !isGenericWorkSummary(episode.summary))
-      ? ordered
-          .filter((episode) => isGenericWorkSummary(episode.summary))
-          .map((episode) => ({
-            stage: "preference",
-            reason: "generic_work_summary",
-            row: serializeEpisodeTraceRow(episode, repository),
-          }))
-      : [];
-    const preferred = ordered.some((episode) => !isGenericWorkSummary(episode.summary))
-      ? ordered.filter((episode) => !isGenericWorkSummary(episode.summary))
-      : ordered;
-    const includedRows = preferred.slice(0, limit);
-
-    return {
-      episodes: includedRows,
-      trace: {
-        prompt: `date:${date}`,
-        repository,
-        includeOtherRepositories,
-        eligibleScopes: includeOtherRepositories ? [] : buildLocalEligibility(repository),
-        primaryTerms: [],
-        terms: [],
-        lexicalQuery: "",
-        rankedRows: preferred
-          .slice(0, Math.max(limit * 3, 12))
-          .map((episode) => serializeEpisodeTraceRow(episode, repository)),
-        includedRows: includedRows.map((episode) => serializeEpisodeTraceRow(episode, repository)),
-        filtered: [
-          ...filtered,
-          ...deduped.filtered,
-          ...genericFiltered,
-        ],
-      },
-    };
+  findRelevantEpisodesByDateDetailed(...args) {
+    return findRelevantEpisodesByDateDetailed(this, ...args);
   }
 
-  searchPromptSemanticRows({
-    query,
-    repository,
-    types,
-    scopes,
-    limit,
-    includeOtherRepositories = false,
-    expandAliases = true,
-  }) {
-    return withCurrentRepository(this.searchSemantic({
-      query,
-      repository,
-      includeOtherRepositories,
-      types,
-      scopes,
-      limit,
-      expandAliases,
-    }), repository);
+  searchPromptSemanticRows(...args) {
+    return searchPromptSemanticRows(this, ...args);
   }
 
-  searchPromptSemanticFallback({
-    prompt,
-    repository,
-    types = [],
-    scopes = [],
-    limit = 8,
-    includeOtherRepositories = false,
-    now = new Date(),
-  }) {
-    const terms = extractMeaningfulPromptTerms(prompt, { maxTerms: 8 });
-    if (terms.length === 0) return [];
-    const queryTerms = expandPromptSearchTerms(terms, { maxTerms: 8, maxVariants: 16 });
-    const maxCandidates = Math.max(64, Math.min(256, Math.max(limit, 1) * 32));
-    const rowsById = new Map();
-    for (let index = 0; index < queryTerms.length; index += 1) {
-      const remainingTerms = queryTerms.length - index;
-      const remainingRows = maxCandidates - rowsById.size;
-      if (remainingRows <= 0) break;
-      const termLimit = Math.max(8, Math.ceil(remainingRows / remainingTerms));
-      const rows = this.searchSemantic({
-        query: queryTerms[index],
-        repository,
-        includeOtherRepositories,
-        types,
-        scopes,
-        limit: Math.min(64, termLimit),
-        expandAliases: false,
-        now,
-      });
-      for (const row of rows) {
-        if (!rowsById.has(row.id)) rowsById.set(row.id, row);
-        if (rowsById.size >= maxCandidates) break;
-      }
-    }
-    return scorePromptFallbackRows([...rowsById.values()], terms, { limit });
+  searchPromptSemanticFallback(...args) {
+    return searchPromptSemanticFallback(this, ...args);
   }
 
-  buildPromptSemanticContext({ prompt, repository, limit, identityName, identityOnly }) {
-    let memories = !identityOnly
-      ? this.searchPromptSemanticRows({
-          query: prompt,
-          repository,
-          includeOtherRepositories: false,
-          types: ["commitment", "open_loop", "rejected_approach", "blocker", "user_preference", "assistant_identity", "user_identity", "assistant_goal", "recurring_mistake", "decision", "learned_rule"],
-          limit,
-        })
-      : [];
-    const contentQuery = promptSearchQuery(prompt);
-    if (!identityOnly && memories.length < limit && contentQuery) {
-      const fallbackRows = this.searchPromptSemanticFallback({
-        prompt,
-        repository,
-        includeOtherRepositories: false,
-        types: ["commitment", "open_loop", "rejected_approach", "blocker", "user_preference", "assistant_identity", "user_identity", "assistant_goal", "recurring_mistake", "decision", "learned_rule"],
-        limit,
-      });
-      const byId = new Map(memories.map((row) => [row.id, row]));
-      for (const row of fallbackRows) {
-        if (!byId.has(row.id)) byId.set(row.id, row);
-        if (byId.size >= limit) break;
-      }
-      memories = [...byId.values()].slice(0, limit);
-    }
-    const identityMemories = identityName
-      ? this.searchPromptSemanticRows({
-          query: "",
-          repository,
-          includeOtherRepositories: false,
-          types: ["assistant_identity"],
-          scopes: [MEMORY_SCOPE.GLOBAL],
-          limit: 4,
-        })
-      : [];
-    const assistantPersonaRows = this.searchPromptSemanticRows({
-      query: identityName || "assistant preferred human name",
-      repository,
-      includeOtherRepositories: false,
-      types: ["assistant_identity"],
-      scopes: [MEMORY_SCOPE.GLOBAL],
-      limit: 2,
-    });
-    const relationshipPreferenceRows = !identityOnly
-      ? this.searchPromptSemanticRows({
-          query: "",
-          repository,
-          includeOtherRepositories: false,
-          types: ["interaction_style", "user_identity", "user_preference", "recurring_mistake"],
-          scopes: [MEMORY_SCOPE.GLOBAL],
-          limit: 6,
-        }).filter((memory) => isStyleAddressingMemory(memory)).slice(0, 4)
-      : [];
-
-    return {
-      memories,
-      identityMemories,
-      localMemories: dedupeSemanticContextRows([
-        ...identityMemories,
-        ...memories,
-      ]),
-      assistantPersonaRows,
-      relationshipPreferenceRows,
-    };
+  buildPromptSemanticContext(...args) {
+    return buildPromptSemanticContext(this, ...args);
   }
 
-  buildEffectivePromptStyleSection({
-    prompt,
-    need,
-    assistantPersonaRows,
-    relationshipPreferenceRows,
-    pureTemporalRecall,
-  }) {
-    const styleSection = buildStyleAddressingSection({
-      prompt,
-      promptNeed: need,
-      config: this.config,
-      assistantPersonaRows,
-      relationshipPreferenceRows,
-      renderSemantic: formatSemanticContextLine,
-    });
-    return pureTemporalRecall && need.wantsStyleContext !== true
-      ? {
-          ...styleSection,
-          text: "",
-          trace: {
-            ...styleSection.trace,
-            enabled: false,
-            includeAmbient: false,
-            reason: "suppressed_for_pure_temporal_recall",
-          },
-        }
-      : styleSection;
+  buildEffectivePromptStyleSection(...args) {
+    return buildEffectivePromptStyleSection(this, ...args);
   }
 
-  filterPromptDaySummaries(daySummaryRows, pureTemporalRecall, temporalContentTerms) {
-    return daySummaryRows.filter((summary) => {
-      if (pureTemporalRecall || temporalContentTerms.length === 0) {
-        return true;
-      }
-      const summaryTokens = tokenizeText(summary.summary);
-      return temporalContentTerms.some((term) => summaryTokens.has(term));
-    });
+  filterPromptDaySummaries(...args) {
+    return filterPromptDaySummaries(this, ...args);
   }
 
-  buildIdentityOnlyEpisodeDetails(prompt, repository) {
-    return {
-      episodes: [],
-      trace: {
-        prompt,
-        repository,
-        includeOtherRepositories: false,
-        eligibleScopes: buildLocalEligibility(repository),
-        primaryTerms: [],
-        terms: [],
-        lexicalQuery: "",
-        rankedRows: [],
-        includedRows: [],
-        filtered: [],
-        reason: "identity_only_prompt",
-      },
-    };
+  buildIdentityOnlyEpisodeDetails(...args) {
+    return buildIdentityOnlyEpisodeDetails(this, ...args);
   }
 
-  buildPromptEpisodeContext({
-    prompt,
-    repository,
-    limit,
-    allowRepoLocalTaskContext,
-    allowCrossRepoFallback,
-    pureTemporalRecall,
-    temporalDate,
-    includedDaySummaryRows,
-  }) {
-    if (!allowRepoLocalTaskContext) {
-      return this.buildIdentityOnlyEpisodeDetails(prompt, repository);
-    }
-    if (pureTemporalRecall && includedDaySummaryRows.length > 0) {
-      return {
-        episodes: [],
-        trace: {
-          prompt,
-          repository,
-          includeOtherRepositories: allowCrossRepoFallback,
-          eligibleScopes: allowCrossRepoFallback ? [] : buildLocalEligibility(repository),
-          primaryTerms: [],
-          terms: [],
-          lexicalQuery: "",
-          rankedRows: [],
-          includedRows: [],
-          filtered: [],
-          reason: "suppressed_by_day_summaries",
-        },
-      };
-    }
-    return pureTemporalRecall
-      ? this.findRelevantEpisodesByDateDetailed({
-          date: temporalDate,
-          repository,
-          includeOtherRepositories: allowCrossRepoFallback,
-          limit: Math.max(2, Math.floor(limit / 2)),
-        })
-      : this.findRelevantEpisodesDetailed({
-          prompt,
-          repository,
-          includeOtherRepositories: false,
-          limit: Math.max(2, Math.floor(limit / 2)),
-        });
+  buildPromptEpisodeContext(...args) {
+    return buildPromptEpisodeContext(this, ...args);
   }
 
-  buildPromptTemporalContext({
-    prompt,
-    repository,
-    need,
-    limit,
-    allowRepoLocalTaskContext,
-    allowCrossRepoFallback,
-    assistantPersonaRows,
-    relationshipPreferenceRows,
-  }) {
-    const temporalDate = need.hasTemporalSignal ? inferDateFromPrompt(prompt, this.config) : null;
-    const temporalContentTerms = temporalDate ? extractTemporalContentTerms(prompt, this.config) : [];
-    const pureTemporalRecall = temporalDate !== null && temporalContentTerms.length === 0;
-    const daySummaryRows = temporalDate
-      ? this.getDaySummaries({
-          date: temporalDate,
-          repository,
-          includeOtherRepositories: allowCrossRepoFallback && pureTemporalRecall,
-          limit: pureTemporalRecall && allowCrossRepoFallback
-            ? Math.max(2, Math.min(limit, 4))
-            : 1,
-        })
-      : [];
-    const includedDaySummaryRows = this.filterPromptDaySummaries(
-      daySummaryRows,
-      pureTemporalRecall,
-      temporalContentTerms,
-    );
-    const episodeDetails = this.buildPromptEpisodeContext({
-      prompt,
-      repository,
-      limit,
-      allowRepoLocalTaskContext,
-      allowCrossRepoFallback,
-      pureTemporalRecall,
-      temporalDate,
-      includedDaySummaryRows,
-    });
-    return {
-      temporalDate,
-      temporalContentTerms,
-      pureTemporalRecall,
-      daySummaryRows,
-      includedDaySummaryRows,
-      episodeDetails,
-      episodes: withCurrentRepository(episodeDetails.episodes, repository),
-      effectiveStyleSection: this.buildEffectivePromptStyleSection({
-        prompt,
-        need,
-        assistantPersonaRows,
-        relationshipPreferenceRows,
-        pureTemporalRecall,
-      }),
-    };
+  buildPromptTemporalContext(...args) {
+    return buildPromptTemporalContext(this, ...args);
   }
 
-  buildPromptCrossRepoContext({
-    lexicalPrompt,
-    repository,
-    allowCrossRepoFallback,
-    pureTemporalRecall,
-    sessionStore,
-    limit,
-  }) {
-    const allowGenericCrossRepoFallback = allowCrossRepoFallback && !pureTemporalRecall;
-    const crossRepoPreferenceLimit = Math.max(1, Math.min(2, Math.floor(limit / 2) || 1));
-    const selectCrossRepoRows = (rows) => withCurrentRepository(
-      rows
-        .filter((row) => isCrossRepoRow(row, repository))
-        .slice(0, crossRepoPreferenceLimit),
-      repository,
-    );
-    const crossRepoPreferenceRows = allowGenericCrossRepoFallback
-      ? this.searchSemantic({
-          query: lexicalPrompt,
-          repository,
-          includeOtherRepositories: true,
-          types: ["user_preference", "rejected_approach", "recurring_mistake"],
-          scopes: [MEMORY_SCOPE.TRANSFERABLE],
-          limit: Math.max(limit * 4, 8),
-        })
-      : [];
-    const crossRepoPreferences = allowGenericCrossRepoFallback
-      ? selectCrossRepoRows(crossRepoPreferenceRows)
-      : [];
-    const crossRepoEpisodeDetails = allowGenericCrossRepoFallback
-      ? this.findRelevantEpisodesDetailed({
-          prompt: lexicalPrompt,
-          repository,
-          includeOtherRepositories: true,
-          scopes: [MEMORY_SCOPE.TRANSFERABLE],
-          limit: Math.max(limit * 4, 8),
-        })
-      : null;
-    const crossRepoEpisodes = allowGenericCrossRepoFallback
-      ? selectCrossRepoRows(crossRepoEpisodeDetails.episodes)
-      : [];
-    const crossRepoHints = allowGenericCrossRepoFallback && sessionStore
-      ? withCurrentRepository(
-          sessionStore.findRelevantSessions({
-            prompt: lexicalPrompt,
-            repository: null,
-            limit: Math.max(limit * 4, 8),
-          }).filter((session) => isCrossRepoRow(session, repository))
-            .slice(0, crossRepoPreferenceLimit),
-          repository,
-        )
-      : [];
-    return {
-      allowGenericCrossRepoFallback,
-      crossRepoPreferenceRows,
-      crossRepoPreferences,
-      crossRepoEpisodeDetails,
-      crossRepoEpisodes,
-      crossRepoHints,
-    };
+  buildPromptCrossRepoContext(...args) {
+    return buildPromptCrossRepoContext(this, ...args);
   }
 
-  determinePromptDaySummaryReason({
-    need,
-    temporalDate,
-    includedDaySummaryRows,
-    daySummaryRows,
-  }) {
-    if (!need.hasTemporalSignal) {
-      return "no_temporal_signal";
-    }
-    if (temporalDate === null) {
-      return "unresolved_temporal_date";
-    }
-    if (includedDaySummaryRows.length === 0 && daySummaryRows.length === 0) {
-      return "missing_day_summary";
-    }
-    return includedDaySummaryRows.length === 0
-      ? "summary_did_not_match_prompt_terms"
-      : null;
+  determinePromptDaySummaryReason(...args) {
+    return determinePromptDaySummaryReason(this, ...args);
   }
 
-  buildPromptTemporalVerifier({
-    repository,
-    sessionStore,
-    temporalDate,
-    pureTemporalRecall,
-    allowCrossRepoFallback,
-    limit,
-    daySummaryReason,
-    includedDaySummaryRows,
-    episodes,
-  }) {
-    const temporalVerifierEnabled = !!sessionStore && temporalDate !== null && pureTemporalRecall;
-    const shouldRunTemporalVerifier = temporalVerifierEnabled
-      && includedDaySummaryRows.length === 0
-      && episodes.length === 0
-      && (daySummaryReason === "missing_day_summary" || daySummaryReason === "summary_did_not_match_prompt_terms");
-    const temporalVerifierRows = shouldRunTemporalVerifier
-      ? withCurrentRepository(
-          sessionStore.findSessionsByDate({
-            dateKey: temporalDate,
-            repository,
-            includeOtherRepositories: allowCrossRepoFallback,
-            limit: Math.max(2, Math.min(limit, 3)),
-          }).map((session) => ({
-            ...session,
-            source_type: "session_store_verifier",
-            excerpt: session.workspaceSummary || session.summary,
-          })),
-          repository,
-        )
-      : [];
-    return {
-      temporalVerifierEnabled,
-      shouldRunTemporalVerifier,
-      temporalVerifierRows,
-    };
+  buildPromptTemporalVerifier(...args) {
+    return buildPromptTemporalVerifier(this, ...args);
   }
 
-  buildPromptContextFlags(need) {
-    return {
-      allowRepoLocalTaskContext: need.wantsRepoLocalTaskContext === true
-        && need.wantsCrossRepoExamples !== true,
-      allowCrossRepoFallback: need.allowCrossRepoFallback === true,
-      identityOnly: need.identityOnly === true,
-    };
+  buildPromptContextFlags(...args) {
+    return buildPromptContextFlags(this, ...args);
   }
 
-  buildLexicalPrompt(prompt, promptTerms) {
-    return promptTerms.length > 0 ? promptTerms.join(" ") : prompt;
+  buildLexicalPrompt(...args) {
+    return buildLexicalPrompt(this, ...args);
   }
 
-  resolvePromptRenderTerms(promptTerms, temporalContentTerms) {
-    return temporalContentTerms.length > 0 ? temporalContentTerms : promptTerms;
+  resolvePromptRenderTerms(...args) {
+    return resolvePromptRenderTerms(this, ...args);
   }
 
-  buildExplainComputedState(trace, {
-    need, temporalCtx, allowCrossRepoFallback, limit, repository, sessionStore, promptTerms,
-  }) {
-    const { temporalDate, temporalContentTerms, pureTemporalRecall, includedDaySummaryRows, daySummaryRows, episodes } = temporalCtx;
-    const renderTerms = this.resolvePromptRenderTerms(promptTerms, temporalContentTerms);
-    const hasIncludedDaySummary = includedDaySummaryRows.length > 0;
-    const hasIncludedEpisodes = episodes.length > 0;
-    const daySummaryReason = this.determinePromptDaySummaryReason({
-      need, temporalDate, includedDaySummaryRows, daySummaryRows,
-    });
-    const {
-      temporalVerifierEnabled,
-      shouldRunTemporalVerifier,
-      temporalVerifierRows,
-    } = this.buildPromptTemporalVerifier({
-      repository, sessionStore, temporalDate, pureTemporalRecall,
-      allowCrossRepoFallback, limit, daySummaryReason, includedDaySummaryRows, episodes,
-    });
-    setPromptTemporalVerifierTraceState({
-      trace, repository, sessionStore, temporalDate, pureTemporalRecall,
-      temporalVerifierEnabled, shouldRunTemporalVerifier, temporalVerifierRows,
-    });
-    return { renderTerms, hasIncludedDaySummary, hasIncludedEpisodes, daySummaryReason, shouldRunTemporalVerifier, temporalVerifierRows };
+  buildExplainComputedState(...args) {
+    return buildExplainComputedState(this, ...args);
   }
 
-  collectPromptContext({
-    prompt,
-    repository,
-    includeOtherRepositories = false,
-    limit = 6,
-    sessionStore = null,
-    promptNeed = null,
-  }) {
-    this.ensureOpen();
-    const promptTerms = extractNormalizedFtsTerms(prompt, {
-      aliases: QUERY_ALIASES,
-      normalize: normalizeFtsToken,
-    });
-    const lexicalPrompt = this.buildLexicalPrompt(prompt, promptTerms);
-    const identityName = detectAssistantIdentityName(prompt);
-    const need = promptNeed ?? buildDefaultPromptNeed(prompt, includeOtherRepositories);
-    const flags = this.buildPromptContextFlags(need);
-    const { allowRepoLocalTaskContext, allowCrossRepoFallback, identityOnly } = flags;
-    const semanticCtx = this.buildPromptSemanticContext({ prompt, repository, limit, identityName, identityOnly });
-    const temporalCtx = this.buildPromptTemporalContext({
-      prompt, repository, need, limit, allowRepoLocalTaskContext, allowCrossRepoFallback,
-      assistantPersonaRows: semanticCtx.assistantPersonaRows,
-      relationshipPreferenceRows: semanticCtx.relationshipPreferenceRows,
-    });
-    // Query-matched style evidence remains useful even when ambient persona
-    // injection is disabled. Only suppress duplicate style entries that the
-    // dedicated section actually renders, or preserve temporal suppression.
-    semanticCtx.localMemories = semanticCtx.localMemories.filter((memory) => !isStyleAddressingMemory(memory)
-      || (!need.hasTemporalSignal && !temporalCtx.effectiveStyleSection.text.includes(memory.content)));
-    const crossRepoCtx = this.buildPromptCrossRepoContext({
-      lexicalPrompt, repository, allowCrossRepoFallback,
-      pureTemporalRecall: temporalCtx.pureTemporalRecall, sessionStore, limit,
-    });
-    const trace = buildExplainPromptTrace({
-      prompt, repository, allowCrossRepoFallback, promptTerms, identityName,
-      semanticCtx, temporalCtx, crossRepoCtx, sessionStore,
-    });
-    const state = this.buildExplainComputedState(trace, {
-      need, temporalCtx, allowCrossRepoFallback, limit, repository, sessionStore, promptTerms,
-    });
-    return {
-      prompt,
-      repository,
-      sessionStore,
-      need,
-      flags,
-      promptTerms,
-      semanticCtx,
-      temporalCtx,
-      crossRepoCtx,
-      state,
-      trace,
-    };
+  collectPromptContext(...args) {
+    return collectPromptContext(this, ...args);
   }
 
-  // Deprecated wrapper: prefer assembleRecall. Kept for one PR so existing
-  // row/trace callers can keep a { text, trace } shape.
-  explainPromptContext(args) {
-    return renderPromptContext(this.collectPromptContext(args));
+  explainPromptContext(...args) {
+    return explainPromptContext(this, ...args);
   }
 
-  buildPromptContext({
-    prompt,
-    repository,
-    includeOtherRepositories = false,
-    limit = 6,
-    sessionStore = null,
-    promptNeed = null,
-  }) {
-    return this.explainPromptContext({
-      prompt,
-      repository,
-      includeOtherRepositories,
-      limit,
-      sessionStore,
-      promptNeed,
-    }).text;
+  buildPromptContext(...args) {
+    return buildPromptContext(this, ...args);
   }
-}
-
-function inferDateFromPrompt(prompt, config = null) {
-  if (!readTemporalQueryNormalizationEnabled(config)) {
-    const text = String(prompt || "").toLowerCase();
-    const now = new Date();
-    const startOfUtcDay = new Date(now);
-    startOfUtcDay.setUTCHours(0, 0, 0, 0);
-
-    if (text.includes("today")) {
-      return startOfUtcDay.toISOString().slice(0, 10);
-    }
-    if (text.includes("yesterday")) {
-      const value = new Date(startOfUtcDay);
-      value.setUTCDate(value.getUTCDate() - 1);
-      return value.toISOString().slice(0, 10);
-    }
-
-    const weekdays = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"];
-    const namedDay = weekdays.find((weekday) => text.includes(weekday));
-    if (!namedDay) {
-      return null;
-    }
-
-    const targetIndex = weekdays.indexOf(namedDay);
-    const currentIndex = now.getUTCDay();
-    const diff = (currentIndex - targetIndex + 7) % 7 || 7;
-    const value = new Date(startOfUtcDay);
-    value.setUTCDate(value.getUTCDate() - diff);
-    return value.toISOString().slice(0, 10);
-  }
-  return inferNormalizedDateFromPrompt(prompt, { now: config?.now });
-}
-
-// --- Episode retrieval helpers (todo 6) ---
-
-function dedupeEpisodesWithTrace(episodes, currentRepository = null) {
-  const seenSummaries = new Set();
-  const seenSessions = new Set();
-  const deduped = [];
-  const filtered = [];
-
-  for (const episode of episodes) {
-    if (seenSessions.has(episode.session_id)) {
-      filtered.push({
-        stage: "dedupe",
-        reason: "duplicate_session",
-        row: serializeEpisodeTraceRow(episode, currentRepository),
-      });
-      continue;
-    }
-    const summaryKey = normalizeText(episode.summary).toLowerCase();
-    if (summaryKey && seenSummaries.has(summaryKey)) {
-      filtered.push({
-        stage: "dedupe",
-        reason: "duplicate_summary",
-        row: serializeEpisodeTraceRow(episode, currentRepository),
-      });
-      continue;
-    }
-    seenSessions.add(episode.session_id);
-    if (summaryKey) {
-      seenSummaries.add(summaryKey);
-    }
-    deduped.push(episode);
-  }
-
-  return {
-    rows: deduped,
-    filtered,
-  };
-}
-
-function filterEpisodePoolWithTrace(pool, stageName, repository) {
-  const included = [];
-  const filtered = [];
-  for (const episode of pool) {
-    const reason = explainEpisodeExclusionReason(episode);
-    if (!reason) {
-      included.push(episode);
-    } else {
-      filtered.push({ stage: stageName, reason, row: serializeEpisodeTraceRow(episode, repository) });
-    }
-  }
-  return { included, filtered };
-}
-
-function separateGenericEpisodes(ordered, repository) {
-  const hasNonGeneric = ordered.some((episode) => !isGenericWorkSummary(episode.summary));
-  const genericFiltered = hasNonGeneric
-    ? ordered
-      .filter((episode) => isGenericWorkSummary(episode.summary))
-      .map((episode) => ({
-        stage: "preference",
-        reason: "generic_work_summary",
-        row: serializeEpisodeTraceRow(episode, repository),
-      }))
-    : [];
-  const preferred = hasNonGeneric
-    ? ordered.filter((episode) => !isGenericWorkSummary(episode.summary))
-    : ordered;
-  return { preferred, genericFiltered };
-}
-
-function buildExplainPromptTrace({ prompt, repository, allowCrossRepoFallback, promptTerms, identityName, semanticCtx, temporalCtx, crossRepoCtx, sessionStore }) {
-  return createPromptContextTrace({
-    prompt,
-    repository,
-    allowCrossRepoFallback,
-    allowGenericCrossRepoFallback: crossRepoCtx.allowGenericCrossRepoFallback,
-    promptTerms,
-    identityName,
-    temporalDate: temporalCtx.temporalDate,
-    memories: semanticCtx.memories,
-    localMemories: semanticCtx.localMemories,
-    identityMemories: semanticCtx.identityMemories,
-    effectiveStyleSection: temporalCtx.effectiveStyleSection,
-    assistantPersonaRows: semanticCtx.assistantPersonaRows,
-    relationshipPreferenceRows: semanticCtx.relationshipPreferenceRows,
-    daySummaryRows: temporalCtx.daySummaryRows,
-    includedDaySummaryRows: temporalCtx.includedDaySummaryRows,
-    episodeDetails: temporalCtx.episodeDetails,
-    crossRepoPreferenceRows: crossRepoCtx.crossRepoPreferenceRows,
-    crossRepoPreferences: crossRepoCtx.crossRepoPreferences,
-    crossRepoEpisodeDetails: crossRepoCtx.crossRepoEpisodeDetails,
-    crossRepoEpisodes: crossRepoCtx.crossRepoEpisodes,
-    crossRepoHints: crossRepoCtx.crossRepoHints,
-    sessionStore,
-  });
 }


### PR DESCRIPTION
## Summary
- `lib/db/db.mjs` had grown to 5300+ lines, mixing connection lifecycle, migrations, stats, activity state, semantic memory writes, episode search, prompt context assembly, and more inside one `LoreDb` class.
- Split each cohesive group of methods into its own `db-*.mjs` module (`db-activity-state`, `db-stats`, `db-scope-management`, `db-semantic-memory-write`, `db-episode-search`, `db-prompt-context`, `db-deferred-extraction`, `db-maintenance-runs`, `db-backfill-runs`, `db-memory-domain-observation`, `db-memory-hygiene`, `db-embedding`, `db-intent-trajectory`, `db-error-telemetry`, plus two small shared helper modules `db-shared` and `db-trace-serializers`), following the existing `db-migration-runner.mjs` / `db-retrieval-policy.mjs` pattern already used in this directory.
- Two existing sibling files (`db-improvement-artifacts.mjs`, `db-trace-samples.mjs`) got the corresponding methods appended, since they already held the `*Impl` logic those methods called into.
- `db.mjs` itself now just holds the `LoreDb` class shell: constructor, connection lifecycle (open/close/backup/restore), migration orchestration passthroughs, and thin one-line delegators (`method(...args) { return externalFn(this, ...args); }`) for everything extracted.
- No behavior changed — every method keeps its exact original body, just relocated, with `this` renamed to `owner` and threaded through as the first parameter (matching the existing convention in this codebase).

`lib/db/db.mjs`: 5331 → 1138 lines (79% smaller). No new file is a monster; the largest (`db-prompt-context.mjs`) is 852 lines and single-responsibility.

## Test plan
- [x] Confirmed all 185 original `LoreDb.prototype` methods still exist (same count, same names) via introspection
- [x] Confirmed `LoreDb` is the only export other code imports from `db.mjs` (unchanged)
- [x] `node --test 'tests/**/*.test.mjs'` — 1286 passed, 0 failed, 1 pre-existing unrelated skip
- [x] `npm run lint` — clean, zero new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCMh9u51xctgYyLhQ3s5uM